### PR TITLE
fix(pi-heartbeat): load stats from DB instead of resetting on restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,13 @@ Key extensions:
 - Validate with `npm run typecheck` (tsc --noEmit), test with `npm test`
 - Keep web UIs as single HTML files (vanilla JS + inline CSS), served from extension root
 
-## Task Management (MANDATORY)
+## ⚠️ Task Management & Branching (MANDATORY — NO EXCEPTIONS)
 
-**Every piece of work MUST be tracked with `td`.** No exceptions — no matter how small the change.
+**STOP. Read this before writing any code.**
 
-Before starting any work:
+**Every single change MUST have a `td` task AND its own feature branch.** This is non-negotiable. No commits to `main`. No skipping tasks "because it's small". No bundling unrelated work. One task = one branch = one piece of work.
+
+### Required workflow — follow every time:
 1. **Check for existing task:** `td status` or `td ready`
 2. **Create a task if none exists:** `td create "description" --type task|bug|feature|chore`
 3. **Start the task:** `td start <id>`
@@ -80,9 +82,12 @@ Before starting any work:
 6. **Commit to the feature branch**, then handoff: `td handoff <id> --done "..."`
 7. **Submit for review:** `td review <id>`
 
-Every task gets its own feature branch. Never commit directly to `main`. Branch names always start with the task ID followed by `/`.
-
-This applies to bug fixes, features, refactors, doc updates, config changes — everything. If you're changing code, there must be a `td` task and a feature branch for it.
+### Rules:
+- **Never commit to `main`** — always use a feature branch
+- **Branch names start with task ID:** `<task-id>/<short-description>`
+- **Every change needs a task** — bug fixes, features, refactors, doc updates, config changes, typo fixes — everything
+- **One task per branch** — don't mix unrelated work
+- **No exceptions** — if you forgot to create a task, stop and create one now before continuing
 
 ## Other Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Key extensions:
 
 ### Required workflow — follow every time:
 1. **Check for existing task:** `td status` or `td ready`
-2. **Create a task if none exists:** `td create "description" --type task|bug|feature|chore`
+2. **Create a task if none exists:** `td create "description" --type task|bug|feature|chore` (use `--minor` for small/trivial changes)
 3. **Start the task:** `td start <id>`
 4. **Create a feature branch:** `git checkout -b <task-id>/<short-description>` (e.g. `td-e29be6/delete-button-icon`)
 5. **Log progress as you go:** `td log "what you did"`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+---
+name: pi
+description: Pi coding agent home directory — extensions, skills, prompts, and runtime config
+---
+
+## Overview
+
+Personal Pi agent home directory, symlinked to `~/.pi/agent`. Contains local extensions, custom skills, prompt templates, and agent profiles. Each extension is a self-contained Node.js package in `extensions/` with its own `AGENTS.md` for detailed context.
+
+## Directory Layout
+
+```
+├── agents/          # Agent profile prompt overrides (planner, reviewer, scout, worker)
+├── extensions/      # Local extensions (each has own package.json + AGENTS.md)
+├── skills/          # Shared skills (changelog-generator, git-project-status, etc.)
+├── .pi/
+│   ├── skills/      # Project-specific skills (code-review, github, td, blog-post, etc.)
+│   └── prompts/     # Prompt templates (implement, scout-and-plan, implement-and-review)
+├── themes/          # Custom TUI themes
+├── db/              # Runtime SQLite databases (gitignored)
+├── cache/           # Runtime cache (gitignored)
+├── sessions/        # Agent session state (gitignored)
+└── telemetry/       # Local telemetry data (gitignored)
+```
+
+## Extensions
+
+22 local extensions in `extensions/`. Each has its own `AGENTS.md` with detailed architecture, entity models, and conventions — read those before modifying an extension.
+
+Key extensions:
+- **pi-webserver** — shared HTTP server with auth; other extensions mount on it
+- **pi-kysely** — shared database registry with table-level RBAC
+- **pi-myfinance** — personal finance (accounts, transactions, vendors, budgets, reports)
+- **pi-personal-crm** — contacts, companies, interactions
+- **pi-channels** — bidirectional messaging (Telegram, webhooks)
+- **pi-memory** — persistent long-term memory and daily logs
+- **pi-vault** — Obsidian vault integration
+
+## Extension Development Conventions
+
+### Structure
+- Default export: `export default function (pi: ExtensionAPI) { ... }`
+- Import types from `@mariozechner/pi-coding-agent` (`ExtensionAPI`, `getAgentDir`, `SettingsManager`)
+- TypeScript with `strict: true`, target ES2022, module ESNext, `allowImportingTsExtensions`
+- Use `.ts` extensions in imports (e.g. `import { foo } from "./bar.ts"`)
+- Tool parameter schemas use `@sinclair/typebox` (`Type.Object`, `Type.String`, etc.)
+- Tool results return `{ content: [{ type: "text", text: "..." }], details: {} }`
+
+### Lifecycle & Events
+- Initialize DB and state in `pi.on("session_start", async (event, ctx) => { ... })`
+- Register tools with `pi.registerTool({ ... })`, commands with `pi.registerCommand(name, { ... })`
+- Communicate between extensions via `pi.events.emit()` / `pi.events.on()` — never import directly
+- Mount web UI via `pi.events.emit("web:mount", { name, prefix, handler })` and API via `"web:mount-api"`
+- Listen for `"web:ready"` to re-mount if pi-webserver starts after your extension
+
+### Database
+- SQLite via better-sqlite3 (sync) as default backend; optional Kysely via event bus
+- DB files go in `db/` directory under agent home (e.g. `db/finance.db`)
+- Table names prefixed by extension (e.g. `finance_accounts`, `crm_contacts`)
+- Migrations tracked in a `<prefix>_migrations` table with version numbers
+- Parameterized queries only — no string interpolation in SQL
+- WAL mode enabled (`PRAGMA journal_mode = WAL`)
+
+### Code Style
+- No `console.log` — use pi-logger or structured error returns
+- Settings via `SettingsManager.create(cwd, agentDir)` for per-project + global config
+- Validate with `npm run typecheck` (tsc --noEmit), test with `npm test`
+- Keep web UIs as single HTML files (vanilla JS + inline CSS), served from extension root
+
+## Conventions
+
+- `td` CLI for task management; tasks tracked in `.todos/`
+- Each extension owns its own DB tables (prefixed by extension name)
+- Tools return structured markdown for LLM consumption

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,14 @@ Before starting any work:
 1. **Check for existing task:** `td status` or `td ready`
 2. **Create a task if none exists:** `td create "description" --type task|bug|feature|chore`
 3. **Start the task:** `td start <id>`
-4. **Log progress as you go:** `td log "what you did"`
-5. **Handoff when done:** `td handoff <id> --done "..." `
-6. **Submit for review:** `td review <id>`
+4. **Create a feature branch:** `git checkout -b <task-id>/<short-description>` (e.g. `td-e29be6/delete-button-icon`)
+5. **Log progress as you go:** `td log "what you did"`
+6. **Commit to the feature branch**, then handoff: `td handoff <id> --done "..."`
+7. **Submit for review:** `td review <id>`
 
-This applies to bug fixes, features, refactors, doc updates, config changes — everything. If you're changing code, there must be a `td` task for it.
+Every task gets its own feature branch. Never commit directly to `main`. Branch names always start with the task ID followed by `/`.
+
+This applies to bug fixes, features, refactors, doc updates, config changes — everything. If you're changing code, there must be a `td` task and a feature branch for it.
 
 ## Other Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,21 @@ Key extensions:
 - Validate with `npm run typecheck` (tsc --noEmit), test with `npm test`
 - Keep web UIs as single HTML files (vanilla JS + inline CSS), served from extension root
 
-## Conventions
+## Task Management (MANDATORY)
 
-- `td` CLI for task management; tasks tracked in `.todos/`
+**Every piece of work MUST be tracked with `td`.** No exceptions — no matter how small the change.
+
+Before starting any work:
+1. **Check for existing task:** `td status` or `td ready`
+2. **Create a task if none exists:** `td create "description" --type task|bug|feature|chore`
+3. **Start the task:** `td start <id>`
+4. **Log progress as you go:** `td log "what you did"`
+5. **Handoff when done:** `td handoff <id> --done "..." `
+6. **Submit for review:** `td review <id>`
+
+This applies to bug fixes, features, refactors, doc updates, config changes — everything. If you're changing code, there must be a `td` task for it.
+
+## Other Conventions
+
 - Each extension owns its own DB tables (prefixed by extension name)
 - Tools return structured markdown for LLM consumption

--- a/extensions/pi-heartbeat/src/db-kysely.ts
+++ b/extensions/pi-heartbeat/src/db-kysely.ts
@@ -14,11 +14,19 @@
 import type { EventBus } from "@mariozechner/pi-coding-agent";
 
 const ACTOR = "pi-heartbeat";
-
-type Driver = "sqlite" | "postgres" | "mysql";
+const EVENT_TIMEOUT_MS = 15_000;
 
 let events: EventBus;
-let driver: Driver = "sqlite";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+		promise.then(
+			(val) => { clearTimeout(timer); resolve(val); },
+			(err) => { clearTimeout(timer); reject(err); },
+		);
+	});
+}
 
 // ── Schema ──────────────────────────────────────────────────────
 
@@ -46,25 +54,20 @@ const SCHEMA = {
 export async function initDb(eventBus: EventBus): Promise<void> {
 	events = eventBus;
 
-	// Detect SQL dialect from pi-kysely
-	events.emit("kysely:info", {
-		reply: (info: { defaultDriver?: string }) => {
-			if (info.defaultDriver === "postgres" || info.defaultDriver === "mysql") {
-				driver = info.defaultDriver;
-			}
-		},
-	});
-
 	// Register schema (additive, idempotent)
-	await new Promise<void>((resolve, reject) => {
-		events.emit("kysely:schema:register", {
-			...SCHEMA,
-			reply: (result: { ok: boolean; errors: string[] }) => {
-				if (result.ok) resolve();
-				else reject(new Error(`Schema register failed: ${result.errors.join("; ")}`));
-			},
-		});
-	});
+	await withTimeout(
+		new Promise<void>((resolve, reject) => {
+			events.emit("kysely:schema:register", {
+				...SCHEMA,
+				reply: (result: { ok: boolean; errors: string[] }) => {
+					if (result.ok) resolve();
+					else reject(new Error(`Schema register failed: ${result.errors.join("; ")}`));
+				},
+			});
+		}),
+		EVENT_TIMEOUT_MS,
+		"kysely:schema:register",
+	);
 }
 
 // ── Query helper ────────────────────────────────────────────────
@@ -76,16 +79,20 @@ interface QueryResult {
 }
 
 function query(sql: string, params: unknown[] = []): Promise<QueryResult> {
-	return new Promise((resolve, reject) => {
-		events.emit("kysely:query", {
-			actor: ACTOR,
-			input: { sql, params },
-			reply: (result: QueryResult) => resolve(result),
-			ack: (ack: { ok: boolean; error?: string }) => {
-				if (!ack.ok) reject(new Error(ack.error));
-			},
-		});
-	});
+	return withTimeout(
+		new Promise((resolve, reject) => {
+			events.emit("kysely:query", {
+				actor: ACTOR,
+				input: { sql, params },
+				reply: (result: QueryResult) => resolve(result),
+				ack: (ack: { ok: boolean; error?: string }) => {
+					if (!ack.ok) reject(new Error(ack.error));
+				},
+			});
+		}),
+		EVENT_TIMEOUT_MS,
+		"kysely:query",
+	);
 }
 
 // ── Types ───────────────────────────────────────────────────────

--- a/extensions/pi-heartbeat/src/db-kysely.ts
+++ b/extensions/pi-heartbeat/src/db-kysely.ts
@@ -16,7 +16,7 @@ import type { EventBus } from "@mariozechner/pi-coding-agent";
 const ACTOR = "pi-heartbeat";
 const EVENT_TIMEOUT_MS = 15_000;
 
-let events: EventBus;
+let events: EventBus | null = null;
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
@@ -53,11 +53,12 @@ const SCHEMA = {
 
 export async function initDb(eventBus: EventBus): Promise<void> {
 	events = eventBus;
+	const bus = events;
 
 	// Register schema (additive, idempotent)
 	await withTimeout(
 		new Promise<void>((resolve, reject) => {
-			events.emit("kysely:schema:register", {
+			bus.emit("kysely:schema:register", {
 				...SCHEMA,
 				reply: (result: { ok: boolean; errors: string[] }) => {
 					if (result.ok) resolve();
@@ -79,14 +80,19 @@ interface QueryResult {
 }
 
 function query(sql: string, params: unknown[] = []): Promise<QueryResult> {
+	if (!events) throw new Error("Heartbeat DB not initialized — call initDb() first");
+	const bus = events;
 	return withTimeout(
 		new Promise((resolve, reject) => {
-			events.emit("kysely:query", {
+			let settled = false;
+			bus.emit("kysely:query", {
 				actor: ACTOR,
 				input: { sql, params },
-				reply: (result: QueryResult) => resolve(result),
+				reply: (result: QueryResult) => {
+					if (!settled) { settled = true; resolve(result); }
+				},
 				ack: (ack: { ok: boolean; error?: string }) => {
-					if (!ack.ok) reject(new Error(ack.error));
+					if (!ack.ok && !settled) { settled = true; reject(new Error(ack.error)); }
 				},
 			});
 		}),
@@ -175,10 +181,7 @@ export async function getStats(): Promise<{
 	};
 }
 
-export async function cleanOldRuns(beforeDate: string): Promise<number> {
-	const { numAffectedRows } = await query(
-		"DELETE FROM heartbeat_runs WHERE created_at < ?",
-		[beforeDate],
-	);
-	return numAffectedRows ?? 0;
+/** Reset module state (call on session shutdown). */
+export function resetDb(): void {
+	events = null;
 }

--- a/extensions/pi-heartbeat/src/db-kysely.ts
+++ b/extensions/pi-heartbeat/src/db-kysely.ts
@@ -1,0 +1,177 @@
+/**
+ * pi-heartbeat — Database layer via pi-kysely event bus.
+ *
+ * Stores heartbeat run history in the shared database.
+ * All DB access via events:
+ *
+ *   - kysely:info   — detect SQL dialect (sqlite/postgres/mysql)
+ *   - kysely:schema:register — table creation (portable DDL)
+ *   - kysely:query  — raw SQL for reads/writes
+ *
+ * Requires pi-kysely extension to be loaded.
+ */
+
+import type { EventBus } from "@mariozechner/pi-coding-agent";
+
+const ACTOR = "pi-heartbeat";
+
+type Driver = "sqlite" | "postgres" | "mysql";
+
+let events: EventBus;
+let driver: Driver = "sqlite";
+
+// ── Schema ──────────────────────────────────────────────────────
+
+const SCHEMA = {
+	actor: ACTOR,
+	tables: {
+		heartbeat_runs: {
+			columns: {
+				id:          { type: "integer" as const, primaryKey: true, autoIncrement: true },
+				ok:          { type: "integer" as const, notNull: true, default: 0 },
+				response:    { type: "text" as const },
+				duration_ms: { type: "integer" as const },
+				created_at:  { type: "text" as const, notNull: true },
+			},
+			indexes: [
+				{ columns: ["created_at"], name: "idx_heartbeat_runs_created" },
+				{ columns: ["ok"], name: "idx_heartbeat_runs_ok" },
+			],
+		},
+	},
+};
+
+// ── Init ────────────────────────────────────────────────────────
+
+export async function initDb(eventBus: EventBus): Promise<void> {
+	events = eventBus;
+
+	// Detect SQL dialect from pi-kysely
+	events.emit("kysely:info", {
+		reply: (info: { defaultDriver?: string }) => {
+			if (info.defaultDriver === "postgres" || info.defaultDriver === "mysql") {
+				driver = info.defaultDriver;
+			}
+		},
+	});
+
+	// Register schema (additive, idempotent)
+	await new Promise<void>((resolve, reject) => {
+		events.emit("kysely:schema:register", {
+			...SCHEMA,
+			reply: (result: { ok: boolean; errors: string[] }) => {
+				if (result.ok) resolve();
+				else reject(new Error(`Schema register failed: ${result.errors.join("; ")}`));
+			},
+		});
+	});
+}
+
+// ── Query helper ────────────────────────────────────────────────
+
+interface QueryResult {
+	rows: Record<string, unknown>[];
+	numAffectedRows?: number;
+	insertId?: number | bigint;
+}
+
+function query(sql: string, params: unknown[] = []): Promise<QueryResult> {
+	return new Promise((resolve, reject) => {
+		events.emit("kysely:query", {
+			actor: ACTOR,
+			input: { sql, params },
+			reply: (result: QueryResult) => resolve(result),
+			ack: (ack: { ok: boolean; error?: string }) => {
+				if (!ack.ok) reject(new Error(ack.error));
+			},
+		});
+	});
+}
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface HeartbeatRunRow {
+	id: number;
+	ok: boolean;
+	response: string | null;
+	duration_ms: number | null;
+	created_at: string;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function now(): string {
+	return new Date().toISOString();
+}
+
+function mapRow(r: any): HeartbeatRunRow {
+	return {
+		id: r.id,
+		ok: !!r.ok,
+		response: r.response,
+		duration_ms: r.duration_ms,
+		created_at: r.created_at,
+	};
+}
+
+// ── CRUD ────────────────────────────────────────────────────────
+
+export async function insertRun(ok: boolean, response: string, durationMs: number): Promise<HeartbeatRunRow> {
+	const ts = now();
+	const { insertId } = await query(
+		`INSERT INTO heartbeat_runs (ok, response, duration_ms, created_at)
+		 VALUES (?, ?, ?, ?)`,
+		[ok ? 1 : 0, response, durationMs, ts],
+	);
+	return { id: Number(insertId), ok, response, duration_ms: durationMs, created_at: ts };
+}
+
+export async function getHistory(limit: number = 100): Promise<HeartbeatRunRow[]> {
+	const { rows } = await query(
+		"SELECT * FROM heartbeat_runs ORDER BY created_at DESC LIMIT ?",
+		[limit],
+	);
+	return rows.map(mapRow);
+}
+
+export async function getStats(): Promise<{
+	runCount: number;
+	okCount: number;
+	alertCount: number;
+	lastRun: string | null;
+	lastOk: boolean | null;
+}> {
+	const { rows } = await query(
+		`SELECT
+		   COUNT(*) as run_count,
+		   SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) as ok_count,
+		   SUM(CASE WHEN ok = 0 THEN 1 ELSE 0 END) as alert_count,
+		   MAX(created_at) as last_run
+		 FROM heartbeat_runs`,
+	);
+	const row = rows[0] as any;
+
+	let lastOk: boolean | null = null;
+	if (row.last_run) {
+		const { rows: lastRows } = await query(
+			"SELECT ok FROM heartbeat_runs ORDER BY created_at DESC LIMIT 1",
+		);
+		if (lastRows.length > 0) lastOk = !!(lastRows[0] as any).ok;
+	}
+
+	return {
+		runCount: row.run_count ?? 0,
+		okCount: row.ok_count ?? 0,
+		alertCount: row.alert_count ?? 0,
+		lastRun: row.last_run ?? null,
+		lastOk,
+	};
+}
+
+export async function cleanOldRuns(beforeDate: string): Promise<number> {
+	const { numAffectedRows } = await query(
+		"DELETE FROM heartbeat_runs WHERE created_at < ?",
+		[beforeDate],
+	);
+	return numAffectedRows ?? 0;
+}

--- a/extensions/pi-heartbeat/src/heartbeat.ts
+++ b/extensions/pi-heartbeat/src/heartbeat.ts
@@ -215,18 +215,26 @@ export class HeartbeatRunner {
 			let stderr = "";
 			let settled = false;
 
+			// Parse JSON-line events from RPC stdout
+			const rl = readline.createInterface({ input: child.stdout });
+
+			function settle(result: { stdout: string; stderr: string; exitCode: number }): void {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeout);
+				rl.close();
+				resolve(result);
+			}
+
 			const timeout = setTimeout(() => {
-				if (!settled) {
-					settled = true;
-					child.kill("SIGTERM");
-					resolve({ stdout: responseText, stderr: stderr + "\nHeartbeat timed out", exitCode: 1 });
-				}
+				child.kill("SIGTERM");
+				// Force kill if SIGTERM is ignored
+				setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 5_000);
+				settle({ stdout: responseText, stderr: stderr + "\nHeartbeat timed out", exitCode: 1 });
 			}, timeoutMs);
 
 			child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
 
-			// Parse JSON-line events from RPC stdout
-			const rl = readline.createInterface({ input: child.stdout });
 			rl.on("line", (line) => {
 				try {
 					const event = JSON.parse(line);
@@ -254,19 +262,11 @@ export class HeartbeatRunner {
 			child.stdin.write(promptCmd);
 
 			child.on("close", (code) => {
-				if (!settled) {
-					settled = true;
-					clearTimeout(timeout);
-					resolve({ stdout: responseText, stderr, exitCode: code ?? 0 });
-				}
+				settle({ stdout: responseText, stderr, exitCode: code ?? 0 });
 			});
 
 			child.on("error", (err) => {
-				if (!settled) {
-					settled = true;
-					clearTimeout(timeout);
-					resolve({ stdout: responseText, stderr: stderr + "\n" + err.message, exitCode: 1 });
-				}
+				settle({ stdout: responseText, stderr: stderr + "\n" + err.message, exitCode: 1 });
 			});
 		});
 	}

--- a/extensions/pi-heartbeat/src/heartbeat.ts
+++ b/extensions/pi-heartbeat/src/heartbeat.ts
@@ -1,16 +1,19 @@
 /**
  * pi-heartbeat — Core heartbeat runner.
  *
- * Periodically runs a health-check prompt as an isolated subprocess.
+ * Periodically runs a health-check prompt as an isolated RPC subprocess.
  * If the agent responds with HEARTBEAT_OK, the result is suppressed.
  * Otherwise, the alert is delivered via pi-channels event bus.
  *
- * Spawns `pi -p --no-session` subprocesses (same pattern as pi-cron/pi-subagent).
+ * Spawns `pi --mode rpc` subprocesses — sends a prompt command via stdin,
+ * collects the response from streamed events, then exits gracefully.
  */
 
 import { spawn } from "node:child_process";
+import * as readline from "node:readline";
 import type { HeartbeatSettings } from "./settings.ts";
 import { buildPrompt, readHeartbeatMd, isEffectivelyEmpty } from "./prompt.ts";
+import { isStoreReady, getStore } from "./store.ts";
 
 const HEARTBEAT_OK = "HEARTBEAT_OK";
 
@@ -139,8 +142,15 @@ export class HeartbeatRunner {
 			if (isOk) this.okCount++;
 			else this.alertCount++;
 
+			// Persist to store
+			if (isStoreReady()) {
+				try {
+					await getStore().insertRun(isOk, response, durationMs);
+				} catch { /* ignore store errors */ }
+			}
+
 			this.callbacks.onResult?.(runResult);
-			this.callbacks.log?.("check", { ok: isOk, durationMs }, isOk ? "INFO" : "WARN");
+			this.callbacks.log?.("check", { ok: isOk, durationMs, ...(isOk ? {} : { alert: response }) }, isOk ? "INFO" : "WARN");
 
 			if (!isOk) {
 				this.callbacks.onAlert?.(`🫀 Heartbeat:\n\n${response}`);
@@ -161,8 +171,15 @@ export class HeartbeatRunner {
 			this.runCount++;
 			this.alertCount++;
 
+			// Persist to store
+			if (isStoreReady()) {
+				try {
+					await getStore().insertRun(false, runResult.response, durationMs);
+				} catch { /* ignore store errors */ }
+			}
+
 			this.callbacks.onResult?.(runResult);
-			this.callbacks.log?.("error", { error: err.message, durationMs }, "ERROR");
+			this.callbacks.log?.("error", { alert: err.message, durationMs }, "ERROR");
 			this.callbacks.onAlert?.(`🫀 Heartbeat error: ${err.message}`);
 			return runResult;
 		} finally {
@@ -170,27 +187,86 @@ export class HeartbeatRunner {
 		}
 	}
 
+	private buildArgs(): string[] {
+		const args = ["--mode", "rpc"];
+
+		// Extension loading: -ne disables discovery, then -e for each explicit extension
+		const exts = this.settings.extensions;
+		args.push("-ne");
+		if (exts && exts.length > 0) {
+			for (const ext of exts) {
+				args.push("-e", ext);
+			}
+		}
+
+		return args;
+	}
+
 	private runSubprocess(prompt: string, timeoutMs = 300_000): Promise<{ stdout: string; stderr: string; exitCode: number }> {
 		return new Promise((resolve) => {
-			const child = spawn("pi", ["-p", "--no-session", prompt], {
+			const args = this.buildArgs();
+			const child = spawn("pi", args, {
 				cwd: this.cwd,
-				stdio: ["ignore", "pipe", "pipe"],
+				stdio: ["pipe", "pipe", "pipe"],
 				env: { ...process.env },
-				timeout: timeoutMs,
 			});
 
-			let stdout = "";
+			let responseText = "";
 			let stderr = "";
+			let settled = false;
 
-			child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+			const timeout = setTimeout(() => {
+				if (!settled) {
+					settled = true;
+					child.kill("SIGTERM");
+					resolve({ stdout: responseText, stderr: stderr + "\nHeartbeat timed out", exitCode: 1 });
+				}
+			}, timeoutMs);
+
 			child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
 
+			// Parse JSON-line events from RPC stdout
+			const rl = readline.createInterface({ input: child.stdout });
+			rl.on("line", (line) => {
+				try {
+					const event = JSON.parse(line);
+
+					// Collect text deltas from assistant message streaming
+					if (event.type === "message_update") {
+						const delta = event.assistantMessageEvent;
+						if (delta?.type === "text_delta" && delta.delta) {
+							responseText += delta.delta;
+						}
+					}
+
+					// Agent finished — kill the subprocess
+					if (event.type === "agent_end") {
+						child.stdin.end();
+						child.kill("SIGTERM");
+					}
+				} catch {
+					// Ignore non-JSON lines
+				}
+			});
+
+			// Send the prompt command once the process is ready
+			const promptCmd = JSON.stringify({ type: "prompt", message: prompt }) + "\n";
+			child.stdin.write(promptCmd);
+
 			child.on("close", (code) => {
-				resolve({ stdout, stderr, exitCode: code ?? 1 });
+				if (!settled) {
+					settled = true;
+					clearTimeout(timeout);
+					resolve({ stdout: responseText, stderr, exitCode: code ?? 0 });
+				}
 			});
 
 			child.on("error", (err) => {
-				resolve({ stdout, stderr: stderr + "\n" + err.message, exitCode: 1 });
+				if (!settled) {
+					settled = true;
+					clearTimeout(timeout);
+					resolve({ stdout: responseText, stderr: stderr + "\n" + err.message, exitCode: 1 });
+				}
 			});
 		});
 	}

--- a/extensions/pi-heartbeat/src/heartbeat.ts
+++ b/extensions/pi-heartbeat/src/heartbeat.ts
@@ -223,15 +223,15 @@ export class HeartbeatRunner {
 				if (settled) return;
 				settled = true;
 				clearTimeout(timeout);
-				if (killTimer) { clearTimeout(killTimer); killTimer = null; }
 				rl.close();
 				resolve(result);
 			}
 
 			const timeout = setTimeout(() => {
 				child.kill("SIGTERM");
-				// Force kill if SIGTERM is ignored
+				// Force kill if SIGTERM is ignored — unref so it doesn't block exit
 				killTimer = setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 5_000);
+				killTimer.unref();
 				settle({ stdout: responseText, stderr: stderr + "\nHeartbeat timed out", exitCode: 1 });
 			}, timeoutMs);
 
@@ -264,10 +264,12 @@ export class HeartbeatRunner {
 			child.stdin.write(promptCmd);
 
 			child.on("close", (code) => {
+				if (killTimer) { clearTimeout(killTimer); killTimer = null; }
 				settle({ stdout: responseText, stderr, exitCode: code ?? 0 });
 			});
 
 			child.on("error", (err) => {
+				if (killTimer) { clearTimeout(killTimer); killTimer = null; }
 				settle({ stdout: responseText, stderr: stderr + "\n" + err.message, exitCode: 1 });
 			});
 		});

--- a/extensions/pi-heartbeat/src/heartbeat.ts
+++ b/extensions/pi-heartbeat/src/heartbeat.ts
@@ -236,6 +236,7 @@ export class HeartbeatRunner {
 			}, timeoutMs);
 
 			child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+			child.stdin.on("error", () => { /* ignore EPIPE / ERR_STREAM_DESTROYED */ });
 
 			rl.on("line", (line) => {
 				try {

--- a/extensions/pi-heartbeat/src/heartbeat.ts
+++ b/extensions/pi-heartbeat/src/heartbeat.ts
@@ -259,9 +259,11 @@ export class HeartbeatRunner {
 				}
 			});
 
-			// Send the prompt command once the process is ready
+			// Send the prompt once the child process has spawned
 			const promptCmd = JSON.stringify({ type: "prompt", message: prompt }) + "\n";
-			child.stdin.write(promptCmd);
+			child.once("spawn", () => {
+				child.stdin.write(promptCmd);
+			});
 
 			child.on("close", (code) => {
 				if (killTimer) { clearTimeout(killTimer); killTimer = null; }

--- a/extensions/pi-heartbeat/src/heartbeat.ts
+++ b/extensions/pi-heartbeat/src/heartbeat.ts
@@ -214,6 +214,7 @@ export class HeartbeatRunner {
 			let responseText = "";
 			let stderr = "";
 			let settled = false;
+			let killTimer: ReturnType<typeof setTimeout> | null = null;
 
 			// Parse JSON-line events from RPC stdout
 			const rl = readline.createInterface({ input: child.stdout });
@@ -222,6 +223,7 @@ export class HeartbeatRunner {
 				if (settled) return;
 				settled = true;
 				clearTimeout(timeout);
+				if (killTimer) { clearTimeout(killTimer); killTimer = null; }
 				rl.close();
 				resolve(result);
 			}
@@ -229,7 +231,7 @@ export class HeartbeatRunner {
 			const timeout = setTimeout(() => {
 				child.kill("SIGTERM");
 				// Force kill if SIGTERM is ignored
-				setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 5_000);
+				killTimer = setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 5_000);
 				settle({ stdout: responseText, stderr: stderr + "\nHeartbeat timed out", exitCode: 1 });
 			}, timeoutMs);
 

--- a/extensions/pi-heartbeat/src/index.ts
+++ b/extensions/pi-heartbeat/src/index.ts
@@ -19,7 +19,7 @@ import { resolveSettings } from "./settings.ts";
 import { HeartbeatRunner } from "./heartbeat.ts";
 import { mountHeartbeatRoutes, unmountHeartbeatRoutes } from "./web.ts";
 import { createLogger } from "./logger.ts";
-import { setStore, isStoreReady, getStore, createMemoryStore, createKyselyStore } from "./store.ts";
+import { setStore, isStoreReady, getStore, createMemoryStore, createKyselyStore, resetStore } from "./store.ts";
 
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
@@ -163,7 +163,7 @@ export default function (pi: ExtensionAPI) {
 			runner = null;
 		}
 		// Reset store to avoid stale state across sessions
-		setStore(null);
+		await resetStore();
 	});
 
 	// ── Command: /heartbeat ───────────────────────────────────

--- a/extensions/pi-heartbeat/src/index.ts
+++ b/extensions/pi-heartbeat/src/index.ts
@@ -19,6 +19,7 @@ import { resolveSettings } from "./settings.ts";
 import { HeartbeatRunner } from "./heartbeat.ts";
 import { mountHeartbeatRoutes, unmountHeartbeatRoutes } from "./web.ts";
 import { createLogger } from "./logger.ts";
+import { setStore, isStoreReady, getStore, createMemoryStore, createKyselyStore } from "./store.ts";
 
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
@@ -105,6 +106,40 @@ export default function (pi: ExtensionAPI) {
 		cwd = ctx.cwd;
 		const settings = resolveSettings(cwd);
 
+		// ── Initialize store ────────────────────────────────────
+		if (settings.useKysely) {
+			const initKysely = async () => {
+				if (isStoreReady()) return;
+				try {
+					const store = await createKyselyStore(pi.events as any);
+					setStore(store);
+					log("ready", { backend: "kysely" });
+				} catch (err: any) {
+					log("error", { backend: "kysely", error: err.message }, "ERROR");
+					// Fall back to memory store
+					setStore(createMemoryStore());
+					log("fallback", { backend: "memory", reason: err.message }, "WARN");
+				}
+			};
+
+			pi.events.on("kysely:ready", initKysely);
+
+			log("init", { backend: "kysely", status: "probing for kysely" });
+			let kyselyAlreadyReady = false;
+			pi.events.emit("kysely:info", {
+				reply: () => { kyselyAlreadyReady = true; },
+			});
+			if (kyselyAlreadyReady) {
+				log("init", { backend: "kysely", status: "kysely already available" });
+				await initKysely();
+			} else {
+				log("init", { backend: "kysely", status: "waiting for kysely:ready" });
+			}
+		} else {
+			setStore(createMemoryStore());
+			log("ready", { backend: "memory" });
+		}
+
 		if (pi.getFlag("--heartbeat") || settings.autostart) {
 			runner = createRunner();
 			runner.start();
@@ -164,10 +199,30 @@ export default function (pi: ExtensionAPI) {
 				if (!s || !s.active) {
 					ctx.ui.notify("Heartbeat: inactive. Use /heartbeat on to start.", "info");
 				} else {
+					// Prefer DB stats over in-memory counters
+					let runCount = s.runCount;
+					let okCount = s.okCount;
+					let alertCount = s.alertCount;
+					let lastRunStr = s.lastRun ? s.lastRun.toLocaleTimeString() : null;
+					let lastOkLabel = s.lastResult?.ok ? "OK" : "alert";
+
+					if (isStoreReady()) {
+						try {
+							const dbStats = await getStore().getStats();
+							runCount = dbStats.runCount;
+							okCount = dbStats.okCount;
+							alertCount = dbStats.alertCount;
+							if (dbStats.lastRun) {
+								lastRunStr = new Date(dbStats.lastRun).toLocaleTimeString();
+								lastOkLabel = dbStats.lastOk ? "OK" : "alert";
+							}
+						} catch { /* fall back to in-memory */ }
+					}
+
 					const lines = [
 						`Heartbeat: ✅ active (every ${s.intervalMinutes}m)`,
-						`Runs: ${s.runCount} · OK: ${s.okCount} · Alerts: ${s.alertCount}`,
-						s.lastRun ? `Last: ${s.lastRun.toLocaleTimeString()} (${s.lastResult?.ok ? "OK" : "alert"})` : "No runs yet",
+						`Runs: ${runCount} · OK: ${okCount} · Alerts: ${alertCount}`,
+						lastRunStr ? `Last: ${lastRunStr} (${lastOkLabel})` : "No runs yet",
 					];
 					ctx.ui.notify(lines.join("\n"), "info");
 				}

--- a/extensions/pi-heartbeat/src/index.ts
+++ b/extensions/pi-heartbeat/src/index.ts
@@ -26,6 +26,7 @@ export default function (pi: ExtensionAPI) {
 	let runner: HeartbeatRunner | null = null;
 	let cwd = process.cwd();
 	let webMounted = false;
+	let unsubKyselyReady: (() => void) | null = null;
 
 	// ── Flag: --heartbeat ─────────────────────────────────────
 
@@ -122,7 +123,7 @@ export default function (pi: ExtensionAPI) {
 				}
 			};
 
-			pi.events.on("kysely:ready", initKysely);
+			unsubKyselyReady = pi.events.on("kysely:ready", initKysely);
 
 			log("init", { backend: "kysely", status: "probing for kysely" });
 			let kyselyAlreadyReady = false;
@@ -153,6 +154,10 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async () => {
 		unmountWeb();
+		if (unsubKyselyReady) {
+			unsubKyselyReady();
+			unsubKyselyReady = null;
+		}
 		if (runner) {
 			runner.stop();
 			runner = null;

--- a/extensions/pi-heartbeat/src/index.ts
+++ b/extensions/pi-heartbeat/src/index.ts
@@ -162,6 +162,8 @@ export default function (pi: ExtensionAPI) {
 			runner.stop();
 			runner = null;
 		}
+		// Reset store to avoid stale state across sessions
+		setStore(null);
 	});
 
 	// ── Command: /heartbeat ───────────────────────────────────

--- a/extensions/pi-heartbeat/src/settings.ts
+++ b/extensions/pi-heartbeat/src/settings.ts
@@ -14,6 +14,10 @@ export interface HeartbeatSettings {
 	showOk: boolean;
 	prompt: string | null;
 	webui: boolean;
+	/** Use pi-kysely shared DB for persistent heartbeat history. */
+	useKysely: boolean;
+	/** Extensions to load in the subprocess. If set, uses -ne + -e for each. If null, uses -ne (no extensions). */
+	extensions: string[] | null;
 }
 
 const DEFAULTS: HeartbeatSettings = {
@@ -24,6 +28,8 @@ const DEFAULTS: HeartbeatSettings = {
 	showOk: false,
 	prompt: null,
 	webui: false,
+	useKysely: false,
+	extensions: null,
 };
 
 export function resolveSettings(cwd: string): HeartbeatSettings {
@@ -42,6 +48,8 @@ export function resolveSettings(cwd: string): HeartbeatSettings {
 			showOk: cfg.showOk ?? DEFAULTS.showOk,
 			prompt: cfg.prompt ?? DEFAULTS.prompt,
 			webui: cfg.webui ?? DEFAULTS.webui,
+			useKysely: cfg.useKysely ?? DEFAULTS.useKysely,
+			extensions: Array.isArray(cfg.extensions) ? cfg.extensions : DEFAULTS.extensions,
 		};
 	} catch {
 		return { ...DEFAULTS };

--- a/extensions/pi-heartbeat/src/store.ts
+++ b/extensions/pi-heartbeat/src/store.ts
@@ -1,0 +1,124 @@
+/**
+ * pi-heartbeat — Store abstraction.
+ *
+ * Two backends:
+ *   1. "memory" (default) — in-memory ring buffer (no persistence)
+ *   2. "kysely" — shared DB via pi-kysely event bus (db-kysely.ts)
+ *
+ * Consumers import `getStore()` and get back the same async API.
+ */
+
+// ── Store interface ─────────────────────────────────────────────
+
+export interface HeartbeatEntry {
+	id?: number;
+	ok: boolean;
+	response: string;
+	durationMs: number;
+	time: string;
+}
+
+export interface HeartbeatStats {
+	runCount: number;
+	okCount: number;
+	alertCount: number;
+	lastRun: string | null;
+	lastOk: boolean | null;
+}
+
+export interface HeartbeatStore {
+	insertRun(ok: boolean, response: string, durationMs: number): Promise<HeartbeatEntry>;
+	getHistory(limit?: number): Promise<HeartbeatEntry[]>;
+	getStats(): Promise<HeartbeatStats>;
+}
+
+// ── Singleton ───────────────────────────────────────────────────
+
+let activeStore: HeartbeatStore | null = null;
+
+export function setStore(store: HeartbeatStore): void {
+	activeStore = store;
+}
+
+export function isStoreReady(): boolean {
+	return activeStore !== null;
+}
+
+export function getStore(): HeartbeatStore {
+	if (!activeStore) throw new Error("Heartbeat store not initialized");
+	return activeStore;
+}
+
+// ── Memory backend (in-memory ring buffer, no persistence) ──────
+
+const MAX_HISTORY = 100;
+
+export function createMemoryStore(): HeartbeatStore {
+	const history: HeartbeatEntry[] = [];
+	let runCount = 0;
+	let okCount = 0;
+	let alertCount = 0;
+
+	return {
+		insertRun: async (ok, response, durationMs) => {
+			const entry: HeartbeatEntry = {
+				ok,
+				response,
+				durationMs,
+				time: new Date().toISOString(),
+			};
+			history.unshift(entry);
+			if (history.length > MAX_HISTORY) history.pop();
+			runCount++;
+			if (ok) okCount++;
+			else alertCount++;
+			return entry;
+		},
+		getHistory: async (limit = MAX_HISTORY) => history.slice(0, limit),
+		getStats: async () => ({
+			runCount,
+			okCount,
+			alertCount,
+			lastRun: history.length > 0 ? history[0].time : null,
+			lastOk: history.length > 0 ? history[0].ok : null,
+		}),
+	};
+}
+
+// ── Kysely backend (pi-kysely event bus, async) ─────────────────
+
+interface EventBus {
+	emit(channel: string, data: unknown): void;
+	on(channel: string, handler: (data: unknown) => void): () => void;
+}
+
+export async function createKyselyStore(eventBus: EventBus): Promise<HeartbeatStore> {
+	const db = await import("./db-kysely.ts");
+	await db.initDb(eventBus);
+
+	return {
+		insertRun: async (ok, response, durationMs) => {
+			const row = await db.insertRun(ok, response, durationMs);
+			return {
+				id: row.id,
+				ok: row.ok,
+				response: row.response ?? "",
+				durationMs: row.duration_ms ?? 0,
+				time: row.created_at,
+			};
+		},
+		getHistory: async (limit = 100) => {
+			const rows = await db.getHistory(limit);
+			return rows.map((r) => ({
+				id: r.id,
+				ok: r.ok,
+				response: r.response ?? "",
+				durationMs: r.duration_ms ?? 0,
+				time: r.created_at,
+			}));
+		},
+		getStats: async () => {
+			return db.getStats();
+		},
+	};
+}

--- a/extensions/pi-heartbeat/src/store.ts
+++ b/extensions/pi-heartbeat/src/store.ts
@@ -36,7 +36,7 @@ export interface HeartbeatStore {
 
 let activeStore: HeartbeatStore | null = null;
 
-export function setStore(store: HeartbeatStore): void {
+export function setStore(store: HeartbeatStore | null): void {
 	activeStore = store;
 }
 

--- a/extensions/pi-heartbeat/src/store.ts
+++ b/extensions/pi-heartbeat/src/store.ts
@@ -44,6 +44,15 @@ export function isStoreReady(): boolean {
 	return activeStore !== null;
 }
 
+/** Reset all store state (call on session shutdown). */
+export async function resetStore(): Promise<void> {
+	activeStore = null;
+	try {
+		const db = await import("./db-kysely.ts");
+		db.resetDb();
+	} catch { /* db-kysely may not have been loaded */ }
+}
+
 export function getStore(): HeartbeatStore {
 	if (!activeStore) throw new Error("Heartbeat store not initialized");
 	return activeStore;

--- a/extensions/pi-heartbeat/src/web.ts
+++ b/extensions/pi-heartbeat/src/web.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HeartbeatRunner, HeartbeatRunResult } from "./heartbeat.ts";
+import { isStoreReady, getStore } from "./store.ts";
 
 // ── HTTP helpers ────────────────────────────────────────────────
 
@@ -134,7 +135,7 @@ export function mountHeartbeatRoutes(bus: EventBus, options: HeartbeatWebOptions
 				// GET /api/heartbeat — status + history
 				if (method === "GET" && p === "/") {
 					const runner = opts.getRunner();
-					const status = runner?.getStatus() ?? {
+					const runnerStatus = runner?.getStatus() ?? {
 						active: false,
 						running: false,
 						lastRun: null,
@@ -145,12 +146,38 @@ export function mountHeartbeatRoutes(bus: EventBus, options: HeartbeatWebOptions
 						intervalMinutes: 15,
 					};
 
+					// Read history + stats from store if available, else in-memory
+					let historyData: HistoryEntry[];
+					let statsOverride: { runCount: number; okCount: number; alertCount: number; lastRun: string | null; lastOk: boolean | null } | null = null;
+					if (isStoreReady()) {
+						try {
+							const [storeHistory, storeStats] = await Promise.all([
+								getStore().getHistory(100),
+								getStore().getStats(),
+							]);
+							historyData = storeHistory.map((e) => ({
+								ok: e.ok,
+								response: e.response,
+								durationMs: e.durationMs,
+								time: e.time,
+							}));
+							statsOverride = storeStats;
+						} catch {
+							historyData = getHistory();
+						}
+					} else {
+						historyData = getHistory();
+					}
+
 					json(res, 200, {
 						status: {
-							...status,
-							lastRun: status.lastRun?.toISOString() ?? null,
+							...runnerStatus,
+							lastRun: statsOverride?.lastRun ?? runnerStatus.lastRun?.toISOString() ?? null,
+							runCount: statsOverride?.runCount ?? runnerStatus.runCount,
+							okCount: statsOverride?.okCount ?? runnerStatus.okCount,
+							alertCount: statsOverride?.alertCount ?? runnerStatus.alertCount,
 						},
-						history: getHistory(),
+						history: historyData,
 					});
 					return;
 				}

--- a/extensions/pi-td-webui/src/tasks.html
+++ b/extensions/pi-td-webui/src/tasks.html
@@ -143,6 +143,13 @@
   }
   .td-detail-actions button:hover { background: var(--accent); color: var(--bg); border-color: var(--accent); }
   .td-detail-actions .btn-close-detail { margin-left: auto; background: transparent; }
+  .td-detail-actions .btn-delete { background: transparent; color: var(--fg3); border-color: transparent; padding: 6px 8px; font-size: 14px; }
+  .td-detail-actions .btn-delete:hover { color: var(--red); background: rgba(248,113,113,0.1); border-color: transparent; }
+  .td-detail-actions .btn-delete-confirm { display: none; align-items: center; gap: 6px; font-size: 12px; color: var(--red); }
+  .td-detail-actions .btn-delete-confirm.open { display: flex; }
+  .td-detail-actions .btn-delete-confirm button { font-size: 11px; padding: 3px 10px; }
+  .td-detail-actions .btn-delete-yes { color: #fff; background: var(--red); border-color: var(--red); }
+  .td-detail-actions .btn-delete-yes:hover { background: #dc2626; border-color: #dc2626; }
 
   /* ── Create modal ───────────────────────────────────── */
   .td-modal-overlay {
@@ -745,8 +752,11 @@ async function fetchConfig() {
         await tdUI.reload();
       } catch(e) {}
     },
-    deleteIssue: async function(id) {
-      if (!confirm('Delete issue ' + id + '?')) return;
+    deleteIssue: function(id) {
+      var el = document.getElementById('td-delete-confirm');
+      if (el) el.classList.add('open');
+    },
+    confirmDelete: async function(id) {
       try {
         await fetch('/api/td', {
           method: 'DELETE',
@@ -756,6 +766,10 @@ async function fetchConfig() {
         tdUI.closeDetail();
         await tdUI.reload();
       } catch(e) {}
+    },
+    cancelDelete: function() {
+      var el = document.getElementById('td-delete-confirm');
+      if (el) el.classList.remove('open');
     },
     toggleAddLog: function() {
       var form = document.getElementById('td-add-log-form');
@@ -1365,8 +1379,13 @@ async function fetchConfig() {
       '</p></div>' +
       (statusButtons ? '<div class="td-detail-section"><h4>Actions</h4><div class="td-detail-actions">' + statusButtons + '</div></div>' : '') +
       '<div class="td-detail-actions">' +
-        (readOnly ? '' : '<button style="color:var(--red);border-color:var(--red);" onclick="tdUI.deleteIssue(\'' + esc(issue.id) + '\')">Delete</button>') +
+        '<span class="btn-delete-confirm" id="td-delete-confirm">' +
+          '<span>Delete this issue?</span>' +
+          '<button class="btn-delete-yes" onclick="tdUI.confirmDelete(\'' + esc(issue.id) + '\')">Yes</button>' +
+          '<button onclick="tdUI.cancelDelete()">No</button>' +
+        '</span>' +
         '<button class="btn-close-detail" onclick="tdUI.closeDetail()">Close</button>' +
+        (readOnly ? '' : '<button class="btn-delete" onclick="tdUI.deleteIssue(\'' + esc(issue.id) + '\')" title="Delete">🗑️</button>') +
       '</div>';
 
     document.getElementById('td-detail-overlay').classList.add('open');


### PR DESCRIPTION
## Problem

The heartbeat dashboard and `/heartbeat status` command always showed 0 for run/ok/alert counts after an agent restart. The `HeartbeatRunner` maintains in-memory counters that reset on construction, even though runs are persisted in the DB.

## Changes

### Foundation: persistent DB store and RPC subprocess mode
- Add store abstraction (`store.ts`) with memory and kysely backends
- Add kysely DB layer (`db-kysely.ts`) with `heartbeat_runs` table and CRUD via pi-kysely event bus
- Switch subprocess from `pi -p --no-session` to `pi --mode rpc` with JSON-line event parsing
- Persist heartbeat results to store after each run
- Add `useKysely` and `extensions` settings

### Bug fix: stats from DB
- Dashboard API (`web.ts`) now uses `store.getStats()` for counts instead of runner in-memory counters
- `/heartbeat status` command (`index.ts`) does the same
- Falls back to in-memory counters if store is unavailable

## Task
`td-be070b`