### PR TITLE
feat(pi-myfinance): vendor CRUD actions + kysely schema

### DIFF
--- a/extensions/pi-myfinance/src/db-kysely.ts
+++ b/extensions/pi-myfinance/src/db-kysely.ts
@@ -60,6 +60,21 @@ const SCHEMA = {
 				created_at:    { type: "text" as const, notNull: true },
 			},
 		},
+		finance_vendors: {
+			columns: {
+				id:          { type: "integer" as const, primaryKey: true, autoIncrement: true },
+				name:        { type: "text" as const, notNull: true },
+				country:     { type: "text" as const },
+				category_id: { type: "integer" as const, references: "finance_categories.id", onDelete: "set null" as const },
+				ignore:      { type: "integer" as const, notNull: true, default: "0" },
+				notes:       { type: "text" as const },
+				created_at:  { type: "text" as const, notNull: true },
+				updated_at:  { type: "text" as const, notNull: true },
+			},
+			indexes: [
+				{ columns: ["name"], name: "idx_fin_vendor_name", unique: true },
+			],
+		},
 		finance_transactions: {
 			columns: {
 				id:                     { type: "integer" as const, primaryKey: true, autoIncrement: true },
@@ -138,21 +153,6 @@ const SCHEMA = {
 			},
 			indexes: [
 				{ columns: ["category_id"], name: "idx_fin_kw_category" },
-			],
-		},
-		finance_vendors: {
-			columns: {
-				id:          { type: "integer" as const, primaryKey: true, autoIncrement: true },
-				name:        { type: "text" as const, notNull: true },
-				country:     { type: "text" as const },
-				category_id: { type: "integer" as const, references: "finance_categories.id", onDelete: "set null" as const },
-				ignore:      { type: "integer" as const, notNull: true, default: "0" },
-				notes:       { type: "text" as const },
-				created_at:  { type: "text" as const, notNull: true },
-				updated_at:  { type: "text" as const, notNull: true },
-			},
-			indexes: [
-				{ columns: ["name"], name: "idx_fin_vendor_name", unique: true },
 			],
 		},
 	},
@@ -737,10 +737,10 @@ export const store: FinanceStore = {
 		const ts = now();
 		const r = await q(
 			`INSERT INTO finance_transactions
-			 (account_id, category_id, amount, transaction_type, description, date, tags, notes, recurring_id, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 (account_id, category_id, vendor_id, amount, transaction_type, description, date, tags, notes, recurring_id, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			[
-				data.account_id, data.category_id ?? null, data.amount, data.transaction_type,
+				data.account_id, data.category_id ?? null, data.vendor_id ?? null, data.amount, data.transaction_type,
 				data.description, data.date ?? today(),
 				data.tags ? JSON.stringify(data.tags) : null,
 				data.notes ?? null, data.recurring_id ?? null, ts, ts,
@@ -773,12 +773,13 @@ export const store: FinanceStore = {
 
 		await q(
 			`UPDATE finance_transactions
-			 SET account_id = ?, category_id = ?, amount = ?, transaction_type = ?,
+			 SET account_id = ?, category_id = ?, vendor_id = ?, amount = ?, transaction_type = ?,
 			     description = ?, date = ?, tags = ?, notes = ?, updated_at = ?
 			 WHERE id = ?`,
 			[
 				newAccountId,
 				data.category_id !== undefined ? data.category_id : existing.category_id,
+				data.vendor_id !== undefined ? data.vendor_id : existing.vendor_id,
 				newAmount, newType,
 				data.description ?? existing.description,
 				data.date ?? existing.date,

--- a/extensions/pi-myfinance/src/db-kysely.ts
+++ b/extensions/pi-myfinance/src/db-kysely.ts
@@ -73,6 +73,7 @@ const SCHEMA = {
 				notes:                  { type: "text" as const },
 				recurring_id:           { type: "integer" as const, references: "finance_recurring.id", onDelete: "set null" as const },
 				linked_transaction_id:  { type: "integer" as const },
+				vendor_id:              { type: "integer" as const, references: "finance_vendors.id", onDelete: "set null" as const },
 				created_at:             { type: "text" as const, notNull: true },
 				updated_at:             { type: "text" as const, notNull: true },
 			},
@@ -82,6 +83,7 @@ const SCHEMA = {
 				{ columns: ["category_id"], name: "idx_fin_tx_category" },
 				{ columns: ["transaction_type"], name: "idx_fin_tx_type" },
 				{ columns: ["linked_transaction_id"], name: "idx_fin_tx_linked" },
+				{ columns: ["vendor_id"], name: "idx_fin_tx_vendor" },
 			],
 		},
 		finance_budgets: {
@@ -136,6 +138,21 @@ const SCHEMA = {
 			},
 			indexes: [
 				{ columns: ["category_id"], name: "idx_fin_kw_category" },
+			],
+		},
+		finance_vendors: {
+			columns: {
+				id:          { type: "integer" as const, primaryKey: true, autoIncrement: true },
+				name:        { type: "text" as const, notNull: true },
+				country:     { type: "text" as const },
+				category_id: { type: "integer" as const, references: "finance_categories.id", onDelete: "set null" as const },
+				ignore:      { type: "integer" as const, notNull: true, default: "0" },
+				notes:       { type: "text" as const },
+				created_at:  { type: "text" as const, notNull: true },
+				updated_at:  { type: "text" as const, notNull: true },
+			},
+			indexes: [
+				{ columns: ["name"], name: "idx_fin_vendor_name", unique: true },
 			],
 		},
 	},

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -78,6 +78,8 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 			account_id: Type.Optional(Type.Number({ description: "Account ID" })),
 			category_id: Type.Optional(Type.Number({ description: "Category ID" })),
 
+			vendor_id: Type.Optional(Type.Number({ description: "Vendor ID (for transactions)" })),
+
 			// Account fields
 			name: Type.Optional(Type.String({ description: "Name (account, category, or goal)" })),
 			account_type: Type.Optional(
@@ -140,6 +142,9 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 			),
 			next_date: Type.Optional(Type.String({ description: "Next date for recurring (YYYY-MM-DD)" })),
 			active: Type.Optional(Type.Boolean({ description: "Whether recurring is active" })),
+
+			// Vendor filters
+			include_ignored: Type.Optional(Type.Boolean({ description: "Include ignored/inactive vendors in list_vendors (default: false)" })),
 
 			// Filters
 			date_from: Type.Optional(Type.String({ description: "Filter: start date (YYYY-MM-DD)" })),
@@ -242,6 +247,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 						const tx = await store.createTransaction({
 							account_id: params.account_id,
 							category_id: params.category_id,
+							vendor_id: params.vendor_id,
 							amount: params.amount,
 							transaction_type: params.transaction_type,
 							description: params.description,
@@ -258,6 +264,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 						const updated = await store.updateTransaction(params.id, {
 							account_id: params.account_id,
 							category_id: params.category_id,
+							vendor_id: params.vendor_id,
 							amount: params.amount,
 							transaction_type: params.transaction_type,
 							description: params.description,
@@ -497,8 +504,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 					// ── Vendors ───────────────────────────────
 
 					case "list_vendors": {
-						const includeIgnored = params.active === false; // active=false means show all including ignored
-						const vendors = await store.getVendors(includeIgnored);
+						const vendors = await store.getVendors(params.include_ignored ?? false);
 						if (vendors.length === 0) return text("No vendors found. Use `add_vendor` to create one.");
 						const lines = vendors.map(
 							(v) => `• **${v.name}**${v.country ? ` (${v.country})` : ""}${v.category_name ? ` → ${v.category_name}` : ""}${v.ignore ? " 🚫" : ""} — ${v.transaction_count ?? 0} txs`,

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -41,6 +41,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 				"- list_budgets, set_budget, budget_status\n" +
 				"- list_goals, add_goal, update_goal, goal_progress\n" +
 				"- list_recurring, add_recurring, process_recurring, upcoming_recurring\n" +
+				"- list_vendors, add_vendor, update_vendor, delete_vendor\n" +
 				"- spending_summary, category_breakdown, insights, trend_analysis, auto_categorize\n" +
 				"- import_csv, export_csv\n\n" +
 				"**Transaction types:** in, out\n" +
@@ -63,6 +64,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 					"list_budgets", "set_budget", "budget_status",
 					"list_goals", "add_goal", "update_goal", "goal_progress",
 					"list_recurring", "add_recurring", "update_recurring", "delete_recurring", "process_recurring", "upcoming_recurring",
+					"list_vendors", "add_vendor", "update_vendor", "delete_vendor",
 					"spending_summary", "category_breakdown",
 					"insights", "trend_analysis", "auto_categorize",
 					"import_bank", "import_bank_directory",
@@ -84,6 +86,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 				}),
 			),
 			currency: Type.Optional(Type.String({ description: "Currency code (e.g. NOK, USD, EUR)" })),
+			country: Type.Optional(Type.String({ description: "Country code ISO 3166-1 alpha-2 (e.g. NO, US, SE) — for vendors" })),
 			balance: Type.Optional(Type.Number({ description: "Account balance" })),
 
 			// Transaction fields
@@ -489,6 +492,49 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 							return `${icon} ${r.next_date} | **${r.description}** — ${formatAmount(r.amount)} (${r.frequency})`;
 						});
 						return text(`🔁 **Upcoming Recurring (next ${days} days)**\n\n${lines.join("\n")}`);
+					}
+
+					// ── Vendors ───────────────────────────────
+
+					case "list_vendors": {
+						const includeIgnored = params.active === false; // active=false means show all including ignored
+						const vendors = await store.getVendors(includeIgnored);
+						if (vendors.length === 0) return text("No vendors found. Use `add_vendor` to create one.");
+						const lines = vendors.map(
+							(v) => `• **${v.name}**${v.country ? ` (${v.country})` : ""}${v.category_name ? ` → ${v.category_name}` : ""}${v.ignore ? " 🚫" : ""} — ${v.transaction_count ?? 0} txs`,
+						);
+						return text(`🏪 **Vendors** (${vendors.length})\n\n${lines.join("\n")}`);
+					}
+
+					case "add_vendor": {
+						if (!params.name) return text("❌ `name` is required to add a vendor.");
+						const vendor = await store.createVendor({
+							name: params.name,
+							country: params.country ?? undefined,
+							category_id: params.category_id ?? undefined,
+							ignore: false,
+							notes: params.notes ?? undefined,
+						});
+						return text(`✅ Vendor created: **${vendor.name}** (ID ${vendor.id})`);
+					}
+
+					case "update_vendor": {
+						if (!params.id) return text("❌ `id` is required to update a vendor.");
+						const updated = await store.updateVendor(params.id, {
+							name: params.name ?? undefined,
+							country: params.country ?? undefined,
+							category_id: params.category_id ?? undefined,
+							ignore: params.active !== undefined ? !params.active : undefined,
+							notes: params.notes ?? undefined,
+						});
+						if (!updated) return text(`❌ Vendor #${params.id} not found.`);
+						return text(`✅ Vendor updated: **${updated.name}** (ID ${updated.id})`);
+					}
+
+					case "delete_vendor": {
+						if (!params.id) return text("❌ `id` is required to delete a vendor.");
+						const ok = await store.deleteVendor(params.id);
+						return text(ok ? `✅ Vendor #${params.id} deleted.` : `❌ Vendor #${params.id} not found.`);
 					}
 
 					// ── Reports ───────────────────────────────

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -143,8 +143,9 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 			next_date: Type.Optional(Type.String({ description: "Next date for recurring (YYYY-MM-DD)" })),
 			active: Type.Optional(Type.Boolean({ description: "Whether recurring is active" })),
 
-			// Vendor filters
-			include_ignored: Type.Optional(Type.Boolean({ description: "Include ignored/inactive vendors in list_vendors (default: false)" })),
+			// Vendor fields
+			ignore: Type.Optional(Type.Boolean({ description: "Mark vendor as ignored (hidden from default lists)" })),
+			include_ignored: Type.Optional(Type.Boolean({ description: "Include ignored vendors in list_vendors (default: false)" })),
 
 			// Filters
 			date_from: Type.Optional(Type.String({ description: "Filter: start date (YYYY-MM-DD)" })),
@@ -518,7 +519,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 							name: params.name,
 							country: params.country ?? undefined,
 							category_id: params.category_id ?? undefined,
-							ignore: false,
+							ignore: params.ignore ?? false,
 							notes: params.notes ?? undefined,
 						});
 						return text(`✅ Vendor created: **${vendor.name}** (ID ${vendor.id})`);
@@ -530,7 +531,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 							name: params.name ?? undefined,
 							country: params.country ?? undefined,
 							category_id: params.category_id ?? undefined,
-							ignore: params.active !== undefined ? !params.active : undefined,
+							ignore: params.ignore,
 							notes: params.notes ?? undefined,
 						});
 						if (!updated) return text(`❌ Vendor #${params.id} not found.`);


### PR DESCRIPTION
Add vendor management to the finance tool:
- list_vendors: lists active vendors (active=false to include ignored)
- add_vendor: create vendor with name, country, category_id, notes
- update_vendor: update fields including ignore toggle via active flag
- delete_vendor: remove vendor and clear vendor_id from transactions

Kysely schema (db-kysely.ts):
- finance_vendors table with FK to categories, unique name index
- vendor_id FK on finance_transactions with index

Fixes from review:
- list_vendors: active=false shows ignored (was inverted)
- add_vendor/update_vendor: use params.country not params.currency
- update_vendor: support ignore toggle via active flag
- Added country param to tool schema (ISO 3166-1 alpha-2)
