### PR TITLE
fix(pi-github): use 'git push origin HEAD' in /gh-pr-resolve

### DIFF
--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -395,7 +395,7 @@ export function registerPrFixCommand(pi: ExtensionAPI, log: LogFn, getCwd: () =>
 
 			// Push the branch FIRST — abort if it fails so we don't
 			// resolve threads / post comments referencing a non-existent remote commit
-			const pushResult = await gitExec(["push"], cwd, 30_000);
+			const pushResult = await gitExec(["push", "origin", "HEAD"], cwd, 30_000);
 			if (!pushResult.ok) {
 				errors.push(`git push failed: ${pushResult.stderr}`);
 				ctx.ui.notify(`❌ git push failed — threads not resolved.\n${pushResult.stderr}`, "error");


### PR DESCRIPTION
Bare `git push` fails when the branch has no upstream tracking set (e.g. freshly checked-out PR branches). Changed to `git push origin HEAD` which works without an upstream.

**Task:** `td-6a3424`