### PR TITLE
fix(pi-myfinance): PR #6 review fixes — currency grouping, quote stripping, observability

### DIFF
--- a/extensions/pi-myfinance/src/index.ts
+++ b/extensions/pi-myfinance/src/index.ts
@@ -16,7 +16,8 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
 import { closeDb } from "./db.ts";
 import { getFinanceStore, setFinanceStore, isStoreReady, createSqliteStore, createKyselyStore } from "./store.ts";
-import { registerFinanceTool } from "./tool.ts";
+import { registerFinanceTool, setToolLogger } from "./tool.ts";
+import { createLogger } from "./logger.ts";
 import {
 	mountOnWebServer,
 	isMountedOnWebServer,
@@ -109,6 +110,8 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// Register the finance tool
+	const log = createLogger(pi);
+	setToolLogger(log);
 	registerFinanceTool(pi);
 
 	// Re-mount when pi-webserver starts after us
@@ -325,16 +328,17 @@ export default function (pi: ExtensionAPI) {
 			// Group totals by currency
 			const byCurrency = new Map<string, number>();
 			for (const a of accounts) {
-				const cur = a.currency || "NOK";
+				const cur = a.currency ?? "NOK";
 				byCurrency.set(cur, (byCurrency.get(cur) ?? 0) + Number(a.balance));
 			}
-			const totalStr = [...byCurrency.entries()]
+			const totalParts = [...byCurrency.entries()]
 				.map(([cur, sum]) => `${sum.toLocaleString("nb-NO")} ${cur}`)
 				.join(", ");
+
 			const lines = accounts.map(a =>
-				`  ${a.name} (${a.account_type}): ${Number(a.balance).toLocaleString("nb-NO")} ${a.currency || "NOK"}`
+				`  ${a.name} (${a.account_type}): ${Number(a.balance).toLocaleString("nb-NO")} ${a.currency ?? "NOK"}`
 			);
-			lines.unshift(`💳 **${accounts.length} Account${accounts.length !== 1 ? "s" : ""}** — Total: ${totalStr}`);
+			lines.unshift(`💳 **${accounts.length} Account${accounts.length !== 1 ? "s" : ""}** — Total: ${totalParts}`);
 			ctx.ui.notify(lines.join("\n"), "info");
 		},
 	});
@@ -387,7 +391,7 @@ export default function (pi: ExtensionAPI) {
 			const month = now.toLocaleString("en", { month: "long", year: "numeric" });
 			const lines = [`📊 **Budget Status — ${month}:**`, ""];
 			for (const b of budgets) {
-				const spent = Number((b as any).spent ?? 0);
+				const spent = Number(b.spent ?? 0);
 				const amount = Number(b.amount);
 				const pct = amount > 0 ? Math.round((spent / amount) * 100) : 0;
 				const icon = pct > 100 ? "🔴" : pct > 80 ? "🟡" : "🟢";
@@ -497,7 +501,16 @@ export default function (pi: ExtensionAPI) {
 				accountName = parts.slice(1).join(" ");
 			}
 
-			filePath = filePath.startsWith("~") ? path.join(os.homedir(), filePath.slice(1)) : path.resolve(filePath);
+			// Strip surrounding quotes from account name (user may quote it)
+			accountName = accountName.replace(/^["']|["']$/g, "");
+
+			if (filePath === "~") {
+				filePath = os.homedir();
+			} else if (filePath.startsWith("~/")) {
+				filePath = path.join(os.homedir(), filePath.slice(2));
+			} else {
+				filePath = path.resolve(filePath);
+			}
 
 			if (!fs.existsSync(filePath)) {
 				ctx.ui.notify(`File not found: ${filePath}`, "error");

--- a/extensions/pi-myfinance/src/index.ts
+++ b/extensions/pi-myfinance/src/index.ts
@@ -328,7 +328,7 @@ export default function (pi: ExtensionAPI) {
 			// Group totals by currency
 			const byCurrency = new Map<string, number>();
 			for (const a of accounts) {
-				const cur = a.currency ?? "NOK";
+				const cur = a.currency || "NOK";
 				byCurrency.set(cur, (byCurrency.get(cur) ?? 0) + Number(a.balance));
 			}
 			const totalParts = [...byCurrency.entries()]
@@ -336,7 +336,7 @@ export default function (pi: ExtensionAPI) {
 				.join(", ");
 
 			const lines = accounts.map(a =>
-				`  ${a.name} (${a.account_type}): ${Number(a.balance).toLocaleString("nb-NO")} ${a.currency ?? "NOK"}`
+				`  ${a.name} (${a.account_type}): ${Number(a.balance).toLocaleString("nb-NO")} ${a.currency || "NOK"}`
 			);
 			lines.unshift(`💳 **${accounts.length} Account${accounts.length !== 1 ? "s" : ""}** — Total: ${totalParts}`);
 			ctx.ui.notify(lines.join("\n"), "info");
@@ -504,13 +504,8 @@ export default function (pi: ExtensionAPI) {
 			// Strip surrounding quotes from account name (user may quote it)
 			accountName = accountName.replace(/^["']|["']$/g, "");
 
-			if (filePath === "~") {
-				filePath = os.homedir();
-			} else if (filePath.startsWith("~/")) {
-				filePath = path.join(os.homedir(), filePath.slice(2));
-			} else {
-				filePath = path.resolve(filePath);
-			}
+			filePath = expandHome(filePath);
+			if (!path.isAbsolute(filePath)) filePath = path.resolve(filePath);
 
 			if (!fs.existsSync(filePath)) {
 				ctx.ui.notify(`File not found: ${filePath}`, "error");

--- a/extensions/pi-myfinance/src/logger.ts
+++ b/extensions/pi-myfinance/src/logger.ts
@@ -1,0 +1,8 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const CHANNEL = "finance";
+
+export function createLogger(pi: ExtensionAPI) {
+	return (event: string, data: unknown, level = "INFO") =>
+		pi.events.emit("log", { channel: CHANNEL, event, level, data });
+}

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -784,7 +784,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 // ── Formatting Helpers ──────────────────────────────────────────
 
 function formatAmount(amount: number, currency?: string): string {
-	const curr = currency ?? "NOK";
+	const curr = currency || "NOK";
 	return `${amount.toLocaleString("nb-NO", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${curr}`;
 }
 

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -197,7 +197,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 						// Group totals by currency to avoid summing across different currencies
 						const byCurrency = new Map<string, number>();
 						for (const a of accounts) {
-							const cur = a.currency ?? "NOK";
+							const cur = a.currency || "NOK";
 							byCurrency.set(cur, (byCurrency.get(cur) ?? 0) + a.balance);
 						}
 						const totalParts = [...byCurrency.entries()]

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -11,6 +11,12 @@ import { generateInsights, analyzeTrends, autoCategorize } from "./insights.ts";
 import { importBankFile, importBankDirectory } from "./import-bank.ts";
 import type { TransactionFilters, GoalStatus } from "./types.ts";
 
+let log: ((event: string, data: unknown, level?: string) => void) | null = null;
+
+export function setToolLogger(logger: (event: string, data: unknown, level?: string) => void) {
+	log = logger;
+}
+
 interface ExtensionAPI {
 	registerTool(tool: any): void;
 	on(event: string, handler: (...args: any[]) => any): void;
@@ -167,6 +173,7 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 				const action = params.action as string;
 
 				if (!action) {
+					log?.("missing_action", { raw: JSON.stringify(params).slice(0, 200) }, "DEBUG");
 					return text(
 						"❌ Missing required parameter: `action`.\n\n" +
 						"**Usage:** `finance({ action: \"list_accounts\" })`\n\n" +
@@ -187,8 +194,16 @@ export function registerFinanceTool(pi: ExtensionAPI): void {
 						const lines = accounts.map(
 							(a) => `• **${a.name}** (${a.account_type}) — ${formatAmount(a.balance, a.currency)}`,
 						);
-						const total = accounts.reduce((sum, a) => sum + a.balance, 0);
-						lines.push(`\n**Total:** ${formatAmount(total, "NOK")}`);
+						// Group totals by currency to avoid summing across different currencies
+						const byCurrency = new Map<string, number>();
+						for (const a of accounts) {
+							const cur = a.currency ?? "NOK";
+							byCurrency.set(cur, (byCurrency.get(cur) ?? 0) + a.balance);
+						}
+						const totalParts = [...byCurrency.entries()]
+							.map(([cur, sum]) => formatAmount(sum, cur))
+							.join(", ");
+						lines.push(`\n**Total:** ${totalParts}`);
 						return text(`📊 **Accounts (${accounts.length})**\n\n${lines.join("\n")}`);
 					}
 


### PR DESCRIPTION
Review fixes from the original PR #6 that weren't included in the merge:

- **Currency grouping**: Account totals grouped by currency instead of summing all as NOK (index.ts + tool.ts)
- **Quote stripping**: Strip surrounding quotes from account name in /finance-import-bank
- **Budget cast**: Remove unnecessary `(b as any).spent` — use `b.spent` directly
- **Tilde expansion**: Fix to only match `~/` or lone `~`, not `~otheruser/path`
- **Logger**: Added pi-myfinance logger for debug-level observability in tool param handling

**Task:** `td-a918e0`