### PR TITLE
feat(pi-github): reply on each review thread before resolving in /gh-pr-fix

### DIFF
--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -67,6 +67,13 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
   }
 }`;
 
+const REPLY_TO_THREAD_MUTATION = `
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: $threadId, body: $body }) {
+    comment { id }
+  }
+}`;
+
 const RESOLVE_THREAD_MUTATION = `
 mutation($threadId: ID!) {
   resolveReviewThread(input: { threadId: $threadId }) {
@@ -119,6 +126,11 @@ async function getUnresolvedThreads(owner: string, repo: string, prNumber: numbe
 	}
 
 	return threads;
+}
+
+async function replyToThread(threadId: string, body: string, cwd: string): Promise<boolean> {
+	const result = await ghGraphql<any>(REPLY_TO_THREAD_MUTATION, { threadId, body }, cwd);
+	return !!result?.data?.addPullRequestReviewThreadReply?.comment?.id;
 }
 
 async function resolveThread(threadId: string, cwd: string): Promise<boolean> {
@@ -404,12 +416,22 @@ export function registerPrFixCommand(pi: ExtensionAPI, log: LogFn, getCwd: () =>
 				return;
 			}
 
-			// Resolve each thread
+			// Reply to and resolve each thread
 			let resolved = 0;
 			const resolvedIds = new Set<string>();
+			const shortSha = commitSha ? commitSha.slice(0, 7) : "latest";
+			const commitUrl = commitSha ? `${prInfo.url}/commits/${commitSha}` : "";
+			const commitRef = commitUrl ? `[\`${shortSha}\`](${commitUrl})` : `\`${shortSha}\``;
 
 			for (const thread of threads) {
 				try {
+					// Post a reply comment on the thread before resolving
+					const replyBody = `✅ Addressed in ${commitRef}`;
+					const replied = await replyToThread(thread.id, replyBody, cwd);
+					if (!replied) {
+						errors.push(`Thread at ${thread.path}:${thread.line ?? "?"} — failed to post reply`);
+					}
+
 					const ok = await resolveThread(thread.id, cwd);
 					if (ok) {
 						resolved++;


### PR DESCRIPTION
When /gh-pr-resolve runs, it now posts a '✅ Addressed in <commit>'
reply comment on each review thread before resolving it. This leaves
a per-thread paper trail linking to the fix commit, so reviewers can
see exactly which commit addressed each finding.

Adds addPullRequestReviewThreadReply GraphQL mutation and a
replyToThread() helper.

Task: td-1749b6
