### PR TITLE
fix(pi-cron): collapse newlines in prompts to prevent crontab corruption

### DIFF
--- a/extensions/pi-cron/src/crontab.test.ts
+++ b/extensions/pi-cron/src/crontab.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for crontab serialize/parse — especially multi-line prompt handling.
+ *
+ * Run: npx tsx --test src/crontab.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parse, serialize, type CronJob } from "./crontab.ts";
+
+describe("serialize", () => {
+	it("collapses newlines in prompts to single spaces", () => {
+		const jobs: CronJob[] = [{
+			name: "multi-line",
+			schedule: "0 9 * * *",
+			prompt: "Line one\nLine two\nLine three",
+			channel: "cron",
+			disabled: false,
+		}];
+
+		const output = serialize(jobs);
+		const lines = output.split("\n").filter(l => l && !l.startsWith("#"));
+		assert.equal(lines.length, 1, "should produce exactly one job line");
+		assert.ok(lines[0].includes("Line one Line two Line three"), "newlines should be collapsed to spaces");
+	});
+
+	it("collapses \\r\\n and excess whitespace", () => {
+		const jobs: CronJob[] = [{
+			name: "crlf-test",
+			schedule: "*/5 * * * *",
+			prompt: "First\r\nSecond\r\n\r\nThird   extra   spaces",
+			channel: "cron",
+			disabled: false,
+		}];
+
+		const output = serialize(jobs);
+		const lines = output.split("\n").filter(l => l && !l.startsWith("#"));
+		assert.equal(lines.length, 1);
+		assert.ok(!lines[0].includes("\r"), "should not contain \\r");
+		assert.ok(!lines[0].includes("\n\n"), "should not contain consecutive newlines");
+		assert.ok(lines[0].includes("First Second Third extra spaces"), "excess whitespace should be collapsed");
+	});
+});
+
+describe("parse → serialize round-trip", () => {
+	it("serialize(parse(serialize(jobs))) is idempotent when prompts contain newlines", () => {
+		const jobs: CronJob[] = [
+			{
+				name: "daily-standup",
+				schedule: "0 9 * * 1-5",
+				prompt: "Review my td tasks\nand summarize what's open\n\nInclude blockers",
+				channel: "cron",
+				disabled: false,
+			},
+			{
+				name: "health-check",
+				schedule: "*/15 * * * *",
+				prompt: "Check system health\nreport any issues",
+				channel: "ops",
+				disabled: false,
+			},
+			{
+				name: "weekly-digest",
+				schedule: "0 0 * * 0",
+				prompt: "Summarize the week",
+				channel: "cron",
+				disabled: true,
+			},
+		];
+
+		const first = serialize(jobs);
+		const parsed = parse(first);
+		const second = serialize(parsed);
+
+		assert.equal(first, second, "serialize(parse(serialize(jobs))) should be idempotent");
+
+		// Also verify job count is preserved
+		assert.equal(parsed.length, jobs.length, "should parse same number of jobs");
+	});
+
+	it("preserves all job fields through round-trip", () => {
+		const jobs: CronJob[] = [{
+			name: "test-job",
+			schedule: "30 14 * * *",
+			prompt: "Do something\nimportant\nwith multiple lines",
+			channel: "alerts",
+			disabled: true,
+		}];
+
+		const parsed = parse(serialize(jobs));
+		assert.equal(parsed.length, 1);
+		assert.equal(parsed[0].name, "test-job");
+		assert.equal(parsed[0].schedule, "30 14 * * *");
+		assert.equal(parsed[0].channel, "alerts");
+		assert.equal(parsed[0].disabled, true);
+		// Prompt should have newlines collapsed
+		assert.equal(parsed[0].prompt, "Do something important with multiple lines");
+	});
+});
+
+describe("parse", () => {
+	it("skips blank lines and comments", () => {
+		const content = `
+# comment
+   
+0 9 * * * my-job  Hello world
+# another comment
+`;
+		const jobs = parse(content);
+		assert.equal(jobs.length, 1);
+		assert.equal(jobs[0].name, "my-job");
+	});
+
+	it("parses channel and disabled flags", () => {
+		const content = `0 9 * * * flagged-job channel:ops disabled Do the thing`;
+		const jobs = parse(content);
+		assert.equal(jobs.length, 1);
+		assert.equal(jobs[0].channel, "ops");
+		assert.equal(jobs[0].disabled, true);
+		assert.equal(jobs[0].prompt, "Do the thing");
+	});
+});

--- a/extensions/pi-cron/src/crontab.ts
+++ b/extensions/pi-cron/src/crontab.ts
@@ -92,7 +92,9 @@ export function serialize(jobs: CronJob[]): string {
 		if (job.channel !== "cron") flags.push(`channel:${job.channel}`);
 		if (job.disabled) flags.push("disabled");
 		const flagStr = flags.length > 0 ? "  " + flags.join("  ") : "";
-		lines.push(`${job.schedule}  ${job.name}${flagStr}  ${job.prompt}`);
+		// Collapse newlines/excess whitespace — crontab format is strictly one job per line
+		const prompt = job.prompt.replace(/[\r\n]+/g, " ").replace(/\s{2,}/g, " ").trim();
+		lines.push(`${job.schedule}  ${job.name}${flagStr}  ${prompt}`);
 	}
 
 	return lines.join("\n") + "\n";

--- a/extensions/pi-cron/src/ui/cron.js
+++ b/extensions/pi-cron/src/ui/cron.js
@@ -165,7 +165,7 @@ async function saveJob(e) {
     action: mode,
     name: document.getElementById('jobFormName').value.trim(),
     schedule: document.getElementById('jobFormSchedule').value.trim(),
-    prompt: document.getElementById('jobFormPrompt').value.trim(),
+    prompt: document.getElementById('jobFormPrompt').value.replace(/[\r\n]+/g, ' ').replace(/\s{2,}/g, ' ').trim(),
     channel: document.getElementById('jobFormChannel').value.trim() || 'cron',
   };
   if (!data.name || !data.schedule || !data.prompt) {


### PR DESCRIPTION
Multi-line prompts from the web UI were written verbatim to pi-cron.tab,
which uses a one-job-per-line format. On next parse, each line of the
prompt was interpreted as a separate cron entry.

- serialize(): collapse \n/\r\n and excess whitespace in prompts
- cron.js saveJob(): normalize whitespace before sending to API
- Add crontab.test.ts with round-trip idempotency tests

Fixes td-9bd0d0
