### PR TITLE
feat(pi-td): enable write operations in cross-project web UI

### DIFF
--- a/extensions/pi-td/src/index.ts
+++ b/extensions/pi-td/src/index.ts
@@ -49,10 +49,12 @@ interface TdErrorResult {
 
 type TdResult = TdOkResult | TdErrorResult;
 
-async function runTd(pi: ExtensionAPI, args: string[]): Promise<TdResult> {
+async function runTd(pi: ExtensionAPI, args: string[], cwd?: string): Promise<TdResult> {
 	const cmd = `td ${args.join(" ")}`;
 	try {
-		const result = await pi.exec("td", args, { timeout: 30_000 });
+		const opts: { timeout: number; cwd?: string } = { timeout: 30_000 };
+		if (cwd) opts.cwd = cwd;
+		const result = await pi.exec("td", args, opts);
 		const stdout = result.stdout?.trim() ?? "";
 		const stderr = result.stderr?.trim() || "";
 		if (result.code !== 0) {
@@ -65,6 +67,26 @@ async function runTd(pi: ExtensionAPI, args: string[]): Promise<TdResult> {
 	} catch (err: any) {
 		return { ok: false, error: err.message ?? "Unknown error executing td", cmd };
 	}
+}
+
+/** Validate that projectPath is within the cross-project root (prevents path traversal). */
+function validateProjectPath(projectPath: string, res: ServerResponse): string | null {
+	const config = getCrossProjectConfig(sessionCwd);
+	if (!config) {
+		badRequest(res, "Cross-project not configured");
+		return null;
+	}
+	if (!projectPath || typeof projectPath !== "string") {
+		badRequest(res, "projectPath is required");
+		return null;
+	}
+	const resolved = path.resolve(projectPath);
+	const root = path.resolve(config.rootDir);
+	if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+		badRequest(res, "projectPath is outside the cross-project root");
+		return null;
+	}
+	return resolved;
 }
 
 function normalizePath(subPath: string): string {
@@ -409,6 +431,140 @@ async function handleApi(pi: ExtensionAPI, req: IncomingMessage, res: ServerResp
 		} catch (err: any) {
 			serverError(res, err?.message ?? "Failed to read global issues");
 		}
+		return;
+	}
+	// ── Global detail (read from project's td) ─────────────
+	if (method === "GET" && pathKey === "/global/detail") {
+		const url = new URL(req.url ?? "/", "http://localhost");
+		const id = url.searchParams.get("id");
+		const projectPath = url.searchParams.get("projectPath");
+		if (!id) { badRequest(res, "Missing id parameter"); return; }
+		const resolved = validateProjectPath(projectPath ?? "", res);
+		if (!resolved) return;
+		const result = await runTd(pi, ["show", id, "--json"], resolved);
+		if (!result.ok) { json(res, 404, { error: result.error }); return; }
+		try { json(res, 200, JSON.parse(result.data)); }
+		catch (err: any) { serverError(res, err?.message ?? "Invalid td JSON output"); }
+		return;
+	}
+
+	// ── Global write endpoints ──────────────────────────────
+	if (method === "PATCH" && pathKey === "/global") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { id, status, title, priority, description, labels } = body;
+		if (!id) { badRequest(res, "id is required"); return; }
+		const args = ["update", id];
+		if (status) args.push("--status", status);
+		if (title) args.push("--title", title);
+		if (priority) args.push("--priority", priority);
+		if (description) args.push("--description", description);
+		if (labels) args.push("--labels", labels);
+		if (args.length === 2) { badRequest(res, "Nothing to update"); return; }
+		const result = await runTd(pi, args, resolved);
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 200, { message: result.data });
+		return;
+	}
+	if (method === "POST" && pathKey === "/global") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { title, description, type, priority, labels, parent } = body;
+		if (!title) { badRequest(res, "title is required"); return; }
+		const args = ["create", title];
+		if (type) args.push("--type", type);
+		if (priority) args.push("--priority", priority);
+		if (description) args.push("--description", description);
+		if (labels) args.push("--labels", labels);
+		if (parent) args.push("--parent", parent);
+		const result = await runTd(pi, args, resolved);
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 201, { message: result.data });
+		return;
+	}
+	if (method === "DELETE" && pathKey === "/global") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { id } = body;
+		if (!id) { badRequest(res, "id is required"); return; }
+		const result = await runTd(pi, ["delete", id, "--force"], resolved);
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 200, { message: result.data });
+		return;
+	}
+	if (method === "POST" && pathKey === "/global/review") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { id, message } = body;
+		if (!id) { badRequest(res, "id is required"); return; }
+		const args = ["review", id];
+		if (message) args.push("--note", message);
+		const result = await runTd(pi, args, resolved);
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 200, { message: result.data });
+		return;
+	}
+	if (method === "POST" && pathKey === "/global/approve") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { id, reason } = body;
+		if (!id) { badRequest(res, "id is required"); return; }
+		const args = ["approve", id];
+		if (reason) args.push("--reason", reason);
+		let result = await runTd(pi, args, resolved);
+		if (!result.ok && result.error.includes("cannot approve")) {
+			const newSession = await runTd(pi, ["session", "--new"], resolved);
+			if (!newSession.ok) { badRequest(res, `Failed to create review session: ${newSession.error}`); return; }
+			result = await runTd(pi, args, resolved);
+		}
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 200, { message: result.data });
+		return;
+	}
+	if (method === "POST" && pathKey === "/global/reject") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { id, reason } = body;
+		if (!id) { badRequest(res, "id is required"); return; }
+		const args = ["reject", id];
+		if (reason) args.push("--reason", reason);
+		let result = await runTd(pi, args, resolved);
+		if (!result.ok && result.error.includes("cannot reject")) {
+			const newSession = await runTd(pi, ["session", "--new"], resolved);
+			if (!newSession.ok) { badRequest(res, `Failed to create review session: ${newSession.error}`); return; }
+			result = await runTd(pi, args, resolved);
+		}
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 200, { message: result.data });
+		return;
+	}
+	if (method === "POST" && pathKey === "/global/log") {
+		const body = await readJson(req, res);
+		if (!body) return;
+		const resolved = validateProjectPath(body.projectPath, res);
+		if (!resolved) return;
+		const { id, message, type } = body;
+		if (!id) { badRequest(res, "id is required"); return; }
+		if (!message) { badRequest(res, "message is required"); return; }
+		const args = ["log", "--issue", id];
+		const validTypes = ["progress", "blocker", "decision", "hypothesis", "tried", "result"];
+		if (type && validTypes.includes(type)) args.push("--type", type);
+		args.push(message);
+		const result = await runTd(pi, args, resolved);
+		if (!result.ok) { badRequest(res, result.error); return; }
+		json(res, 200, { message: result.data });
 		return;
 	}
 	if (method === "GET" && pathKey === "/global/stats") {

--- a/extensions/pi-td/src/index.ts
+++ b/extensions/pi-td/src/index.ts
@@ -80,8 +80,16 @@ function validateProjectPath(projectPath: string, res: ServerResponse): string |
 		badRequest(res, "projectPath is required");
 		return null;
 	}
-	const resolved = path.resolve(projectPath);
-	const root = path.resolve(config.rootDir);
+	// Resolve symlinks to prevent escaping the root via symlink targets
+	let resolved: string;
+	let root: string;
+	try {
+		resolved = fs.realpathSync(path.resolve(projectPath));
+		root = fs.realpathSync(path.resolve(config.rootDir));
+	} catch {
+		badRequest(res, "projectPath does not exist");
+		return null;
+	}
 	if (!resolved.startsWith(root + path.sep) && resolved !== root) {
 		badRequest(res, "projectPath is outside the cross-project root");
 		return null;

--- a/extensions/pi-td/src/tasks.html
+++ b/extensions/pi-td/src/tasks.html
@@ -836,9 +836,12 @@ async function fetchConfig() {
         if (resp.ok) {
           // Re-fetch and re-render detail
           if (isGlobal) {
+            var crossIssue = issues.find(function(i) { return i.id === id && i.projectPath === currentDetailProject; });
             var resp2 = await fetch('/api/td/global/detail?id=' + encodeURIComponent(id) + '&projectPath=' + encodeURIComponent(currentDetailProject));
             if (resp2.ok) {
               var detail = await resp2.json();
+              detail.project = crossIssue ? crossIssue.project : '';
+              detail.projectPath = currentDetailProject;
               renderDetail(detail, false);
             }
           } else {

--- a/extensions/pi-td/src/tasks.html
+++ b/extensions/pi-td/src/tasks.html
@@ -541,6 +541,7 @@ async function fetchConfig() {
   var issues = [];
   var globalMode = false;
   var globalProjects = [];
+  var currentDetailProject = null; // projectPath of the currently displayed cross-project issue
   var sortColumn = 'updated_at';
   var sortDirection = 'desc';
   var currentPage = 1;
@@ -687,11 +688,31 @@ async function fetchConfig() {
         try { var resp = await fetch('/api/td/tree'); treeData = await resp.json(); } catch(e) { treeData = { nodes: [], edges: [] }; }
       }
       if (globalMode && project) {
-        // In global mode, show read-only detail from cross-project data
-        var issue = issues.find(function(i) { return i.id === id && i.project === project; });
-        if (issue) renderDetail(issue, true);
+        // In global mode, fetch full detail from the target project's td
+        var crossIssue = issues.find(function(i) { return i.id === id && i.project === project; });
+        var projectPath = crossIssue ? crossIssue.projectPath : '';
+        if (!projectPath) {
+          if (crossIssue) renderDetail(crossIssue, true);
+          return;
+        }
+        currentDetailProject = projectPath;
+        try {
+          var resp = await fetch('/api/td/global/detail?id=' + encodeURIComponent(id) + '&projectPath=' + encodeURIComponent(projectPath));
+          if (resp.ok) {
+            var detail = await resp.json();
+            detail.project = crossIssue.project;
+            detail.projectPath = projectPath;
+            renderDetail(detail, false);
+          } else {
+            // Fallback to cross-project data (read-only)
+            renderDetail(crossIssue, true);
+          }
+        } catch(e) {
+          renderDetail(crossIssue, true);
+        }
         return;
       }
+      currentDetailProject = null;
       var detail = await fetchIssueDetail(id);
       if (!detail) return;
       renderDetail(detail, false);
@@ -701,10 +722,14 @@ async function fetchConfig() {
     },
     updateStatus: async function(id, newStatus) {
       try {
-        await fetch('/api/td', {
+        var isGlobal = !!currentDetailProject;
+        var endpoint = isGlobal ? '/api/td/global' : '/api/td';
+        var payload = { id: id, status: newStatus };
+        if (isGlobal) payload.projectPath = currentDetailProject;
+        await fetch(endpoint, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: id, status: newStatus })
+          body: JSON.stringify(payload)
         });
         tdUI.closeDetail();
         await tdUI.reload();
@@ -712,9 +737,12 @@ async function fetchConfig() {
     },
     reviewIssue: async function(id, message) {
       try {
+        var isGlobal = !!currentDetailProject;
+        var endpoint = isGlobal ? '/api/td/global/review' : '/api/td/review';
         var body = { id: id };
         if (message) body.message = message;
-        await fetch('/api/td/review', {
+        if (isGlobal) body.projectPath = currentDetailProject;
+        await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
@@ -730,10 +758,14 @@ async function fetchConfig() {
     },
     approveIssue: async function(id) {
       try {
-        await fetch('/api/td/approve', {
+        var isGlobal = !!currentDetailProject;
+        var endpoint = isGlobal ? '/api/td/global/approve' : '/api/td/approve';
+        var payload = { id: id };
+        if (isGlobal) payload.projectPath = currentDetailProject;
+        await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: id })
+          body: JSON.stringify(payload)
         });
         tdUI.closeDetail();
         await tdUI.reload();
@@ -743,10 +775,14 @@ async function fetchConfig() {
       if (!reason) reason = prompt('Rejection reason:');
       if (!reason) return;
       try {
-        await fetch('/api/td/reject', {
+        var isGlobal = !!currentDetailProject;
+        var endpoint = isGlobal ? '/api/td/global/reject' : '/api/td/reject';
+        var payload = { id: id, reason: reason };
+        if (isGlobal) payload.projectPath = currentDetailProject;
+        await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: id, reason: reason })
+          body: JSON.stringify(payload)
         });
         tdUI.closeDetail();
         await tdUI.reload();
@@ -758,10 +794,14 @@ async function fetchConfig() {
     },
     confirmDelete: async function(id) {
       try {
-        await fetch('/api/td', {
+        var isGlobal = !!currentDetailProject;
+        var endpoint = isGlobal ? '/api/td/global' : '/api/td';
+        var payload = { id: id };
+        if (isGlobal) payload.projectPath = currentDetailProject;
+        await fetch(endpoint, {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: id })
+          body: JSON.stringify(payload)
         });
         tdUI.closeDetail();
         await tdUI.reload();
@@ -784,15 +824,27 @@ async function fetchConfig() {
       var message = msgEl ? msgEl.value.trim() : '';
       if (!message) return;
       try {
-        var resp = await fetch('/api/td/log', {
+        var isGlobal = !!currentDetailProject;
+        var endpoint = isGlobal ? '/api/td/global/log' : '/api/td/log';
+        var payload = { id: id, message: message, type: typeEl ? typeEl.value : 'progress' };
+        if (isGlobal) payload.projectPath = currentDetailProject;
+        var resp = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: id, message: message, type: typeEl ? typeEl.value : 'progress' })
+          body: JSON.stringify(payload)
         });
         if (resp.ok) {
           // Re-fetch and re-render detail
-          var detail = await fetchIssueDetail(id);
-          if (detail) renderDetail(detail, false);
+          if (isGlobal) {
+            var resp2 = await fetch('/api/td/global/detail?id=' + encodeURIComponent(id) + '&projectPath=' + encodeURIComponent(currentDetailProject));
+            if (resp2.ok) {
+              var detail = await resp2.json();
+              renderDetail(detail, false);
+            }
+          } else {
+            var detail = await fetchIssueDetail(id);
+            if (detail) renderDetail(detail, false);
+          }
         }
       } catch(e) {}
     }


### PR DESCRIPTION
The global/cross-project view was read-only. Now clicking a task in the
All Projects view fetches full detail from the target project's td CLI
and shows the same action buttons as the local view (start, review,
approve, reject, delete, add log).

Backend:
- runTd() accepts optional cwd param to run td in any project directory
- validateProjectPath() ensures projectPath is within the configured
  crossProjectRoot (prevents path traversal)
- New endpoints: GET /global/detail, PATCH /global, POST/DELETE /global,
  POST /global/{review,approve,reject,log}

Frontend:
- showDetail() fetches full issue detail via /api/td/global/detail
- All action functions (updateStatus, reviewIssue, approveIssue,
  rejectIssue, confirmDelete, submitLog) route through /api/td/global/*
  when currentDetailProject is set
- Falls back to read-only mode if detail fetch fails

Closes td-f92b57
