### PR TITLE
feat(pi-channels): voice & audio transcription (epic td-35fa26)

### DIFF
--- a/extensions/pi-channels/.gitignore
+++ b/extensions/pi-channels/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .todo/
 .todos/
 .todos/
+src/adapters/transcribe-apple

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -9,6 +9,8 @@
  *   - Photos (downloaded → temp file → passed as image attachment)
  *   - Documents (text files downloaded → content included in message)
  *   - Voice messages (downloaded → transcribed → passed as text)
+ *   - Audio files (music/recordings → transcribed → passed as text)
+ *   - Audio documents (files with audio MIME → routed through transcription)
  *   - File size validation (1MB for docs/photos, 10MB for voice/audio)
  *   - MIME type filtering (text-like files only for documents)
  *
@@ -73,6 +75,20 @@ const TEXT_EXTENSIONS = new Set([
 function isImageMime(mime: string | undefined): boolean {
 	if (!mime) return false;
 	return mime.startsWith("image/");
+}
+
+/** Audio MIME types that can be transcribed. */
+const AUDIO_MIME_PREFIXES = ["audio/"];
+const AUDIO_MIME_TYPES = new Set([
+	"audio/mpeg", "audio/mp4", "audio/ogg", "audio/wav", "audio/webm",
+	"audio/x-m4a", "audio/flac", "audio/aac", "audio/mp3",
+	"video/ogg", // .ogg containers can be audio-only
+]);
+
+function isAudioMime(mime: string | undefined): boolean {
+	if (!mime) return false;
+	if (AUDIO_MIME_TYPES.has(mime)) return true;
+	return AUDIO_MIME_PREFIXES.some(p => mime.startsWith(p));
 }
 
 function isTextDocument(mimeType: string | undefined, filename: string | undefined): boolean {
@@ -369,11 +385,60 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 				};
 			}
 
+			// Audio documents — route through transcription
+			if (isAudioMime(mimeType)) {
+				if (!transcriber) {
+					return {
+						adapter: "telegram",
+						sender: chatId,
+						text: `⚠️ Audio files are not supported. Please type your message.`,
+						metadata: { ...metadata, rejected: true, hasAudio: true },
+					};
+				}
+
+				if (doc.file_size && doc.file_size > MAX_AUDIO_SIZE) {
+					return {
+						adapter: "telegram",
+						sender: chatId,
+						text: `⚠️ Audio file too large: ${filename || "audio"} (${formatSize(doc.file_size)}, max 10MB).`,
+						metadata: { ...metadata, rejected: true, hasAudio: true },
+					};
+				}
+
+				const downloaded = await downloadFile(doc.file_id, filename, MAX_AUDIO_SIZE);
+				if (!downloaded) {
+					return {
+						adapter: "telegram",
+						sender: chatId,
+						text: caption || `🎵 ${filename || "audio"} (failed to download)`,
+						metadata: { ...metadata, hasAudio: true },
+					};
+				}
+
+				const result = await transcriber.transcribe(downloaded.localPath);
+				if (!result.ok || !result.text) {
+					return {
+						adapter: "telegram",
+						sender: chatId,
+						text: `🎵 ${filename || "audio"} (transcription failed${result.error ? ": " + result.error : ""})`,
+						metadata: { ...metadata, hasAudio: true },
+					};
+				}
+
+				const label = filename ? `Audio: ${filename}` : "Audio file";
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: `🎵 [${label}]: ${result.text}`,
+					metadata: { ...metadata, hasAudio: true, audioTitle: filename },
+				};
+			}
+
 			// Unsupported file type
 			return {
 				adapter: "telegram",
 				sender: chatId,
-				text: `⚠️ Unsupported file type: ${filename || "document"} (${mimeType || "unknown"}). I can handle text files and images.`,
+				text: `⚠️ Unsupported file type: ${filename || "document"} (${mimeType || "unknown"}). I can handle text files, images, and audio.`,
 				metadata: { ...metadata, rejected: true },
 			};
 		}
@@ -426,6 +491,60 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 				sender: chatId,
 				text: `🎤 [Voice message]: ${result.text}`,
 				metadata: { ...metadata, hasVoice: true, voiceDuration: voice.duration },
+			};
+		}
+
+		// ── Audio file (sent as music) ─────────────────────
+		if (msg.audio) {
+			const audio = msg.audio;
+
+			if (!transcriber) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: "⚠️ Audio files are not supported. Please type your message.",
+					metadata: { ...metadata, rejected: true, hasAudio: true },
+				};
+			}
+
+			if (audio.file_size && audio.file_size > MAX_AUDIO_SIZE) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: `⚠️ Audio too large (${formatSize(audio.file_size)}, max 10MB).`,
+					metadata: { ...metadata, rejected: true, hasAudio: true },
+				};
+			}
+
+			const audioName = audio.title || audio.performer || "audio";
+			const downloaded = await downloadFile(audio.file_id, `${audioName}.mp3`, MAX_AUDIO_SIZE);
+			if (!downloaded) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: caption || `🎵 ${audioName} (failed to download)`,
+					metadata: { ...metadata, hasAudio: true },
+				};
+			}
+
+			const result = await transcriber.transcribe(downloaded.localPath);
+			if (!result.ok || !result.text) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: `🎵 ${audioName} (transcription failed${result.error ? ": " + result.error : ""})`,
+					metadata: { ...metadata, hasAudio: true, audioTitle: audio.title, audioDuration: audio.duration },
+				};
+			}
+
+			const label = audio.title
+				? `Audio: ${audio.title}${audio.performer ? ` by ${audio.performer}` : ""}`
+				: "Audio";
+			return {
+				adapter: "telegram",
+				sender: chatId,
+				text: `🎵 [${label}]: ${result.text}`,
+				metadata: { ...metadata, hasAudio: true, audioTitle: audio.title, audioDuration: audio.duration },
 			};
 		}
 
@@ -521,6 +640,15 @@ interface TelegramMessage {
 		file_id: string;
 		file_unique_id: string;
 		duration: number;
+		mime_type?: string;
+		file_size?: number;
+	};
+	audio?: {
+		file_id: string;
+		file_unique_id: string;
+		duration: number;
+		performer?: string;
+		title?: string;
 		mime_type?: string;
 		file_size?: number;
 	};

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -8,7 +8,8 @@
  *   - Text messages
  *   - Photos (downloaded → temp file → passed as image attachment)
  *   - Documents (text files downloaded → content included in message)
- *   - File size validation (max 1MB)
+ *   - Voice messages (downloaded → transcribed → passed as text)
+ *   - File size validation (1MB for docs/photos, 10MB for voice/audio)
  *   - MIME type filtering (text-like files only for documents)
  *
  * Config (in settings.json under pi-channels.adapters.telegram):
@@ -32,10 +33,13 @@ import type {
 	OnIncomingMessage,
 	IncomingMessage,
 	IncomingAttachment,
+	TranscriptionConfig,
 } from "../types.ts";
+import { createTranscriptionProvider, type TranscriptionProvider } from "./transcription.ts";
 
 const MAX_LENGTH = 4096;
 const MAX_FILE_SIZE = 1_048_576; // 1MB
+const MAX_AUDIO_SIZE = 10_485_760; // 10MB — voice/audio files are larger
 
 /** MIME types we treat as text documents (content inlined into the prompt). */
 const TEXT_MIME_TYPES = new Set([
@@ -91,6 +95,17 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 		throw new Error("Telegram adapter requires botToken");
 	}
 
+	// ── Transcription setup ─────────────────────────────────
+	const transcriptionConfig = config.transcription as TranscriptionConfig | undefined;
+	let transcriber: TranscriptionProvider | null = null;
+	if (transcriptionConfig?.enabled) {
+		try {
+			transcriber = createTranscriptionProvider(transcriptionConfig);
+		} catch {
+			// Config error — transcription will be unavailable
+		}
+	}
+
 	const apiBase = `https://api.telegram.org/bot${botToken}`;
 	let offset = 0;
 	let running = false;
@@ -133,7 +148,7 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 	 * Download a file from Telegram by file_id.
 	 * Returns { path, size } or null on failure.
 	 */
-	async function downloadFile(fileId: string, suggestedName?: string): Promise<{ localPath: string; size: number } | null> {
+	async function downloadFile(fileId: string, suggestedName?: string, maxSize = MAX_FILE_SIZE): Promise<{ localPath: string; size: number } | null> {
 		try {
 			// Get file info
 			const infoRes = await fetch(`${apiBase}/getFile?file_id=${fileId}`);
@@ -148,7 +163,7 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 			const fileSize = info.result.file_size ?? 0;
 
 			// Size check before downloading
-			if (fileSize > MAX_FILE_SIZE) return null;
+			if (fileSize > maxSize) return null;
 
 			// Download
 			const fileUrl = `https://api.telegram.org/file/bot${botToken}/${info.result.file_path}`;
@@ -158,7 +173,7 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 			const buffer = Buffer.from(await fileRes.arrayBuffer());
 
 			// Double-check size after download
-			if (buffer.length > MAX_FILE_SIZE) return null;
+			if (buffer.length > maxSize) return null;
 
 			// Write to temp file
 			const ext = path.extname(info.result.file_path) || path.extname(suggestedName || "") || "";
@@ -363,6 +378,57 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 			};
 		}
 
+		// ── Voice message ──────────────────────────────────
+		if (msg.voice) {
+			const voice = msg.voice;
+
+			if (!transcriber) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: "⚠️ Voice messages are not supported. Please type your message.",
+					metadata: { ...metadata, rejected: true, hasVoice: true },
+				};
+			}
+
+			// Size check
+			if (voice.file_size && voice.file_size > MAX_AUDIO_SIZE) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: `⚠️ Voice message too large (${formatSize(voice.file_size)}, max 10MB).`,
+					metadata: { ...metadata, rejected: true, hasVoice: true },
+				};
+			}
+
+			const downloaded = await downloadFile(voice.file_id, "voice.ogg", MAX_AUDIO_SIZE);
+			if (!downloaded) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: "🎤 (voice message — failed to download)",
+					metadata: { ...metadata, hasVoice: true },
+				};
+			}
+
+			const result = await transcriber.transcribe(downloaded.localPath);
+			if (!result.ok || !result.text) {
+				return {
+					adapter: "telegram",
+					sender: chatId,
+					text: `🎤 (voice message — transcription failed${result.error ? ": " + result.error : ""})`,
+					metadata: { ...metadata, hasVoice: true, voiceDuration: voice.duration },
+				};
+			}
+
+			return {
+				adapter: "telegram",
+				sender: chatId,
+				text: `🎤 [Voice message]: ${result.text}`,
+				metadata: { ...metadata, hasVoice: true, voiceDuration: voice.duration },
+			};
+		}
+
 		// ── Text ───────────────────────────────────────────
 		if (msg.text) {
 			return {
@@ -373,7 +439,7 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 			};
 		}
 
-		// Unsupported message type (sticker, voice, etc.) — ignore
+		// Unsupported message type (sticker, video, etc.) — ignore
 		return null;
 	}
 
@@ -448,6 +514,13 @@ interface TelegramMessage {
 		file_id: string;
 		file_unique_id: string;
 		file_name?: string;
+		mime_type?: string;
+		file_size?: number;
+	};
+	voice?: {
+		file_id: string;
+		file_unique_id: string;
+		duration: number;
 		mime_type?: string;
 		file_size?: number;
 	};

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -114,11 +114,13 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 	// ── Transcription setup ─────────────────────────────────
 	const transcriptionConfig = config.transcription as TranscriptionConfig | undefined;
 	let transcriber: TranscriptionProvider | null = null;
+	let transcriberError: string | null = null;
 	if (transcriptionConfig?.enabled) {
 		try {
 			transcriber = createTranscriptionProvider(transcriptionConfig);
-		} catch {
-			// Config error — transcription will be unavailable
+		} catch (err: any) {
+			transcriberError = err.message ?? "Unknown transcription config error";
+			console.error(`[pi-channels] Transcription config error: ${transcriberError}`);
 		}
 	}
 
@@ -391,7 +393,9 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 					return {
 						adapter: "telegram",
 						sender: chatId,
-						text: `⚠️ Audio files are not supported. Please type your message.`,
+						text: transcriberError
+							? `⚠️ Audio transcription misconfigured: ${transcriberError}`
+							: `⚠️ Audio files are not supported. Please type your message.`,
 						metadata: { ...metadata, rejected: true, hasAudio: true },
 					};
 				}
@@ -451,7 +455,9 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 				return {
 					adapter: "telegram",
 					sender: chatId,
-					text: "⚠️ Voice messages are not supported. Please type your message.",
+					text: transcriberError
+						? `⚠️ Voice transcription misconfigured: ${transcriberError}`
+						: "⚠️ Voice messages are not supported. Please type your message.",
 					metadata: { ...metadata, rejected: true, hasVoice: true },
 				};
 			}
@@ -502,7 +508,9 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 				return {
 					adapter: "telegram",
 					sender: chatId,
-					text: "⚠️ Audio files are not supported. Please type your message.",
+					text: transcriberError
+						? `⚠️ Audio transcription misconfigured: ${transcriberError}`
+						: "⚠️ Audio files are not supported. Please type your message.",
 					metadata: { ...metadata, rejected: true, hasAudio: true },
 				};
 			}

--- a/extensions/pi-channels/src/adapters/transcribe-apple.swift
+++ b/extensions/pi-channels/src/adapters/transcribe-apple.swift
@@ -1,0 +1,101 @@
+/// transcribe-apple — macOS speech-to-text via SFSpeechRecognizer.
+///
+/// Usage: transcribe-apple <audio-file> [language-code]
+/// Prints transcribed text to stdout. Exits 1 on error (message to stderr).
+
+import Foundation
+import Speech
+
+guard CommandLine.arguments.count >= 2 else {
+    FileHandle.standardError.write("Usage: transcribe-apple <audio-file> [language-code]\n".data(using: .utf8)!)
+    exit(1)
+}
+
+let filePath = CommandLine.arguments[1]
+let languageCode = CommandLine.arguments.count >= 3 ? CommandLine.arguments[2] : "en-US"
+
+// Normalize short language codes (e.g. "en" → "en-US", "no" → "nb-NO")
+func normalizeLocale(_ code: String) -> Locale {
+    let mapping: [String: String] = [
+        "en": "en-US", "no": "nb-NO", "nb": "nb-NO", "nn": "nn-NO",
+        "sv": "sv-SE", "da": "da-DK", "de": "de-DE", "fr": "fr-FR",
+        "es": "es-ES", "it": "it-IT", "pt": "pt-BR", "ja": "ja-JP",
+        "ko": "ko-KR", "zh": "zh-CN", "ru": "ru-RU", "ar": "ar-SA",
+        "hi": "hi-IN", "pl": "pl-PL", "nl": "nl-NL", "fi": "fi-FI",
+    ]
+    let resolved = mapping[code] ?? code
+    return Locale(identifier: resolved)
+}
+
+let locale = normalizeLocale(languageCode)
+let fileURL = URL(fileURLWithPath: filePath)
+
+guard FileManager.default.fileExists(atPath: filePath) else {
+    FileHandle.standardError.write("File not found: \(filePath)\n".data(using: .utf8)!)
+    exit(1)
+}
+
+guard let recognizer = SFSpeechRecognizer(locale: locale) else {
+    FileHandle.standardError.write("Speech recognizer not available for locale: \(locale.identifier)\n".data(using: .utf8)!)
+    exit(1)
+}
+
+guard recognizer.isAvailable else {
+    FileHandle.standardError.write("Speech recognizer not available (offline model may need download)\n".data(using: .utf8)!)
+    exit(1)
+}
+
+// Request authorization (needed even for on-device recognition)
+let semaphore = DispatchSemaphore(value: 0)
+var authStatus: SFSpeechRecognizerAuthorizationStatus = .notDetermined
+
+SFSpeechRecognizer.requestAuthorization { status in
+    authStatus = status
+    semaphore.signal()
+}
+semaphore.wait()
+
+guard authStatus == .authorized else {
+    FileHandle.standardError.write("Speech recognition not authorized (status: \(authStatus.rawValue)). Grant access in System Settings > Privacy > Speech Recognition.\n".data(using: .utf8)!)
+    exit(1)
+}
+
+// Perform recognition
+let request = SFSpeechURLRecognitionRequest(url: fileURL)
+request.requiresOnDeviceRecognition = true
+request.shouldReportPartialResults = false
+
+let resultSemaphore = DispatchSemaphore(value: 0)
+var transcribedText: String?
+var recognitionError: Error?
+
+recognizer.recognitionTask(with: request) { result, error in
+    if let error = error {
+        recognitionError = error
+        resultSemaphore.signal()
+        return
+    }
+    if let result = result, result.isFinal {
+        transcribedText = result.bestTranscription.formattedString
+        resultSemaphore.signal()
+    }
+}
+
+// Wait up to 60 seconds
+let timeout = resultSemaphore.wait(timeout: .now() + 60)
+if timeout == .timedOut {
+    FileHandle.standardError.write("Transcription timed out after 60 seconds\n".data(using: .utf8)!)
+    exit(1)
+}
+
+if let error = recognitionError {
+    FileHandle.standardError.write("Recognition error: \(error.localizedDescription)\n".data(using: .utf8)!)
+    exit(1)
+}
+
+guard let text = transcribedText, !text.isEmpty else {
+    FileHandle.standardError.write("No speech detected in audio\n".data(using: .utf8)!)
+    exit(1)
+}
+
+print(text)

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -1,0 +1,250 @@
+/**
+ * pi-channels — Pluggable audio transcription.
+ *
+ * Supports three providers:
+ *   - "apple"      — macOS SFSpeechRecognizer (free, offline, no API key)
+ *   - "openai"     — Whisper API
+ *   - "elevenlabs" — Scribe API
+ *
+ * Usage:
+ *   const provider = createTranscriptionProvider(config);
+ *   const result = await provider.transcribe("/path/to/audio.ogg", "en");
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFile } from "node:child_process";
+import type { TranscriptionConfig } from "../types.ts";
+
+// ── Public interface ────────────────────────────────────────────
+
+export interface TranscriptionResult {
+	ok: boolean;
+	text?: string;
+	error?: string;
+}
+
+export interface TranscriptionProvider {
+	transcribe(filePath: string, language?: string): Promise<TranscriptionResult>;
+}
+
+/** Create a transcription provider from config. */
+export function createTranscriptionProvider(config: TranscriptionConfig): TranscriptionProvider {
+	switch (config.provider) {
+		case "apple":
+			return new AppleProvider(config);
+		case "openai":
+			return new OpenAIProvider(config);
+		case "elevenlabs":
+			return new ElevenLabsProvider(config);
+		default:
+			throw new Error(`Unknown transcription provider: ${config.provider}`);
+	}
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/** Resolve "env:VAR_NAME" patterns to actual environment variable values. */
+function resolveEnvValue(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	if (value.startsWith("env:")) {
+		const envVar = value.slice(4);
+		return process.env[envVar] || undefined;
+	}
+	return value;
+}
+
+function validateFile(filePath: string): TranscriptionResult | null {
+	if (!fs.existsSync(filePath)) {
+		return { ok: false, error: `File not found: ${filePath}` };
+	}
+	const stat = fs.statSync(filePath);
+	// 25MB limit (Whisper max; Telegram max is 20MB)
+	if (stat.size > 25 * 1024 * 1024) {
+		return { ok: false, error: `File too large: ${(stat.size / 1024 / 1024).toFixed(1)}MB (max 25MB)` };
+	}
+	if (stat.size === 0) {
+		return { ok: false, error: "File is empty" };
+	}
+	return null;
+}
+
+// ── Apple Provider ──────────────────────────────────────────────
+
+const SWIFT_HELPER_SRC = path.join(__dirname, "transcribe-apple.swift");
+const SWIFT_HELPER_BIN = path.join(__dirname, "transcribe-apple");
+
+class AppleProvider implements TranscriptionProvider {
+	private language: string | undefined;
+	private compiled = false;
+
+	constructor(config: TranscriptionConfig) {
+		this.language = config.language;
+	}
+
+	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {
+		if (process.platform !== "darwin") {
+			return { ok: false, error: "Apple transcription is only available on macOS" };
+		}
+
+		const fileErr = validateFile(filePath);
+		if (fileErr) return fileErr;
+
+		// Compile Swift helper on first use
+		if (!this.compiled) {
+			const compileResult = await this.compileHelper();
+			if (!compileResult.ok) return compileResult;
+			this.compiled = true;
+		}
+
+		const lang = language || this.language;
+		const args = [filePath];
+		if (lang) args.push(lang);
+
+		return new Promise((resolve) => {
+			execFile(SWIFT_HELPER_BIN, args, { timeout: 60_000 }, (err, stdout, stderr) => {
+				if (err) {
+					resolve({ ok: false, error: stderr?.trim() || err.message });
+					return;
+				}
+				const text = stdout.trim();
+				if (!text) {
+					resolve({ ok: false, error: "Transcription returned empty result" });
+					return;
+				}
+				resolve({ ok: true, text });
+			});
+		});
+	}
+
+	private compileHelper(): Promise<TranscriptionResult> {
+		// Skip if already compiled and binary exists
+		if (fs.existsSync(SWIFT_HELPER_BIN)) {
+			return Promise.resolve({ ok: true });
+		}
+
+		if (!fs.existsSync(SWIFT_HELPER_SRC)) {
+			return Promise.resolve({
+				ok: false,
+				error: `Swift helper source not found: ${SWIFT_HELPER_SRC}`,
+			});
+		}
+
+		return new Promise((resolve) => {
+			execFile(
+				"swiftc",
+				["-O", "-o", SWIFT_HELPER_BIN, SWIFT_HELPER_SRC],
+				{ timeout: 30_000 },
+				(err, _stdout, stderr) => {
+					if (err) {
+						resolve({ ok: false, error: `Failed to compile Swift helper: ${stderr?.trim() || err.message}` });
+						return;
+					}
+					resolve({ ok: true });
+				},
+			);
+		});
+	}
+}
+
+// ── OpenAI Provider ─────────────────────────────────────────────
+
+class OpenAIProvider implements TranscriptionProvider {
+	private apiKey: string;
+	private model: string;
+	private language: string | undefined;
+
+	constructor(config: TranscriptionConfig) {
+		const key = resolveEnvValue(config.apiKey);
+		if (!key) throw new Error("OpenAI transcription requires apiKey");
+		this.apiKey = key;
+		this.model = config.model || "whisper-1";
+		this.language = config.language;
+	}
+
+	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {
+		const fileErr = validateFile(filePath);
+		if (fileErr) return fileErr;
+
+		const lang = language || this.language;
+
+		try {
+			const form = new FormData();
+			const fileBuffer = fs.readFileSync(filePath);
+			const filename = path.basename(filePath);
+			form.append("file", new Blob([fileBuffer]), filename);
+			form.append("model", this.model);
+			if (lang) form.append("language", lang);
+
+			const response = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+				method: "POST",
+				headers: { Authorization: `Bearer ${this.apiKey}` },
+				body: form,
+			});
+
+			if (!response.ok) {
+				const body = await response.text();
+				return { ok: false, error: `OpenAI API error (${response.status}): ${body.slice(0, 200)}` };
+			}
+
+			const data = await response.json() as { text?: string };
+			if (!data.text) {
+				return { ok: false, error: "OpenAI returned empty transcription" };
+			}
+			return { ok: true, text: data.text };
+		} catch (err: any) {
+			return { ok: false, error: `OpenAI transcription failed: ${err.message}` };
+		}
+	}
+}
+
+// ── ElevenLabs Provider ─────────────────────────────────────────
+
+class ElevenLabsProvider implements TranscriptionProvider {
+	private apiKey: string;
+	private model: string;
+	private language: string | undefined;
+
+	constructor(config: TranscriptionConfig) {
+		const key = resolveEnvValue(config.apiKey);
+		if (!key) throw new Error("ElevenLabs transcription requires apiKey");
+		this.apiKey = key;
+		this.model = config.model || "scribe_v1";
+		this.language = config.language;
+	}
+
+	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {
+		const fileErr = validateFile(filePath);
+		if (fileErr) return fileErr;
+
+		const lang = language || this.language;
+
+		try {
+			const form = new FormData();
+			const fileBuffer = fs.readFileSync(filePath);
+			const filename = path.basename(filePath);
+			form.append("file", new Blob([fileBuffer]), filename);
+			form.append("model_id", this.model);
+			if (lang) form.append("language_code", lang);
+
+			const response = await fetch("https://api.elevenlabs.io/v1/speech-to-text", {
+				method: "POST",
+				headers: { "xi-api-key": this.apiKey },
+				body: form,
+			});
+
+			if (!response.ok) {
+				const body = await response.text();
+				return { ok: false, error: `ElevenLabs API error (${response.status}): ${body.slice(0, 200)}` };
+			}
+
+			const data = await response.json() as { text?: string };
+			if (!data.text) {
+				return { ok: false, error: "ElevenLabs returned empty transcription" };
+			}
+			return { ok: true, text: data.text };
+		} catch (err: any) {
+			return { ok: false, error: `ElevenLabs transcription failed: ${err.message}` };
+		}
+	}
+}

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -71,8 +71,8 @@ function validateFile(filePath: string): TranscriptionResult | null {
 
 // ── Apple Provider ──────────────────────────────────────────────
 
-const SWIFT_HELPER_SRC = path.join(__dirname, "transcribe-apple.swift");
-const SWIFT_HELPER_BIN = path.join(__dirname, "transcribe-apple");
+const SWIFT_HELPER_SRC = path.join(import.meta.dirname, "transcribe-apple.swift");
+const SWIFT_HELPER_BIN = path.join(import.meta.dirname, "transcribe-apple");
 
 class AppleProvider implements TranscriptionProvider {
 	private language: string | undefined;

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -76,7 +76,7 @@ const SWIFT_HELPER_BIN = path.join(__dirname, "transcribe-apple");
 
 class AppleProvider implements TranscriptionProvider {
 	private language: string | undefined;
-	private compiled = false;
+	private compilePromise: Promise<TranscriptionResult> | null = null;
 
 	constructor(config: TranscriptionConfig) {
 		this.language = config.language;
@@ -90,12 +90,12 @@ class AppleProvider implements TranscriptionProvider {
 		const fileErr = validateFile(filePath);
 		if (fileErr) return fileErr;
 
-		// Compile Swift helper on first use
-		if (!this.compiled) {
-			const compileResult = await this.compileHelper();
-			if (!compileResult.ok) return compileResult;
-			this.compiled = true;
+		// Compile Swift helper on first use (promise-based lock prevents races)
+		if (!this.compilePromise) {
+			this.compilePromise = this.compileHelper();
 		}
+		const compileResult = await this.compilePromise;
+		if (!compileResult.ok) return compileResult;
 
 		const lang = language || this.language;
 		const args = [filePath];

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -21,7 +21,7 @@ export interface ChannelMessage {
 
 export interface IncomingAttachment {
 	/** Attachment type */
-	type: "image" | "document";
+	type: "image" | "document" | "audio";
 	/** Local file path (temporary, downloaded by the adapter) */
 	path: string;
 	/** Original filename (if available) */
@@ -30,6 +30,26 @@ export interface IncomingAttachment {
 	mimeType?: string;
 	/** File size in bytes */
 	size?: number;
+}
+
+// ── Transcription config ────────────────────────────────────────
+
+export interface TranscriptionConfig {
+	/** Enable voice/audio transcription (default: false) */
+	enabled: boolean;
+	/**
+	 * Transcription provider:
+	 * - "apple"      — macOS SFSpeechRecognizer (free, offline, no API key)
+	 * - "openai"     — Whisper API
+	 * - "elevenlabs" — Scribe API
+	 */
+	provider: "apple" | "openai" | "elevenlabs";
+	/** API key for cloud providers (supports env:VAR_NAME). Not needed for apple. */
+	apiKey?: string;
+	/** Model name (e.g. "whisper-1", "scribe_v1"). Provider-specific default used if omitted. */
+	model?: string;
+	/** ISO 639-1 language hint (e.g. "en", "no"). Optional. */
+	language?: string;
 }
 
 export interface IncomingMessage {

--- a/extensions/pi-channels/tsconfig.json
+++ b/extensions/pi-channels/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Voice & Audio Transcription for pi-channels

Modular transcription system for the Telegram adapter with three pluggable providers.

### Changes

**Types** (td-b212fd)
- Added `'audio'` to `IncomingAttachment.type`
- Added `TranscriptionConfig` interface (`provider`, `apiKey`, `model`, `language`)

**Transcription module** (td-c2d758) — `src/adapters/transcription.ts`
- `TranscriptionProvider` interface with `createTranscriptionProvider()` factory
- **Apple**: macOS SFSpeechRecognizer via Swift CLI helper (free, offline, on-device)
- **OpenAI**: Whisper API
- **ElevenLabs**: Scribe API
- `env:VAR_NAME` resolution for API keys, file validation, error handling

**Swift helper** — `src/adapters/transcribe-apple.swift`
- ~100-line CLI using `SFSpeechRecognizer` with on-device recognition
- Locale normalization (`en` → `en-US`, `no` → `nb-NO`, etc.)
- Auto-compiled on first use with promise-based lock (no race conditions)

**Voice messages** (td-12cb8e)
- Downloads voice files (up to 10MB), transcribes, returns `🎤 [Voice message]: <text>`
- Graceful fallback: config errors surfaced, transcription failures reported

**Audio files** (td-80831f)
- Native `msg.audio` (music/recordings) with title/performer metadata
- Audio documents (files with audio MIME sent via paperclip)
- Same download → transcribe → prefix pattern as voice

### Config
```json
{
  "transcription": {
    "enabled": true,
    "provider": "apple",
    "language": "en"
  }
}
```

Consolidates PRs #18, #19, #20, #21 (all closed).