### PR TITLE
fix(pi-subagent): register tool synchronously so it's visible to the model

### DIFF
--- a/extensions/pi-subagent/src/index.ts
+++ b/extensions/pi-subagent/src/index.ts
@@ -46,7 +46,7 @@ export default function (pi: ExtensionAPI) {
 	// Register tool synchronously — tools registered in session_start are not visible to the model.
 	// Settings are resolved lazily per-invocation using ctx.cwd so project-level settings
 	// (.pi/settings.json) are read from the correct directory, not process.cwd() at load time.
-	registerSubagentTool(pi, (cwd) => resolveSettings(cwd), log);
+	registerSubagentTool(pi, resolveSettings, log);
 
 	// Inject available agents into system prompt (user-scope only to prevent prompt injection from untrusted repos)
 	pi.on("before_agent_start", async (event: any, ctx: any) => {

--- a/extensions/pi-subagent/src/index.ts
+++ b/extensions/pi-subagent/src/index.ts
@@ -43,10 +43,9 @@ export type {
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
 
-	pi.on("session_start", async (_event, ctx) => {
-		const settings = resolveSettings(ctx.cwd);
-		registerSubagentTool(pi, settings, log);
-	});
+	// Register tool synchronously — tools registered in session_start are not visible to the model
+	const settings = resolveSettings(process.cwd());
+	registerSubagentTool(pi, settings, log);
 
 	// Inject available agents into system prompt (user-scope only to prevent prompt injection from untrusted repos)
 	pi.on("before_agent_start", async (event: any, ctx: any) => {

--- a/extensions/pi-subagent/src/index.ts
+++ b/extensions/pi-subagent/src/index.ts
@@ -43,9 +43,10 @@ export type {
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
 
-	// Register tool synchronously — tools registered in session_start are not visible to the model
-	const settings = resolveSettings(process.cwd());
-	registerSubagentTool(pi, settings, log);
+	// Register tool synchronously — tools registered in session_start are not visible to the model.
+	// Settings are resolved lazily per-invocation using ctx.cwd so project-level settings
+	// (.pi/settings.json) are read from the correct directory, not process.cwd() at load time.
+	registerSubagentTool(pi, (cwd) => resolveSettings(cwd), log);
 
 	// Inject available agents into system prompt (user-scope only to prevent prompt injection from untrusted repos)
 	pi.on("before_agent_start", async (event: any, ctx: any) => {

--- a/extensions/pi-subagent/src/tool.ts
+++ b/extensions/pi-subagent/src/tool.ts
@@ -406,7 +406,7 @@ const COLLAPSED_ITEM_COUNT = 10;
 
 export function registerSubagentTool(
 	pi: ExtensionAPI,
-	settings: SubagentSettings,
+	getSettings: (cwd: string) => SubagentSettings,
 	log: Logger = () => {},
 ): void {
 	pi.registerTool({
@@ -436,6 +436,7 @@ export function registerSubagentTool(
 		parameters: SubagentParams,
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const settings = getSettings(ctx.cwd);
 			const scope: AgentScope = params.agentScope ?? "user";
 			const discovery = discoverAgents(ctx.cwd, scope);
 			const agents = discovery.agents;


### PR DESCRIPTION
Tools registered inside session_start event handlers are not visible to the
LLM — they must be registered synchronously in the default export function.

Moved resolveSettings() + registerSubagentTool() from session_start to the
top level of the default export. resolveSettings() is already synchronous
(uses fs.readFileSync) so this is safe.
