### PR TITLE
feat(pi-channels): Slack adapter with Socket Mode

### DIFF
--- a/extensions/pi-channels/package-lock.json
+++ b/extensions/pi-channels/package-lock.json
@@ -8,6 +8,10 @@
       "name": "pi-channels",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@slack/socket-mode": "^2.0.5",
+        "@slack/web-api": "^7.14.1"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.0.0"
@@ -1526,6 +1530,80 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.5.tgz",
+      "integrity": "sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4",
+        "@slack/web-api": "^7.10.0",
+        "@types/node": ">=18",
+        "@types/ws": "^8",
+        "eventemitter3": "^5",
+        "ws": "^8"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.0.tgz",
+      "integrity": "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.14.1.tgz",
+      "integrity": "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.20.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.13.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.4",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
@@ -2269,6 +2347,21 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2360,6 +2453,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2431,6 +2541,19 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -2516,6 +2639,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2574,6 +2709,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
@@ -2582,6 +2726,20 @@
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2607,6 +2765,51 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2673,6 +2876,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2767,6 +2976,26 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2797,6 +3026,43 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2808,6 +3074,15 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -2862,6 +3137,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-uri": {
@@ -2936,6 +3248,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2965,6 +3289,45 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/highlight.js": {
@@ -3059,6 +3422,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3067,6 +3436,18 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3174,6 +3555,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mime-db": {
@@ -3328,6 +3718,71 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -3500,8 +3955,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3989,7 +4443,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/extensions/pi-channels/package.json
+++ b/extensions/pi-channels/package.json
@@ -2,19 +2,27 @@
   "name": "pi-channels",
   "version": "0.1.0",
   "description": "Two-way channel extension for pi — route messages between agents and Telegram, webhooks, and custom adapters",
-  "keywords": ["pi-package"],
+  "keywords": [
+    "pi-package"
+  ],
   "license": "MIT",
   "author": "Espen Nilsen",
   "pi": {
-    "extensions": ["./src/index.ts"]
+    "extensions": [
+      "./src/index.ts"
+    ]
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-coding-agent": "*",
     "@sinclair/typebox": "*"
+  },
+  "dependencies": {
+    "@slack/socket-mode": "^2.0.5",
+    "@slack/web-api": "^7.14.1"
   }
 }

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -1,0 +1,296 @@
+/**
+ * pi-channels — Built-in Slack adapter (bidirectional).
+ *
+ * Outgoing: Slack Web API chat.postMessage.
+ * Incoming: Socket Mode (WebSocket) for events + slash commands.
+ *
+ * Supports:
+ *   - Text messages (channels, groups, DMs, multi-party DMs)
+ *   - @mentions (app_mention events)
+ *   - Slash commands (/aivena by default)
+ *   - Typing indicators (chat action)
+ *   - Thread replies (when replying in threads)
+ *   - Message splitting for long messages (>3000 chars)
+ *   - Channel allowlisting (optional)
+ *
+ * Requires:
+ *   - App-level token (xapp-...) for Socket Mode connection
+ *   - Bot token (xoxb-...) for Web API calls
+ *   - Socket Mode enabled in app settings
+ *
+ * Config (in settings.json under pi-channels.adapters.slack):
+ * {
+ *   "type": "slack",
+ *   "appToken": "env:SLACK_APP_TOKEN",
+ *   "botToken": "env:SLACK_BOT_TOKEN",
+ *   "allowedChannelIds": ["C0123456789"],
+ *   "respondToMentionsOnly": true,
+ *   "slashCommand": "/aivena"
+ * }
+ */
+
+import { SocketModeClient } from "@slack/socket-mode";
+import { WebClient } from "@slack/web-api";
+import type {
+	ChannelAdapter,
+	ChannelMessage,
+	AdapterConfig,
+	OnIncomingMessage,
+} from "../types.ts";
+
+const MAX_LENGTH = 3000; // Slack block text limit; actual API limit is 4000 but leave margin
+
+// ── Config resolution ───────────────────────────────────────────
+
+function resolveSecret(value: unknown): string {
+	if (typeof value !== "string") return "";
+	if (value.startsWith("env:")) {
+		const envVar = value.slice(4);
+		return process.env[envVar] ?? "";
+	}
+	return value;
+}
+
+// ── Slack event types (subset) ──────────────────────────────────
+
+interface SlackMessageEvent {
+	type: string;
+	subtype?: string;
+	channel: string;
+	user?: string;
+	text?: string;
+	ts: string;
+	thread_ts?: string;
+	channel_type?: string;
+	bot_id?: string;
+}
+
+interface SlackMentionEvent {
+	type: string;
+	channel: string;
+	user: string;
+	text: string;
+	ts: string;
+	thread_ts?: string;
+}
+
+interface SlackCommandPayload {
+	command: string;
+	text: string;
+	user_id: string;
+	user_name: string;
+	channel_id: string;
+	channel_name: string;
+	trigger_id: string;
+}
+
+// ── Factory ─────────────────────────────────────────────────────
+
+export function createSlackAdapter(config: AdapterConfig): ChannelAdapter {
+	const appToken = resolveSecret(config.appToken);
+	const botToken = resolveSecret(config.botToken);
+	const allowedChannelIds = config.allowedChannelIds as string[] | undefined;
+	const respondToMentionsOnly = config.respondToMentionsOnly === true;
+	const slashCommand = (config.slashCommand as string) ?? "/aivena";
+
+	if (!appToken) throw new Error("Slack adapter requires appToken (xapp-...)");
+	if (!botToken) throw new Error("Slack adapter requires botToken (xoxb-...)");
+
+	let socketClient: SocketModeClient | null = null;
+	const webClient = new WebClient(botToken);
+	let botUserId: string | null = null;
+
+	// ── Helpers ─────────────────────────────────────────────
+
+	function isAllowed(channelId: string): boolean {
+		if (!allowedChannelIds || allowedChannelIds.length === 0) return true;
+		return allowedChannelIds.includes(channelId);
+	}
+
+	/** Strip the bot's own @mention from message text */
+	function stripBotMention(text: string): string {
+		if (!botUserId) return text;
+		// Slack formats mentions as <@U12345>
+		return text.replace(new RegExp(`<@${botUserId}>\\s*`, "g"), "").trim();
+	}
+
+	/** Build metadata common to all incoming messages */
+	function buildMetadata(event: { channel?: string; user?: string; ts?: string; thread_ts?: string; channel_type?: string }, extra?: Record<string, unknown>): Record<string, unknown> {
+		return {
+			channelId: event.channel,
+			userId: event.user,
+			timestamp: event.ts,
+			threadTs: event.thread_ts,
+			channelType: event.channel_type,
+			...extra,
+		};
+	}
+
+	// ── Sending ─────────────────────────────────────────────
+
+	async function sendSlack(channelId: string, text: string, threadTs?: string): Promise<void> {
+		await webClient.chat.postMessage({
+			channel: channelId,
+			text,
+			thread_ts: threadTs,
+			// Unfurl links/media is off by default to keep responses clean
+			unfurl_links: false,
+			unfurl_media: false,
+		});
+	}
+
+	// ── Adapter ─────────────────────────────────────────────
+
+	return {
+		direction: "bidirectional" as const,
+
+		async sendTyping(recipient: string): Promise<void> {
+			// Slack doesn't have a direct "typing" API for bots in channels.
+			// We can use a reaction or simply no-op. For DMs, there's no API either.
+			// Best we can do is nothing — Slack bots don't show typing indicators.
+		},
+
+		async send(message: ChannelMessage): Promise<void> {
+			const prefix = message.source ? `*[${message.source}]*\n` : "";
+			const full = prefix + message.text;
+			const threadTs = message.metadata?.threadTs as string | undefined;
+
+			if (full.length <= MAX_LENGTH) {
+				await sendSlack(message.recipient, full, threadTs);
+				return;
+			}
+
+			// Split long messages at newlines
+			let remaining = full;
+			while (remaining.length > 0) {
+				if (remaining.length <= MAX_LENGTH) {
+					await sendSlack(message.recipient, remaining, threadTs);
+					break;
+				}
+				let splitAt = remaining.lastIndexOf("\n", MAX_LENGTH);
+				if (splitAt < MAX_LENGTH / 2) splitAt = MAX_LENGTH;
+				await sendSlack(message.recipient, remaining.slice(0, splitAt), threadTs);
+				remaining = remaining.slice(splitAt).replace(/^\n/, "");
+			}
+		},
+
+		async start(onMessage: OnIncomingMessage): Promise<void> {
+			if (socketClient) return;
+
+			// Resolve bot user ID (for stripping self-mentions)
+			try {
+				const authResult = await webClient.auth.test();
+				botUserId = authResult.user_id as string ?? null;
+			} catch {
+				// Non-fatal — mention stripping just won't work
+			}
+
+			socketClient = new SocketModeClient({
+				appToken,
+				// Suppress noisy internal logging
+				logLevel: "ERROR" as any,
+			});
+
+			// ── Message events ──────────────────────────────
+			// Socket Mode wraps events in envelopes. The client emits
+			// typed events: 'message', 'app_mention', 'slash_commands', etc.
+			// Each handler receives { event, body, ack, ... }
+
+			socketClient.on("message", async ({ event, ack }: { event: SlackMessageEvent; ack: () => Promise<void> }) => {
+				await ack();
+
+				// Ignore bot messages (including our own)
+				if (event.bot_id || event.subtype === "bot_message") return;
+				// Ignore message_changed, message_deleted, etc.
+				if (event.subtype) return;
+				if (!event.text) return;
+				if (!isAllowed(event.channel)) return;
+
+				// In channels, optionally only respond to @mentions
+				// (app_mention events are handled separately below)
+				if (respondToMentionsOnly && event.channel_type === "channel") return;
+
+				// Use channel:threadTs as sender key for threaded conversations
+				const sender = event.thread_ts
+					? `${event.channel}:${event.thread_ts}`
+					: event.channel;
+
+				onMessage({
+					adapter: "slack",
+					sender,
+					text: stripBotMention(event.text),
+					metadata: buildMetadata(event, {
+						eventType: "message",
+					}),
+				});
+			});
+
+			// ── App mention events ──────────────────────────
+			socketClient.on("app_mention", async ({ event, ack }: { event: SlackMentionEvent; ack: () => Promise<void> }) => {
+				await ack();
+
+				if (!isAllowed(event.channel)) return;
+
+				const sender = event.thread_ts
+					? `${event.channel}:${event.thread_ts}`
+					: event.channel;
+
+				onMessage({
+					adapter: "slack",
+					sender,
+					text: stripBotMention(event.text),
+					metadata: buildMetadata(event, {
+						eventType: "app_mention",
+					}),
+				});
+			});
+
+			// ── Slash commands ───────────────────────────────
+			socketClient.on("slash_commands", async ({ body, ack }: { body: SlackCommandPayload; ack: (response?: any) => Promise<void> }) => {
+				if (body.command !== slashCommand) {
+					await ack();
+					return;
+				}
+
+				if (!body.text?.trim()) {
+					await ack({ text: `Usage: ${slashCommand} [your message]` });
+					return;
+				}
+
+				// Acknowledge immediately (Slack requires <3s response)
+				await ack({ text: "🤔 Thinking..." });
+
+				if (!isAllowed(body.channel_id)) return;
+
+				onMessage({
+					adapter: "slack",
+					sender: body.channel_id,
+					text: body.text.trim(),
+					metadata: {
+						channelId: body.channel_id,
+						channelName: body.channel_name,
+						userId: body.user_id,
+						userName: body.user_name,
+						eventType: "slash_command",
+						command: body.command,
+					},
+				});
+			});
+
+			// ── Interactive payloads (future: button clicks, modals) ──
+			socketClient.on("interactive", async ({ body, ack }: { body: any; ack: () => Promise<void> }) => {
+				await ack();
+				// TODO: handle interactive payloads (block actions, modals)
+			});
+
+			await socketClient.start();
+		},
+
+		async stop(): Promise<void> {
+			if (socketClient) {
+				await socketClient.disconnect();
+				socketClient = null;
+			}
+		},
+	};
+}

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -84,7 +84,9 @@ interface SlackCommandPayload {
 
 // ── Factory ─────────────────────────────────────────────────────
 
-export function createSlackAdapter(config: AdapterConfig, cwd?: string): ChannelAdapter {
+export type SlackAdapterLogger = (event: string, data: Record<string, unknown>, level?: string) => void;
+
+export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: SlackAdapterLogger): ChannelAdapter {
 	// Tokens live in settings under pi-channels.slack (not in the adapter config block)
 	const appToken = (cwd ? getChannelSetting(cwd, "slack.appToken") as string : null)
 		?? config.appToken as string;
@@ -232,7 +234,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 							eventType: "message",
 						}),
 					});
-				} catch (err) { console.error("[pi-channels:slack] message handler error:", err); }
+				} catch (err) { log?.("slack-handler-error", { handler: "message", error: String(err) }, "error"); }
 			});
 
 			// ── App mention events ──────────────────────────
@@ -254,7 +256,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 							eventType: "app_mention",
 						}),
 					});
-				} catch (err) { console.error("[pi-channels:slack] app_mention handler error:", err); }
+				} catch (err) { log?.("slack-handler-error", { handler: "app_mention", error: String(err) }, "error"); }
 			});
 
 			// ── Slash commands ───────────────────────────────
@@ -291,7 +293,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 							command: body.command,
 						},
 					});
-				} catch (err) { console.error("[pi-channels:slack] slash_commands handler error:", err); }
+				} catch (err) { log?.("slack-handler-error", { handler: "slash_commands", error: String(err) }, "error"); }
 			});
 
 			// ── Interactive payloads (future: button clicks, modals) ──
@@ -299,7 +301,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 				try {
 					await ack();
 					// TODO: handle interactive payloads (block actions, modals)
-				} catch (err) { console.error("[pi-channels:slack] interactive handler error:", err); }
+				} catch (err) { log?.("slack-handler-error", { handler: "interactive", error: String(err) }, "error"); }
 			});
 
 			await socketClient.start();

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -234,7 +234,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: Sl
 							eventType: "message",
 						}),
 					});
-				} catch (err) { log?.("slack-handler-error", { handler: "message", error: String(err) }, "error"); }
+				} catch (err) { log?.("slack-handler-error", { handler: "message", error: String(err) }, "ERROR"); }
 			});
 
 			// ── App mention events ──────────────────────────
@@ -256,7 +256,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: Sl
 							eventType: "app_mention",
 						}),
 					});
-				} catch (err) { log?.("slack-handler-error", { handler: "app_mention", error: String(err) }, "error"); }
+				} catch (err) { log?.("slack-handler-error", { handler: "app_mention", error: String(err) }, "ERROR"); }
 			});
 
 			// ── Slash commands ───────────────────────────────
@@ -293,7 +293,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: Sl
 							command: body.command,
 						},
 					});
-				} catch (err) { log?.("slack-handler-error", { handler: "slash_commands", error: String(err) }, "error"); }
+				} catch (err) { log?.("slack-handler-error", { handler: "slash_commands", error: String(err) }, "ERROR"); }
 			});
 
 			// ── Interactive payloads (future: button clicks, modals) ──
@@ -301,7 +301,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: Sl
 				try {
 					await ack();
 					// TODO: handle interactive payloads (block actions, modals)
-				} catch (err) { log?.("slack-handler-error", { handler: "interactive", error: String(err) }, "error"); }
+				} catch (err) { log?.("slack-handler-error", { handler: "interactive", error: String(err) }, "ERROR"); }
 			});
 
 			await socketClient.start();

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -14,18 +14,26 @@
  *   - Channel allowlisting (optional)
  *
  * Requires:
- *   - App-level token (xapp-...) for Socket Mode connection
- *   - Bot token (xoxb-...) for Web API calls
+ *   - App-level token (xapp-...) for Socket Mode — in settings under pi-channels.slack.appToken
+ *   - Bot token (xoxb-...) for Web API — in settings under pi-channels.slack.botToken
  *   - Socket Mode enabled in app settings
  *
- * Config (in settings.json under pi-channels.adapters.slack):
+ * Config in ~/.pi/agent/settings.json:
  * {
- *   "type": "slack",
- *   "appToken": "env:SLACK_APP_TOKEN",
- *   "botToken": "env:SLACK_BOT_TOKEN",
- *   "allowedChannelIds": ["C0123456789"],
- *   "respondToMentionsOnly": true,
- *   "slashCommand": "/aivena"
+ *   "pi-channels": {
+ *     "adapters": {
+ *       "slack": {
+ *         "type": "slack",
+ *         "allowedChannelIds": ["C0123456789"],
+ *         "respondToMentionsOnly": true,
+ *         "slashCommand": "/aivena"
+ *       }
+ *     },
+ *     "slack": {
+ *       "appToken": "xapp-1-...",
+ *       "botToken": "xoxb-..."
+ *     }
+ *   }
  * }
  */
 
@@ -37,19 +45,9 @@ import type {
 	AdapterConfig,
 	OnIncomingMessage,
 } from "../types.ts";
+import { getChannelSetting } from "../config.ts";
 
 const MAX_LENGTH = 3000; // Slack block text limit; actual API limit is 4000 but leave margin
-
-// ── Config resolution ───────────────────────────────────────────
-
-function resolveSecret(value: unknown): string {
-	if (typeof value !== "string") return "";
-	if (value.startsWith("env:")) {
-		const envVar = value.slice(4);
-		return process.env[envVar] ?? "";
-	}
-	return value;
-}
 
 // ── Slack event types (subset) ──────────────────────────────────
 
@@ -86,15 +84,19 @@ interface SlackCommandPayload {
 
 // ── Factory ─────────────────────────────────────────────────────
 
-export function createSlackAdapter(config: AdapterConfig): ChannelAdapter {
-	const appToken = resolveSecret(config.appToken);
-	const botToken = resolveSecret(config.botToken);
+export function createSlackAdapter(config: AdapterConfig, cwd?: string): ChannelAdapter {
+	// Tokens live in settings under pi-channels.slack (not in the adapter config block)
+	const appToken = (cwd ? getChannelSetting(cwd, "slack.appToken") as string : null)
+		?? config.appToken as string;
+	const botToken = (cwd ? getChannelSetting(cwd, "slack.botToken") as string : null)
+		?? config.botToken as string;
+
 	const allowedChannelIds = config.allowedChannelIds as string[] | undefined;
 	const respondToMentionsOnly = config.respondToMentionsOnly === true;
 	const slashCommand = (config.slashCommand as string) ?? "/aivena";
 
-	if (!appToken) throw new Error("Slack adapter requires appToken (xapp-...)");
-	if (!botToken) throw new Error("Slack adapter requires botToken (xoxb-...)");
+	if (!appToken) throw new Error("Slack adapter requires appToken (xapp-...) in settings under pi-channels.slack.appToken");
+	if (!botToken) throw new Error("Slack adapter requires botToken (xoxb-...) in settings under pi-channels.slack.botToken");
 
 	let socketClient: SocketModeClient | null = null;
 	const webClient = new WebClient(botToken);

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -200,83 +200,94 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 
 			socketClient.on("message", async ({ event, ack }: { event: SlackMessageEvent; ack: () => Promise<void> }) => {
 				await ack();
+				try {
+					// Ignore bot messages (including our own)
+					if (event.bot_id || event.subtype === "bot_message") return;
+					// Ignore message_changed, message_deleted, etc.
+					if (event.subtype) return;
+					if (!event.text) return;
+					if (!isAllowed(event.channel)) return;
 
-				// Ignore bot messages (including our own)
-				if (event.bot_id || event.subtype === "bot_message") return;
-				// Ignore message_changed, message_deleted, etc.
-				if (event.subtype) return;
-				if (!event.text) return;
-				if (!isAllowed(event.channel)) return;
+					// Skip messages that @mention the bot — these are handled
+					// by the app_mention listener to avoid duplicate responses
+					if (botUserId && event.text.includes(`<@${botUserId}>`)) return;
 
-				// In channels, optionally only respond to @mentions
-				// (app_mention events are handled separately below)
-				if (respondToMentionsOnly && event.channel_type === "channel") return;
+					// In channels/groups, optionally only respond to @mentions
+					// (app_mention events are handled separately below)
+					if (respondToMentionsOnly && (event.channel_type === "channel" || event.channel_type === "group")) return;
 
-				// Use channel:threadTs as sender key for threaded conversations
-				const sender = event.thread_ts
-					? `${event.channel}:${event.thread_ts}`
-					: event.channel;
+					// Use channel:threadTs as sender key for threaded conversations
+					const sender = event.thread_ts
+						? `${event.channel}:${event.thread_ts}`
+						: event.channel;
 
-				onMessage({
-					adapter: "slack",
-					sender,
-					text: stripBotMention(event.text),
-					metadata: buildMetadata(event, {
-						eventType: "message",
-					}),
-				});
+					onMessage({
+						adapter: "slack",
+						sender,
+						text: stripBotMention(event.text),
+						metadata: buildMetadata(event, {
+							eventType: "message",
+						}),
+					});
+				} catch { /* prevent unhandled rejection from destabilizing Socket Mode */ }
 			});
 
 			// ── App mention events ──────────────────────────
 			socketClient.on("app_mention", async ({ event, ack }: { event: SlackMentionEvent; ack: () => Promise<void> }) => {
 				await ack();
+				try {
+					if (!isAllowed(event.channel)) return;
 
-				if (!isAllowed(event.channel)) return;
+					const sender = event.thread_ts
+						? `${event.channel}:${event.thread_ts}`
+						: event.channel;
 
-				const sender = event.thread_ts
-					? `${event.channel}:${event.thread_ts}`
-					: event.channel;
-
-				onMessage({
-					adapter: "slack",
-					sender,
-					text: stripBotMention(event.text),
-					metadata: buildMetadata(event, {
-						eventType: "app_mention",
-					}),
-				});
+					onMessage({
+						adapter: "slack",
+						sender,
+						text: stripBotMention(event.text),
+						metadata: buildMetadata(event, {
+							eventType: "app_mention",
+						}),
+					});
+				} catch { /* prevent unhandled rejection from destabilizing Socket Mode */ }
 			});
 
 			// ── Slash commands ───────────────────────────────
 			socketClient.on("slash_commands", async ({ body, ack }: { body: SlackCommandPayload; ack: (response?: any) => Promise<void> }) => {
-				if (body.command !== slashCommand) {
-					await ack();
-					return;
-				}
+				try {
+					if (body.command !== slashCommand) {
+						await ack();
+						return;
+					}
 
-				if (!body.text?.trim()) {
-					await ack({ text: `Usage: ${slashCommand} [your message]` });
-					return;
-				}
+					if (!body.text?.trim()) {
+						await ack({ text: `Usage: ${slashCommand} [your message]` });
+						return;
+					}
 
-				// Acknowledge immediately (Slack requires <3s response)
-				await ack({ text: "🤔 Thinking..." });
+					if (!isAllowed(body.channel_id)) {
+						await ack({ text: "⛔ This command is not available in this channel." });
+						return;
+					}
 
-				if (!isAllowed(body.channel_id)) return;
+					// Acknowledge immediately (Slack requires <3s response)
+					await ack({ text: "🤔 Thinking..." });
 
-				onMessage({
-					adapter: "slack",
-					sender: body.channel_id,
-					text: body.text.trim(),
-					metadata: {
-						channelId: body.channel_id,
-						channelName: body.channel_name,
-						userId: body.user_id,
-						userName: body.user_name,
-						eventType: "slash_command",
-						command: body.command,
-					},
-				});
+					onMessage({
+						adapter: "slack",
+						sender: body.channel_id,
+						text: body.text.trim(),
+						metadata: {
+							channelId: body.channel_id,
+							channelName: body.channel_name,
+							userId: body.user_id,
+							userName: body.user_name,
+							eventType: "slash_command",
+							command: body.command,
+						},
+					});
+				} catch { /* prevent unhandled rejection from destabilizing Socket Mode */ }
 			});
 
 			// ── Interactive payloads (future: button clicks, modals) ──

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -199,8 +199,9 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 			// Each handler receives { event, body, ack, ... }
 
 			socketClient.on("message", async ({ event, ack }: { event: SlackMessageEvent; ack: () => Promise<void> }) => {
-				await ack();
 				try {
+					await ack();
+
 					// Ignore bot messages (including our own)
 					if (event.bot_id || event.subtype === "bot_message") return;
 					// Ignore message_changed, message_deleted, etc.
@@ -208,9 +209,11 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 					if (!event.text) return;
 					if (!isAllowed(event.channel)) return;
 
-					// Skip messages that @mention the bot — these are handled
-					// by the app_mention listener to avoid duplicate responses
-					if (botUserId && event.text.includes(`<@${botUserId}>`)) return;
+					// Skip messages that @mention the bot in channels/groups — these are
+					// handled by the app_mention listener to avoid duplicate responses.
+					// DMs (im) and multi-party DMs (mpim) don't fire app_mention, so we
+					// must NOT skip those here.
+					if (botUserId && (event.channel_type === "channel" || event.channel_type === "group") && event.text.includes(`<@${botUserId}>`)) return;
 
 					// In channels/groups, optionally only respond to @mentions
 					// (app_mention events are handled separately below)
@@ -229,13 +232,14 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 							eventType: "message",
 						}),
 					});
-				} catch { /* prevent unhandled rejection from destabilizing Socket Mode */ }
+				} catch (err) { console.error("[pi-channels:slack] message handler error:", err); }
 			});
 
 			// ── App mention events ──────────────────────────
 			socketClient.on("app_mention", async ({ event, ack }: { event: SlackMentionEvent; ack: () => Promise<void> }) => {
-				await ack();
 				try {
+					await ack();
+
 					if (!isAllowed(event.channel)) return;
 
 					const sender = event.thread_ts
@@ -250,7 +254,7 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 							eventType: "app_mention",
 						}),
 					});
-				} catch { /* prevent unhandled rejection from destabilizing Socket Mode */ }
+				} catch (err) { console.error("[pi-channels:slack] app_mention handler error:", err); }
 			});
 
 			// ── Slash commands ───────────────────────────────
@@ -287,13 +291,15 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string): Channel
 							command: body.command,
 						},
 					});
-				} catch { /* prevent unhandled rejection from destabilizing Socket Mode */ }
+				} catch (err) { console.error("[pi-channels:slack] slash_commands handler error:", err); }
 			});
 
 			// ── Interactive payloads (future: button clicks, modals) ──
 			socketClient.on("interactive", async ({ body, ack }: { body: any; ack: () => Promise<void> }) => {
-				await ack();
-				// TODO: handle interactive payloads (block actions, modals)
+				try {
+					await ack();
+					// TODO: handle interactive payloads (block actions, modals)
+				} catch (err) { console.error("[pi-channels:slack] interactive handler error:", err); }
 			});
 
 			await socketClient.start();

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -76,15 +76,17 @@ export function getChannelSetting(cwd: string, keyPath: string): unknown {
 	const globalCh = global?.[SETTINGS_KEY] ?? {};
 	const projectCh = project?.[SETTINGS_KEY] ?? {};
 
-	// Project overrides global
-	const merged = { ...globalCh, ...projectCh };
-
-	// Walk dotted path
-	const parts = keyPath.split(".");
-	let current: any = merged;
-	for (const part of parts) {
-		if (current == null || typeof current !== "object") return undefined;
-		current = current[part];
+	// Walk the dotted path independently in each scope to avoid
+	// shallow-merge dropping sibling keys from nested objects.
+	function walk(obj: any): unknown {
+		let current: any = obj;
+		for (const part of keyPath.split(".")) {
+			if (current == null || typeof current !== "object") return undefined;
+			current = current[part];
+		}
+		return current;
 	}
-	return current;
+
+	// Project overrides global at the leaf level
+	return walk(projectCh) ?? walk(globalCh);
 }

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -1,9 +1,9 @@
 /**
- * pi-channels — Config from pi settings files.
+ * pi-channels — Config from pi SettingsManager.
  *
- * Reads the "pi-channels" key from:
- *   1. ~/.pi/agent/settings.json (global)
- *   2. .pi/settings.json (project, overrides global)
+ * Reads the "pi-channels" key from settings via SettingsManager,
+ * which merges global (~/.pi/agent/settings.json) and project
+ * (.pi/settings.json) configs automatically.
  *
  * Example settings.json:
  * {
@@ -12,53 +12,79 @@
  *       "telegram": {
  *         "type": "telegram",
  *         "botToken": "your-telegram-bot-token"
+ *       },
+ *       "slack": {
+ *         "type": "slack"
  *       }
  *     },
+ *     "slack": {
+ *       "appToken": "xapp-...",
+ *       "botToken": "xoxb-..."
+ *     },
  *     "routes": {
- *       "ops": { "adapter": "telegram", "recipient": "-100987654321" },
- *       "cron": { "adapter": "telegram", "recipient": "123456789" }
+ *       "ops": { "adapter": "telegram", "recipient": "-100987654321" }
  *     }
  *   }
  * }
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
+import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
 import type { ChannelConfig } from "./types.ts";
 
 const SETTINGS_KEY = "pi-channels";
 
-function readJsonSafe(filePath: string): Record<string, unknown> {
-	try {
-		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
-	} catch {
-		return {};
-	}
-}
-
 export function loadConfig(cwd: string): ChannelConfig {
-	const globalPath = path.join(os.homedir(), ".pi", "agent", "settings.json");
-	const projectPath = path.join(cwd, ".pi", "settings.json");
+	const agentDir = getAgentDir();
+	const sm = SettingsManager.create(cwd, agentDir);
+	const global = sm.getGlobalSettings() as Record<string, any>;
+	const project = sm.getProjectSettings() as Record<string, any>;
 
-	const global = readJsonSafe(globalPath)[SETTINGS_KEY] as Record<string, unknown> | undefined;
-	const project = readJsonSafe(projectPath)[SETTINGS_KEY] as Record<string, unknown> | undefined;
+	const globalCh = global?.[SETTINGS_KEY] ?? {};
+	const projectCh = project?.[SETTINGS_KEY] ?? {};
 
 	// Project overrides global (shallow merge of adapters + routes + bridge)
 	const merged: ChannelConfig = {
 		adapters: {
-			...(global?.adapters as Record<string, unknown> ?? {}),
-			...(project?.adapters as Record<string, unknown> ?? {}),
+			...(globalCh.adapters ?? {}),
+			...(projectCh.adapters ?? {}),
 		} as ChannelConfig["adapters"],
 		routes: {
-			...(global?.routes as Record<string, { adapter: string; recipient: string }> ?? {}),
-			...(project?.routes as Record<string, { adapter: string; recipient: string }> ?? {}),
+			...(globalCh.routes ?? {}),
+			...(projectCh.routes ?? {}),
 		},
 		bridge: {
-			...(global?.bridge as Record<string, unknown> ?? {}),
-			...(project?.bridge as Record<string, unknown> ?? {}),
+			...(globalCh.bridge ?? {}),
+			...(projectCh.bridge ?? {}),
 		} as ChannelConfig["bridge"],
 	};
 
 	return merged;
+}
+
+/**
+ * Read a setting from the "pi-channels" config by dotted key path.
+ * Useful for adapter-specific secrets that shouldn't live in the adapter config block.
+ *
+ * Example: getChannelSetting(cwd, "slack.appToken") reads pi-channels.slack.appToken
+ */
+export function getChannelSetting(cwd: string, keyPath: string): unknown {
+	const agentDir = getAgentDir();
+	const sm = SettingsManager.create(cwd, agentDir);
+	const global = sm.getGlobalSettings() as Record<string, any>;
+	const project = sm.getProjectSettings() as Record<string, any>;
+
+	const globalCh = global?.[SETTINGS_KEY] ?? {};
+	const projectCh = project?.[SETTINGS_KEY] ?? {};
+
+	// Project overrides global
+	const merged = { ...globalCh, ...projectCh };
+
+	// Walk dotted path
+	const parts = keyPath.split(".");
+	let current: any = merged;
+	for (const part of parts) {
+		if (current == null || typeof current !== "object") return undefined;
+		current = current[part];
+	}
+	return current;
 }

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -87,6 +87,8 @@ export function getChannelSetting(cwd: string, keyPath: string): unknown {
 		return current;
 	}
 
-	// Project overrides global at the leaf level
-	return walk(projectCh) ?? walk(globalCh);
+	// Project overrides global at the leaf level.
+	// Use explicit undefined check so null can be used to unset a global default.
+	const projectValue = walk(projectCh);
+	return projectValue !== undefined ? projectValue : walk(globalCh);
 }

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -63,7 +63,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		const config = loadConfig(ctx.cwd);
-		registry.loadConfig(config);
+		registry.loadConfig(config, ctx.cwd);
 
 		const errors = registry.getErrors();
 		for (const err of errors) {

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -45,6 +45,7 @@ import { createLogger } from "./logger.ts";
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
 	const registry = new ChannelRegistry();
+	registry.setLogger(log);
 	let bridge: ChatBridge | null = null;
 
 	// ── Flag: --chat-bridge ───────────────────────────────────

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -5,6 +5,7 @@
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelConfig, AdapterDirection, OnIncomingMessage, IncomingMessage } from "./types.ts";
 import { createTelegramAdapter } from "./adapters/telegram.ts";
 import { createWebhookAdapter } from "./adapters/webhook.ts";
+import { createSlackAdapter } from "./adapters/slack.ts";
 
 // ── Built-in adapter factories ──────────────────────────────────
 
@@ -13,6 +14,7 @@ type AdapterFactory = (config: AdapterConfig) => ChannelAdapter;
 const builtinFactories: Record<string, AdapterFactory> = {
 	telegram: createTelegramAdapter,
 	webhook: createWebhookAdapter,
+	slack: createSlackAdapter,
 };
 
 // ── Registry ────────────────────────────────────────────────────

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -9,7 +9,7 @@ import { createSlackAdapter } from "./adapters/slack.ts";
 
 // ── Built-in adapter factories ──────────────────────────────────
 
-type AdapterFactory = (config: AdapterConfig) => ChannelAdapter;
+type AdapterFactory = (config: AdapterConfig, cwd?: string) => ChannelAdapter;
 
 const builtinFactories: Record<string, AdapterFactory> = {
 	telegram: createTelegramAdapter,
@@ -34,8 +34,9 @@ export class ChannelRegistry {
 
 	/**
 	 * Load adapters + routes from config. Custom adapters (registered via events) are preserved.
+	 * @param cwd — working directory, passed to adapter factories for settings resolution.
 	 */
-	loadConfig(config: ChannelConfig): void {
+	loadConfig(config: ChannelConfig, cwd?: string): void {
 		this.errors = [];
 
 		// Stop existing adapters
@@ -66,7 +67,7 @@ export class ChannelRegistry {
 				continue;
 			}
 			try {
-				this.adapters.set(name, factory(adapterConfig));
+				this.adapters.set(name, factory(adapterConfig, cwd));
 			} catch (err: any) {
 				this.errors.push({ adapter: name, error: err.message });
 			}

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -9,7 +9,9 @@ import { createSlackAdapter } from "./adapters/slack.ts";
 
 // ── Built-in adapter factories ──────────────────────────────────
 
-type AdapterFactory = (config: AdapterConfig, cwd?: string) => ChannelAdapter;
+export type AdapterLogger = (event: string, data: Record<string, unknown>, level?: string) => void;
+
+type AdapterFactory = (config: AdapterConfig, cwd?: string, log?: AdapterLogger) => ChannelAdapter;
 
 const builtinFactories: Record<string, AdapterFactory> = {
 	telegram: createTelegramAdapter,
@@ -24,12 +26,20 @@ export class ChannelRegistry {
 	private routes = new Map<string, { adapter: string; recipient: string }>();
 	private errors: Array<{ adapter: string; error: string }> = [];
 	private onIncoming: OnIncomingMessage = () => {};
+	private log?: AdapterLogger;
 
 	/**
 	 * Set the callback for incoming messages (called by the extension entry).
 	 */
 	setOnIncoming(cb: OnIncomingMessage): void {
 		this.onIncoming = cb;
+	}
+
+	/**
+	 * Set the logger for adapter error reporting.
+	 */
+	setLogger(log: AdapterLogger): void {
+		this.log = log;
 	}
 
 	/**
@@ -67,7 +77,7 @@ export class ChannelRegistry {
 				continue;
 			}
 			try {
-				this.adapters.set(name, factory(adapterConfig, cwd));
+				this.adapters.set(name, factory(adapterConfig, cwd, this.log));
 			} catch (err: any) {
 				this.errors.push({ adapter: name, error: err.message });
 			}


### PR DESCRIPTION
## Summary

Adds a bidirectional Slack adapter to pi-channels using Socket Mode (WebSocket) for receiving events and the Slack Web API for sending messages.

### Config

```json
{
  "pi-channels": {
    "adapters": {
      "slack": {
        "type": "slack",
        "appToken": "env:SLACK_APP_TOKEN",
        "botToken": "env:SLACK_BOT_TOKEN",
        "allowedChannelIds": ["C0123456789"],
        "respondToMentionsOnly": true,
        "slashCommand": "/aivena"
      }
    },
    "routes": {
      "ops": { "adapter": "slack", "recipient": "C0123456789" }
    }
  }
}
```

### Features
- **Socket Mode** — no public HTTP endpoint needed. Uses WebSocket via `@slack/socket-mode`
- **Message events** — channels, groups, DMs, multi-party DMs
- **@mentions** — `app_mention` events with bot mention stripping
- **Slash commands** — `/aivena` (configurable) with immediate acknowledgement
- **Channel allowlisting** — optional `allowedChannelIds` filter
- **Mentions-only mode** — `respondToMentionsOnly: true` ignores non-mention messages in channels (DMs always respond)
- **Thread-aware** — sender key includes thread_ts for bridge threading (`channel:threadTs`)
- **Long messages** — auto-splits at 3000 chars
- **Interactive payloads** — acknowledged (handler stub for future buttons/modals)

### Dependencies
- `@slack/socket-mode` ^2.0.5
- `@slack/web-api` ^7.14.1

### Slack App Requirements
App manifest with Socket Mode enabled (`socket_mode_enabled: true`), bot events subscribed (`app_mention`, `message.*`), and app-level token with `connections:write` scope.

Resolves td-419864