### PR TITLE
fix: paginate review threads in gh-pr-fix — fetch all pages, not just first 100

### DIFF
--- a/extensions/pi-brave-search/CHANGELOG.md
+++ b/extensions/pi-brave-search/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-calendar/CHANGELOG.md
+++ b/extensions/pi-calendar/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-context/CHANGELOG.md
+++ b/extensions/pi-context/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (44157c3)
 
 ### Added
 

--- a/extensions/pi-cron/CHANGELOG.md
+++ b/extensions/pi-cron/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.0] - 2026-02-17
+## [0.2.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-dotenv/CHANGELOG.md
+++ b/extensions/pi-dotenv/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-github/CHANGELOG.md
+++ b/extensions/pi-github/CHANGELOG.md
@@ -5,8 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 
-- Initial release.
+- Initial release
+- All commands accept repo refs (`owner/repo#N`, PR URLs, plain numbers) — no longer limited to cwd repo
+- `defaultOwner` setting in `settings.json` under `pi-github` — enables short refs like `repo#N`
+- Smart PR discovery: `/gh-pr-fix` without args scans all open PRs for unresolved review threads
+- Local clone resolution: auto-finds `~/Dev/<repo>` when targeting remote repos
+- `/gh-pr-fix` presents thread IDs and `gh api graphql` commands for the agent to resolve threads directly
+- `.npmignore` and npm publish metadata (`files`, `repository`)
+- `AGENTS.md` with architecture docs
+
+### Changed
+
+- `/gh-pr-fix` simplified to single-step flow — no more two-phase resolve workflow
+- `/gh-pr-fix` replies to each thread with fix summary before resolving
+- All commands (`/gh-status`, `/gh-issues`, `/gh-actions`, `/gh-pr-review`, `/gh-pr-merge`) now accept `owner/repo` refs
+- Removed stateful `activePrFix` session tracking — agent handles resolution via CLI commands

--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -81,9 +81,10 @@ query($owner: String!, $repo: String!, $prNumber: Int!, $cursor: String) {
 async function getUnresolvedThreads(owner: string, repo: string, prNumber: number, cwd: string): Promise<ReviewThread[]> {
 	const threads: ReviewThread[] = [];
 	let cursor: string | null = null;
+	const MAX_PAGES = 50;
 
-	// Paginate through all review threads (100 per page)
-	while (true) {
+	// Paginate through all review threads (100 per page, max 50 pages = 5000 threads)
+	for (let page = 0; page < MAX_PAGES; page++) {
 		const variables: Record<string, any> = { owner, repo, prNumber };
 		if (cursor) variables.cursor = cursor;
 

--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -44,14 +44,18 @@ interface PrInfo {
 // ── GraphQL Queries ─────────────────────────────────────────────
 
 const REVIEW_THREADS_QUERY = `
-query($owner: String!, $repo: String!, $prNumber: Int!) {
+query($owner: String!, $repo: String!, $prNumber: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $prNumber) {
       number
       title
       headRefName
       url
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           id
           isResolved
@@ -75,30 +79,42 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
 // ── Helpers ─────────────────────────────────────────────────────
 
 async function getUnresolvedThreads(owner: string, repo: string, prNumber: number, cwd: string): Promise<ReviewThread[]> {
-	const data = await ghGraphql<any>(REVIEW_THREADS_QUERY, { owner, repo, prNumber }, cwd);
-	if (!data?.data?.repository?.pullRequest?.reviewThreads?.nodes) return [];
-
 	const threads: ReviewThread[] = [];
-	for (const node of data.data.repository.pullRequest.reviewThreads.nodes) {
-		if (node.isResolved) continue;
+	let cursor: string | null = null;
 
-		const comments = (node.comments?.nodes ?? []).map((c: any) => ({
-			author: c.author?.login ?? "unknown",
-			body: c.body,
-			createdAt: c.createdAt,
-		}));
+	// Paginate through all review threads (100 per page)
+	while (true) {
+		const variables: Record<string, any> = { owner, repo, prNumber };
+		if (cursor) variables.cursor = cursor;
 
-		if (comments.length === 0) continue;
+		const data = await ghGraphql<any>(REVIEW_THREADS_QUERY, variables, cwd);
+		const reviewThreads = data?.data?.repository?.pullRequest?.reviewThreads;
+		if (!reviewThreads?.nodes) break;
 
-		threads.push({
-			id: node.id,
-			isResolved: false,
-			path: node.path ?? "",
-			line: node.line,
-			body: comments[0].body,
-			author: comments[0].author,
-			comments,
-		});
+		for (const node of reviewThreads.nodes) {
+			if (node.isResolved) continue;
+
+			const comments = (node.comments?.nodes ?? []).map((c: any) => ({
+				author: c.author?.login ?? "unknown",
+				body: c.body,
+				createdAt: c.createdAt,
+			}));
+
+			if (comments.length === 0) continue;
+
+			threads.push({
+				id: node.id,
+				isResolved: false,
+				path: node.path ?? "",
+				line: node.line,
+				body: comments[0].body,
+				author: comments[0].author,
+				comments,
+			});
+		}
+
+		if (!reviewThreads.pageInfo?.hasNextPage) break;
+		cursor = reviewThreads.pageInfo.endCursor;
 	}
 
 	return threads;

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-heartbeat/CHANGELOG.md
+++ b/extensions/pi-heartbeat/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-jobs/CHANGELOG.md
+++ b/extensions/pi-jobs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-kysely/CHANGELOG.md
+++ b/extensions/pi-kysely/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-logger/CHANGELOG.md
+++ b/extensions/pi-logger/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-memory/CHANGELOG.md
+++ b/extensions/pi-memory/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-myfinance/CHANGELOG.md
+++ b/extensions/pi-myfinance/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-npm/CHANGELOG.md
+++ b/extensions/pi-npm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-personal-crm/CHANGELOG.md
+++ b/extensions/pi-personal-crm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.0] - 2026-02-17
+## [0.2.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-projects/CHANGELOG.md
+++ b/extensions/pi-projects/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-subagent/CHANGELOG.md
+++ b/extensions/pi-subagent/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-supabase/CHANGELOG.md
+++ b/extensions/pi-supabase/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-td/CHANGELOG.md
+++ b/extensions/pi-td/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.0] - 2026-02-17
+## [0.2.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-telemetry/CHANGELOG.md
+++ b/extensions/pi-telemetry/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.0.0] - 2026-02-17
+## [1.0.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-vault/CHANGELOG.md
+++ b/extensions/pi-vault/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-web-dashboard/CHANGELOG.md
+++ b/extensions/pi-web-dashboard/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-webnav/CHANGELOG.md
+++ b/extensions/pi-webnav/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 

--- a/extensions/pi-workon/CHANGELOG.md
+++ b/extensions/pi-workon/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-02-17
+## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added
 


### PR DESCRIPTION
The GraphQL query used reviewThreads(first: 100) with no pagination.
PRs with >100 threads (e.g. battleground.no#1 with 117) silently
dropped threads beyond the first page, reporting 0 unresolved when
the unresolved ones were on page 2+.
