### PR TITLE
feat(pi-github): add /gh-pr-open command to open PR in browser

### DIFF
--- a/extensions/pi-github/AGENTS.md
+++ b/extensions/pi-github/AGENTS.md
@@ -43,6 +43,7 @@ None — this extension registers no LLM tools.
 - `/gh-status` / `/github-status` — Repo overview: PR/issue counts, review status, CI, current branch PR
 - `/gh-notifications` / `/github-notifications` — Unread GitHub notifications
 - `/gh-pr-create` / `/github-pr-create` — Push current branch and open a PR (`gh pr create --fill`)
+- `/gh-pr-open` / `/github-pr-open` — Open PR in browser (current branch or specified number/repo)
 - `/gh-pr-review` / `/github-pr-review` — Show review feedback for current branch's PR (or specified number)
 - `/gh-pr-fix` / `/github-pr-fix` — Fetch unresolved review threads and launch agentic fix+commit+push loop
 - `/gh-pr-merge` / `/github-pr-merge` — Merge PR, delete branches, pull base (`--merge|--rebase|--squash`)

--- a/extensions/pi-github/AGENTS.md
+++ b/extensions/pi-github/AGENTS.md
@@ -42,8 +42,7 @@ None — this extension registers no LLM tools.
 - `/gh-issues` / `/github-issues` — List open issues (filters: `mine`, `label:<name>`, `all`)
 - `/gh-status` / `/github-status` — Repo overview: PR/issue counts, review status, CI, current branch PR
 - `/gh-notifications` / `/github-notifications` — Unread GitHub notifications
-- `/gh-pr-create` / `/github-pr-create` — Push current branch and open a PR (`gh pr create --fill`)
-- `/gh-pr-open` / `/github-pr-open` — Open PR in browser (current branch or specified number/repo)
+- `/gh-pr-create` / `/github-pr-create` — Push branch, gather diff, have LLM draft title+description, confirm with user, then create PR
 - `/gh-pr-review` / `/github-pr-review` — Show review feedback for current branch's PR (or specified number)
 - `/gh-pr-fix` / `/github-pr-fix` — Fetch unresolved review threads and launch agentic fix+commit+push loop
 - `/gh-pr-merge` / `/github-pr-merge` — Merge PR, delete branches, pull base (`--merge|--rebase|--squash`)

--- a/extensions/pi-github/CHANGELOG.md
+++ b/extensions/pi-github/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `/gh-pr-create` now gathers commits and diff, has the LLM draft a PR title and description, asks the user for input, and only creates the PR after confirmation. Replaces the previous `--fill` shortcut.
 
+### Removed
+
+- `/gh-pr-open` / `/github-pr-open` — removed before first publish.
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-github/CHANGELOG.md
+++ b/extensions/pi-github/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.1] - 2026-02-17
+
+### Added
+
+- `/gh-pr-open` / `/github-pr-open` — open PR in browser (auto-detects from current branch or accepts PR number/repo ref)
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-github/CHANGELOG.md
+++ b/extensions/pi-github/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.1.1] - 2026-02-17
 
-### Added
+### Changed
 
-- `/gh-pr-open` / `/github-pr-open` — open PR in browser (auto-detects from current branch or accepts PR number/repo ref)
+- `/gh-pr-create` now gathers commits and diff, has the LLM draft a PR title and description, asks the user for input, and only creates the PR after confirmation. Replaces the previous `--fill` shortcut.
 
 ## [0.1.0] - 2026-02-17 (7839f93)
 

--- a/extensions/pi-github/src/commands.ts
+++ b/extensions/pi-github/src/commands.ts
@@ -309,6 +309,45 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 		},
 	});
 
+	// ── /gh-pr-open · /github-pr-open ─────────────────────────
+
+	registerDualCommand(pi, "gh-pr-open", "github-pr-open", {
+		description: "Open PR in browser: /gh-pr-open [pr-number | owner/repo#N | PR-URL]",
+		handler: async (args, ctx) => {
+			const { ref } = extractRepoRef(args);
+			const resolved = await resolveRepo(ref, sessionCwd);
+			if (!resolved) {
+				ctx.ui.notify("❌ Could not determine repo. Specify owner/repo or run from a git repo.", "error");
+				return;
+			}
+			const rFlag = repoFlag(resolved.owner, resolved.repo);
+
+			let prNum = ref.prNumber;
+
+			if (!prNum) {
+				const branch = await getCurrentBranch(sessionCwd);
+				if (!branch) {
+					ctx.ui.notify("❌ Not in a git repo. Specify a PR number or owner/repo#N.", "error");
+					return;
+				}
+				const branchPrs = await ghJson<any[]>(["pr", "list", ...rFlag, "--head", branch, "--json", "number,title"]);
+				if (!branchPrs || branchPrs.length === 0) {
+					ctx.ui.notify(`No PR found for branch \`${branch}\` on ${resolved.slug}.`, "info");
+					return;
+				}
+				prNum = branchPrs[0].number;
+			}
+
+			const result = await gh(["pr", "view", String(prNum), ...rFlag, "--web"], sessionCwd);
+			if (result.ok) {
+				ctx.ui.notify(`🔗 Opened PR #${prNum} on ${resolved.slug} in browser.`, "info");
+				log("pr-open", { repo: resolved.slug, prNum });
+			} else {
+				ctx.ui.notify(`❌ Failed to open PR #${prNum}: ${result.stderr || result.stdout}`, "error");
+			}
+		},
+	});
+
 	// ── /gh-pr-review · /github-pr-review ─────────────────────
 
 	registerDualCommand(pi, "gh-pr-review", "github-pr-review", {

--- a/extensions/pi-github/src/commands.ts
+++ b/extensions/pi-github/src/commands.ts
@@ -48,6 +48,7 @@ export function setSessionCwd(cwd: string): void {
 // ── Register all commands ───────────────────────────────────────
 
 export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
+	const sendUserMessage = pi.sendUserMessage.bind(pi);
 
 	// ── /gh-prs · /github-prs ─────────────────────────────────
 
@@ -241,11 +242,20 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 	// ── /gh-pr-create · /github-pr-create ─────────────────────
 
 	registerDualCommand(pi, "gh-pr-create", "github-pr-create", {
-		description: "Create a PR for the current branch: /gh-pr-create [title]",
+		description: "Create a PR for the current branch with an LLM-generated summary: /gh-pr-create [base-branch]",
 		handler: async (args, ctx) => {
 			const branch = await getCurrentBranch(sessionCwd);
 			if (!branch || branch === "main" || branch === "master") {
 				ctx.ui.notify("❌ Cannot create PR from main/master branch.", "error");
+				return;
+			}
+
+			const base = args.trim() || "main";
+
+			// Check if a PR already exists for this branch
+			const existing = await ghJson<any[]>(["pr", "list", "--head", branch, "--json", "number,url"]);
+			if (existing && existing.length > 0) {
+				ctx.ui.notify(`❌ PR already exists for branch \`${branch}\`: ${existing[0].url}`, "error");
 				return;
 			}
 
@@ -260,18 +270,71 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 				return;
 			}
 
-			const ghArgs = ["pr", "create", "--fill"];
-			if (args) {
-				ghArgs.push("--title", args);
+			// Gather context: commits and diff summary
+			const commitsResult = await new Promise<{ ok: boolean; stdout: string }>((resolve) => {
+				execFile("git", ["log", `${base}..${branch}`, "--pretty=format:%h %s", "--reverse"], { cwd: sessionCwd, timeout: 10_000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+					resolve({ ok: !err, stdout: stdout?.trim() ?? "" });
+				});
+			});
+
+			const diffStatResult = await new Promise<{ ok: boolean; stdout: string }>((resolve) => {
+				execFile("git", ["diff", `${base}...${branch}`, "--stat"], { cwd: sessionCwd, timeout: 10_000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+					resolve({ ok: !err, stdout: stdout?.trim() ?? "" });
+				});
+			});
+
+			const diffResult = await new Promise<{ ok: boolean; stdout: string }>((resolve) => {
+				execFile("git", ["diff", `${base}...${branch}`], { cwd: sessionCwd, timeout: 15_000, maxBuffer: 5 * 1024 * 1024 }, (err, stdout) => {
+					resolve({ ok: !err, stdout: stdout?.trim() ?? "" });
+				});
+			});
+
+			// Truncate diff if too large
+			const maxDiffLen = 50_000;
+			let diff = diffResult.ok ? diffResult.stdout : "";
+			if (diff.length > maxDiffLen) {
+				diff = diff.slice(0, maxDiffLen) + "\n\n… (diff truncated)";
 			}
 
-			const result = await gh(ghArgs, sessionCwd);
-			if (result.ok) {
-				ctx.ui.notify(`✅ PR created: ${result.stdout}`, "info");
-				log("pr-create", { branch, url: result.stdout });
-			} else {
-				ctx.ui.notify(`❌ Failed to create PR: ${result.stderr || result.stdout}`, "error");
-			}
+			const prompt = [
+				`Create a GitHub pull request for branch \`${branch}\` → \`${base}\`.`,
+				"",
+				"## Commits",
+				"```",
+				commitsResult.ok ? commitsResult.stdout : "(no commits found)",
+				"```",
+				"",
+				"## Diff stat",
+				"```",
+				diffStatResult.ok ? diffStatResult.stdout : "(unavailable)",
+				"```",
+				"",
+				"## Diff",
+				"```diff",
+				diff || "(empty diff)",
+				"```",
+				"",
+				"## Instructions",
+				"",
+				"Based on the commits and diff above, write a clear PR title and description.",
+				"Then create the PR by running:",
+				"```bash",
+				`gh pr create --base ${base} --title "YOUR TITLE" --body "YOUR DESCRIPTION"`,
+				"```",
+				"",
+				"Guidelines for the PR description:",
+				"- Start with a concise summary of what the PR does and why",
+				"- List key changes as bullet points",
+				"- Keep it factual — don't pad with filler",
+				"- Use markdown formatting",
+				"- If there are breaking changes, call them out explicitly",
+				"",
+				"**Before creating the PR, present your draft title and description to the user and ask if they have any input or changes.** Only run the `gh pr create` command after they confirm.",
+			].join("\n");
+
+			ctx.ui.notify(`📝 Gathering diff for \`${branch}\` → \`${base}\`…`, "info");
+			sendUserMessage(prompt, { deliverAs: "followUp" });
+			log("pr-create", { branch, base });
 		},
 	});
 
@@ -306,45 +369,6 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 
 			ctx.ui.notify(`**Workflow Runs on ${resolved.slug}** (${runs.length})\n${lines.join("\n")}`, "info");
 			log("actions", { repo: resolved.slug, count: runs.length });
-		},
-	});
-
-	// ── /gh-pr-open · /github-pr-open ─────────────────────────
-
-	registerDualCommand(pi, "gh-pr-open", "github-pr-open", {
-		description: "Open PR in browser: /gh-pr-open [pr-number | owner/repo#N | PR-URL]",
-		handler: async (args, ctx) => {
-			const { ref } = extractRepoRef(args);
-			const resolved = await resolveRepo(ref, sessionCwd);
-			if (!resolved) {
-				ctx.ui.notify("❌ Could not determine repo. Specify owner/repo or run from a git repo.", "error");
-				return;
-			}
-			const rFlag = repoFlag(resolved.owner, resolved.repo);
-
-			let prNum = ref.prNumber;
-
-			if (!prNum) {
-				const branch = await getCurrentBranch(sessionCwd);
-				if (!branch) {
-					ctx.ui.notify("❌ Not in a git repo. Specify a PR number or owner/repo#N.", "error");
-					return;
-				}
-				const branchPrs = await ghJson<any[]>(["pr", "list", ...rFlag, "--head", branch, "--json", "number,title"]);
-				if (!branchPrs || branchPrs.length === 0) {
-					ctx.ui.notify(`No PR found for branch \`${branch}\` on ${resolved.slug}.`, "info");
-					return;
-				}
-				prNum = branchPrs[0].number;
-			}
-
-			const result = await gh(["pr", "view", String(prNum), ...rFlag, "--web"], sessionCwd);
-			if (result.ok) {
-				ctx.ui.notify(`🔗 Opened PR #${prNum} on ${resolved.slug} in browser.`, "info");
-				log("pr-open", { repo: resolved.slug, prNum });
-			} else {
-				ctx.ui.notify(`❌ Failed to open PR #${prNum}: ${result.stderr || result.stdout}`, "error");
-			}
 		},
 	});
 

--- a/extensions/pi-github/src/commands.ts
+++ b/extensions/pi-github/src/commands.ts
@@ -253,7 +253,7 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 			const base = args.trim() || "main";
 
 			// Check if a PR already exists for this branch
-			const existing = await ghJson<any[]>(["pr", "list", "--head", branch, "--json", "number,url"]);
+			const existing = await ghJson<any[]>(["pr", "list", "--head", branch, "--json", "number,url"], sessionCwd);
 			if (existing && existing.length > 0) {
 				ctx.ui.notify(`❌ PR already exists for branch \`${branch}\`: ${existing[0].url}`, "error");
 				return;
@@ -271,6 +271,8 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 			}
 
 			// Gather context: commits and diff summary
+			ctx.ui.notify(`📝 Gathering diff for \`${branch}\` → \`${base}\`…`, "info");
+
 			const commitsResult = await new Promise<{ ok: boolean; stdout: string }>((resolve) => {
 				execFile("git", ["log", `${base}..${branch}`, "--pretty=format:%h %s", "--reverse"], { cwd: sessionCwd, timeout: 10_000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
 					resolve({ ok: !err, stdout: stdout?.trim() ?? "" });
@@ -332,7 +334,6 @@ export function registerCommands(pi: ExtensionAPI, log: LogFn): void {
 				"**Before creating the PR, present your draft title and description to the user and ask if they have any input or changes.** Only run the `gh pr create` command after they confirm.",
 			].join("\n");
 
-			ctx.ui.notify(`📝 Gathering diff for \`${branch}\` → \`${base}\`…`, "info");
 			sendUserMessage(prompt, { deliverAs: "followUp" });
 			log("pr-create", { branch, base });
 		},

--- a/extensions/pi-github/src/index.ts
+++ b/extensions/pi-github/src/index.ts
@@ -7,6 +7,7 @@
  *   - /gh-status       — Repo status summary
  *   - /gh-notifications — GitHub notifications
  *   - /gh-pr-create    — Create PR for current branch
+ *   - /gh-pr-open      — Open PR in browser
  *   - /gh-pr-review    — Show PR review feedback
  *   - /gh-pr-fix       — Fix PR review feedback (validates with user, fixes, resolves)
  *   - /gh-pr-merge     — Merge PR, delete remote/local branch, pull base

--- a/extensions/pi-github/src/index.ts
+++ b/extensions/pi-github/src/index.ts
@@ -6,8 +6,7 @@
  *   - /gh-issues       — List open issues
  *   - /gh-status       — Repo status summary
  *   - /gh-notifications — GitHub notifications
- *   - /gh-pr-create    — Create PR for current branch
- *   - /gh-pr-open      — Open PR in browser
+ *   - /gh-pr-create    — Create PR with LLM-generated summary
  *   - /gh-pr-review    — Show PR review feedback
  *   - /gh-pr-fix       — Fix PR review feedback (validates with user, fixes, resolves)
  *   - /gh-pr-merge     — Merge PR, delete remote/local branch, pull base


### PR DESCRIPTION
Opens the PR for the current branch (or a specified PR number/repo ref)
in the default browser via 'gh pr view --web'. Follows the same repo
ref parsing as other commands (owner/repo#N, PR URLs, plain numbers).
