### PR TITLE
feat(pi-channels): support custom JSON payload in webhook adapter

### DIFF
--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Remove metadata side-channel payload switching (`metadata["json"]`) in favor of typed fields
 - Allow raw JSON sends without injecting empty `text` into outgoing messages
 - Omit request body for webhook `GET`/`HEAD` requests to avoid undici runtime errors
+- Omit `Content-Type` for bodyless `GET`/`HEAD` webhook requests
+- Prevent silent raw payload drops by rejecting `GET`/`HEAD` requests that include `json/rawBody`
+- Add `HEAD` method support to the `notify` tool
 - Document `contentType` precedence over `headers["Content-Type"]` for webhook config
 
 ## [0.1.0] - 2026-02-17 (7839f93)

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.1] - 2026-02-19 (7442720)
+
+### Added
+
+- Support custom JSON payload in webhook adapter via `json` parameter in notify tool
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Support custom JSON payload in webhook adapter via `json` parameter in notify tool
+- Support custom JSON payloads in webhook adapter via `notify` tool
+- Add explicit webhook payload controls: `payloadMode` (`envelope`/`raw`), `rawBody`, and per-message webhook overrides (`method`, `contentType`)
+
+### Fixed
+
+- Guard `notify` JSON parsing and return graceful `Invalid JSON` errors instead of throwing
+- Remove metadata side-channel payload switching (`metadata["json"]`) in favor of typed fields
+- Allow raw JSON sends without injecting empty `text` into outgoing messages
+- Omit request body for webhook `GET`/`HEAD` requests to avoid undici runtime errors
+- Document `contentType` precedence over `headers["Content-Type"]` for webhook config
 
 ## [0.1.0] - 2026-02-17 (7839f93)
 

--- a/extensions/pi-channels/README.md
+++ b/extensions/pi-channels/README.md
@@ -75,9 +75,10 @@ Use `"env:VAR_NAME"` to reference environment variables. Project settings overri
 
 For webhook sends, `notify` supports:
 - `payloadMode`: `"envelope"` (default) or `"raw"`
-- `json`: raw request body (required when `payloadMode` is `"raw"`; auto-enables raw mode if provided)
-- `method`: HTTP method override for raw mode
-- `contentType`: `Content-Type` override for raw mode
+- `json`: raw request body (auto-enables raw mode if provided; required for body-carrying raw methods)
+- `method`: HTTP method override for raw mode (`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`)
+- `contentType`: `Content-Type` override for raw mode (applies only when a request body is sent)
+- `GET`/`HEAD` raw requests are bodyless (do not provide `json`)
 
 ## Commands
 

--- a/extensions/pi-channels/README.md
+++ b/extensions/pi-channels/README.md
@@ -47,7 +47,7 @@ Use `"env:VAR_NAME"` to reference environment variables. Project settings overri
 |------|-----------|------------|
 | `telegram` | bidirectional | `botToken`, `polling`, `parseMode`, `allowedChatIds`, `transcription` |
 | `slack` | bidirectional | `botToken`, `appToken` |
-| `webhook` | outgoing | `method`, `headers` |
+| `webhook` | outgoing | `method`, `contentType`, `payloadMode`, `headers` |
 
 ### Bridge settings
 
@@ -66,9 +66,15 @@ Use `"env:VAR_NAME"` to reference environment variables. Project settings overri
 
 | Action | Required params | Description |
 |--------|----------------|-------------|
-| `send` | `adapter`, `text` | Send a message via an adapter name or route alias |
+| `send` | `adapter`, (`text` or `json`) | Send a message via an adapter name or route alias |
 | `list` | — | Show configured adapters and routes |
 | `test` | `adapter` | Send a test ping |
+
+For webhook sends, `notify` supports:
+- `payloadMode`: `"envelope"` (default) or `"raw"`
+- `json`: raw request body (required when `payloadMode` is `"raw"`; auto-enables raw mode if provided)
+- `method`: HTTP method override for raw mode
+- `contentType`: `Content-Type` override for raw mode
 
 ## Commands
 

--- a/extensions/pi-channels/README.md
+++ b/extensions/pi-channels/README.md
@@ -49,6 +49,9 @@ Use `"env:VAR_NAME"` to reference environment variables. Project settings overri
 | `slack` | bidirectional | `botToken`, `appToken` |
 | `webhook` | outgoing | `method`, `contentType`, `payloadMode`, `headers` |
 
+> Webhook migration note: custom `Content-Type` should be set via `contentType`.
+> If both `contentType` and `headers["Content-Type"]` are provided, `contentType` wins.
+
 ### Bridge settings
 
 | Key | Default | Description |

--- a/extensions/pi-channels/package.json
+++ b/extensions/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-channels",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Two-way channel extension for pi — route messages between agents and Telegram, webhooks, and custom adapters",
   "keywords": [
     "pi-package"

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -155,6 +155,9 @@ export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: Sl
 		},
 
 		async send(message: ChannelMessage): Promise<void> {
+			if (!message.text) {
+				throw new Error("Slack adapter requires text");
+			}
 			const prefix = message.source ? `*[${message.source}]*\n` : "";
 			const full = prefix + message.text;
 			const threadTs = message.metadata?.threadTs as string | undefined;

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -589,6 +589,9 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 		},
 
 		async send(message: ChannelMessage): Promise<void> {
+			if (!message.text) {
+				throw new Error("Telegram adapter requires text");
+			}
 			const prefix = message.source ? `[${message.source}]\n` : "";
 			const full = prefix + message.text;
 

--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -53,11 +53,16 @@ export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
 				});
 			}
 
-			const res = await fetch(message.recipient, {
+			const request: RequestInit = {
 				method,
 				headers: { ...extraHeaders, "Content-Type": contentType },
-				body,
-			});
+			};
+			const normalizedMethod = method.toUpperCase();
+			if (normalizedMethod !== "GET" && normalizedMethod !== "HEAD") {
+				request.body = body;
+			}
+
+			const res = await fetch(message.recipient, request);
 
 			if (!res.ok) {
 				const err = await res.text().catch(() => "unknown error");

--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -35,16 +35,22 @@ export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
 			const contentType = payloadMode === "raw"
 				? (message.webhook?.contentType ?? defaultContentType)
 				: defaultContentType;
+			const normalizedMethod = method.toUpperCase();
+			const canHaveBody = normalizedMethod !== "GET" && normalizedMethod !== "HEAD";
 
-			let body: string;
+			let body: string | undefined;
 			if (payloadMode === "raw") {
-				if (message.rawBody === undefined) {
-					throw new Error("Webhook raw payload mode requires rawBody");
+				if (canHaveBody) {
+					if (message.rawBody === undefined) {
+						throw new Error(`Webhook raw payload mode requires rawBody for ${normalizedMethod} requests`);
+					}
+					body = typeof message.rawBody === "string"
+						? message.rawBody
+						: JSON.stringify(message.rawBody);
+				} else if (message.rawBody !== undefined) {
+					throw new Error(`Webhook ${normalizedMethod} requests cannot include a body; omit json/rawBody or use POST/PUT/PATCH/DELETE`);
 				}
-				body = typeof message.rawBody === "string"
-					? message.rawBody
-					: JSON.stringify(message.rawBody);
-			} else {
+			} else if (canHaveBody) {
 				body = JSON.stringify({
 					text: message.text ?? "",
 					source: message.source,
@@ -53,12 +59,20 @@ export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
 				});
 			}
 
-			const request: RequestInit = {
-				method,
-				headers: { ...extraHeaders, "Content-Type": contentType },
-			};
-			const normalizedMethod = method.toUpperCase();
-			if (normalizedMethod !== "GET" && normalizedMethod !== "HEAD") {
+			const headers: Record<string, string> = {};
+			for (const [key, value] of Object.entries(extraHeaders)) {
+				if (key.toLowerCase() === "content-type") continue;
+				headers[key] = value;
+			}
+			if (body !== undefined) {
+				headers["Content-Type"] = contentType;
+			}
+
+			const request: RequestInit = { method };
+			if (Object.keys(headers).length > 0) {
+				request.headers = headers;
+			}
+			if (body !== undefined) {
 				request.body = body;
 			}
 

--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -21,15 +21,27 @@ export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
 		direction: "outgoing" as const,
 
 		async send(message: ChannelMessage): Promise<void> {
-			const res = await fetch(message.recipient, {
-				method,
-				headers: { "Content-Type": "application/json", ...extraHeaders },
-				body: JSON.stringify({
+			// Check for custom JSON payload in metadata
+			const customJson = message.metadata?.["json"];
+			
+			let body: string;
+			if (customJson !== undefined) {
+				// Use custom JSON directly
+				body = JSON.stringify(customJson);
+			} else {
+				// Default payload structure
+				body = JSON.stringify({
 					text: message.text,
 					source: message.source,
 					metadata: message.metadata,
 					timestamp: new Date().toISOString(),
-				}),
+				});
+			}
+
+			const res = await fetch(message.recipient, {
+				method,
+				headers: { "Content-Type": "application/json", ...extraHeaders },
+				body,
 			});
 
 			if (!res.ok) {

--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -1,37 +1,52 @@
 /**
  * pi-channels — Built-in webhook adapter.
  *
- * POSTs message as JSON. The recipient field is the webhook URL.
+ * Sends HTTP requests where recipient is the webhook URL.
+ * Supports two payload modes:
+ *   - envelope (default): { text, source, metadata, timestamp }
+ *   - raw: send rawBody as-is (string) or JSON-serialized (non-string)
  *
  * Config:
  * {
  *   "type": "webhook",
  *   "method": "POST",
+ *   "contentType": "application/json",
+ *   "payloadMode": "envelope",
  *   "headers": { "Authorization": "Bearer ..." }
  * }
  */
 
-import type { ChannelAdapter, ChannelMessage, AdapterConfig } from "../types.ts";
+import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelPayloadMode } from "../types.ts";
 
 export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
-	const method = (config.method as string) ?? "POST";
+	const defaultMethod = (config.method as string) ?? "POST";
+	const defaultContentType = (config.contentType as string) ?? "application/json";
 	const extraHeaders = (config.headers as Record<string, string>) ?? {};
+	const defaultPayloadMode: ChannelPayloadMode = config.payloadMode === "raw" ? "raw" : "envelope";
 
 	return {
 		direction: "outgoing" as const,
 
 		async send(message: ChannelMessage): Promise<void> {
-			// Check for custom JSON payload in metadata
-			const customJson = message.metadata?.["json"];
-			
+			const payloadMode = message.payloadMode ?? defaultPayloadMode;
+			const method = payloadMode === "raw"
+				? (message.webhook?.method ?? defaultMethod)
+				: defaultMethod;
+			const contentType = payloadMode === "raw"
+				? (message.webhook?.contentType ?? defaultContentType)
+				: defaultContentType;
+
 			let body: string;
-			if (customJson !== undefined) {
-				// Use custom JSON directly
-				body = JSON.stringify(customJson);
+			if (payloadMode === "raw") {
+				if (message.rawBody === undefined) {
+					throw new Error("Webhook raw payload mode requires rawBody");
+				}
+				body = typeof message.rawBody === "string"
+					? message.rawBody
+					: JSON.stringify(message.rawBody);
 			} else {
-				// Default payload structure
 				body = JSON.stringify({
-					text: message.text,
+					text: message.text ?? "",
 					source: message.source,
 					metadata: message.metadata,
 					timestamp: new Date().toISOString(),
@@ -40,7 +55,7 @@ export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
 
 			const res = await fetch(message.recipient, {
 				method,
-				headers: { "Content-Type": "application/json", ...extraHeaders },
+				headers: { ...extraHeaders, "Content-Type": contentType },
 				body,
 			});
 

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -13,6 +13,7 @@ interface ChannelToolParams {
 	recipient?: string;
 	text?: string;
 	source?: string;
+	json?: string;
 }
 
 export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry): void {
@@ -34,10 +35,13 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 				Type.String({ description: "Recipient — chat ID, webhook URL, etc. (required for send unless using a route)" }),
 			),
 			text: Type.Optional(
-				Type.String({ description: "Message text (required for send)" }),
+				Type.String({ description: "Message text (required for send unless using json)" }),
 			),
 			source: Type.Optional(
 				Type.String({ description: "Source label (optional)" }),
+			),
+			json: Type.Optional(
+				Type.String({ description: "Custom JSON payload to send (optional, replaces text + default structure)" }),
 			),
 		}) as any,
 
@@ -61,15 +65,16 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 					break;
 				}
 				case "send": {
-					if (!params.adapter || !params.text) {
-						result = "Missing required fields: adapter and text.";
+					if (!params.adapter || (!params.text && !params.json)) {
+						result = "Missing required fields: adapter and (text or json).";
 						break;
 					}
 					const r = await registry.send({
 						adapter: params.adapter,
 						recipient: params.recipient ?? "",
-						text: params.text,
+						text: params.text ?? "",
 						source: params.source,
+						metadata: params.json ? { json: JSON.parse(params.json) } : undefined,
 					});
 					result = r.ok
 						? `✓ Sent via "${params.adapter}"${params.recipient ? ` to ${params.recipient}` : ""}`

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -14,6 +14,9 @@ interface ChannelToolParams {
 	text?: string;
 	source?: string;
 	json?: string;
+	payloadMode?: "envelope" | "raw";
+	method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+	contentType?: string;
 }
 
 export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry): void {
@@ -35,13 +38,28 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 				Type.String({ description: "Recipient — chat ID, webhook URL, etc. (required for send unless using a route)" }),
 			),
 			text: Type.Optional(
-				Type.String({ description: "Message text (required for send unless using json)" }),
+				Type.String({ description: "Message text (required for send unless using json payload)" }),
 			),
 			source: Type.Optional(
 				Type.String({ description: "Source label (optional)" }),
 			),
 			json: Type.Optional(
-				Type.String({ description: "Custom JSON payload to send (optional, replaces text + default structure)" }),
+				Type.String({ description: "Custom JSON payload string (optional, sends raw JSON body when provided)" }),
+			),
+			payloadMode: Type.Optional(
+				StringEnum(
+					["envelope", "raw"] as const,
+					{ description: "Webhook payload mode (default: envelope, auto-switches to raw when json is provided)" },
+				) as any,
+			),
+			method: Type.Optional(
+				StringEnum(
+					["GET", "POST", "PUT", "PATCH", "DELETE"] as const,
+					{ description: "HTTP method override for webhook raw mode" },
+				) as any,
+			),
+			contentType: Type.Optional(
+				Type.String({ description: "Content-Type header override for webhook raw mode" }),
 			),
 		}) as any,
 
@@ -65,16 +83,50 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 					break;
 				}
 				case "send": {
-					if (!params.adapter || (!params.text && !params.json)) {
-						result = "Missing required fields: adapter and (text or json).";
+					if (!params.adapter) {
+						result = "Missing required field: adapter.";
 						break;
 					}
+
+					const payloadMode = params.payloadMode ?? (params.json ? "raw" : "envelope");
+
+					if (payloadMode === "raw" && !params.json) {
+						result = "Raw payload mode requires json.";
+						break;
+					}
+					if (payloadMode === "envelope" && !params.text) {
+						result = "Envelope payload mode requires text.";
+						break;
+					}
+					if (payloadMode === "envelope" && params.json) {
+						result = "json is only supported in raw payload mode.";
+						break;
+					}
+					if (payloadMode !== "raw" && (params.method || params.contentType)) {
+						result = "method/contentType overrides are only supported in raw payload mode.";
+						break;
+					}
+
+					let parsedJson: unknown;
+					if (payloadMode === "raw" && params.json) {
+						try {
+							parsedJson = JSON.parse(params.json);
+						} catch (err: any) {
+							result = `Invalid JSON: ${err.message ?? "Malformed JSON payload."}`;
+							break;
+						}
+					}
+
 					const r = await registry.send({
 						adapter: params.adapter,
 						recipient: params.recipient ?? "",
-						text: params.text ?? "",
+						text: params.text,
 						source: params.source,
-						metadata: params.json ? { json: JSON.parse(params.json) } : undefined,
+						payloadMode,
+						rawBody: parsedJson,
+						webhook: payloadMode === "raw"
+							? { method: params.method, contentType: params.contentType }
+							: undefined,
 					});
 					result = r.ok
 						? `✓ Sent via "${params.adapter}"${params.recipient ? ` to ${params.recipient}` : ""}`

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -91,7 +91,6 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 					const payloadMode = params.payloadMode ?? (params.json ? "raw" : "envelope");
 					const normalizedMethod = params.method?.toUpperCase();
 					const methodDisallowsBody = normalizedMethod === "GET" || normalizedMethod === "HEAD";
-					const methodAllowsBody = normalizedMethod !== undefined && !methodDisallowsBody;
 
 					if (payloadMode === "envelope" && !params.text) {
 						result = "Envelope payload mode requires text.";
@@ -106,7 +105,7 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 						break;
 					}
 					if (payloadMode === "raw" && !methodDisallowsBody && !params.json) {
-						result = `Raw payload mode requires json${normalizedMethod ? ` for ${normalizedMethod}` : ""} requests.`;
+						result = `Raw payload mode requires json${normalizedMethod ? ` for ${normalizedMethod} requests` : ""}.`;
 						break;
 					}
 					if (payloadMode === "raw" && methodDisallowsBody && params.json) {

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -15,7 +15,7 @@ interface ChannelToolParams {
 	source?: string;
 	json?: string;
 	payloadMode?: "envelope" | "raw";
-	method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+	method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
 	contentType?: string;
 }
 
@@ -54,7 +54,7 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 			),
 			method: Type.Optional(
 				StringEnum(
-					["GET", "POST", "PUT", "PATCH", "DELETE"] as const,
+					["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"] as const,
 					{ description: "HTTP method override for webhook raw mode" },
 				) as any,
 			),
@@ -89,11 +89,10 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 					}
 
 					const payloadMode = params.payloadMode ?? (params.json ? "raw" : "envelope");
+					const normalizedMethod = params.method?.toUpperCase();
+					const methodDisallowsBody = normalizedMethod === "GET" || normalizedMethod === "HEAD";
+					const methodAllowsBody = normalizedMethod !== undefined && !methodDisallowsBody;
 
-					if (payloadMode === "raw" && !params.json) {
-						result = "Raw payload mode requires json.";
-						break;
-					}
 					if (payloadMode === "envelope" && !params.text) {
 						result = "Envelope payload mode requires text.";
 						break;
@@ -104,6 +103,14 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 					}
 					if (payloadMode !== "raw" && (params.method || params.contentType)) {
 						result = "method/contentType overrides are only supported in raw payload mode.";
+						break;
+					}
+					if (payloadMode === "raw" && methodAllowsBody && !params.json) {
+						result = `Raw payload mode requires json for ${normalizedMethod} requests.`;
+						break;
+					}
+					if (payloadMode === "raw" && methodDisallowsBody && params.json) {
+						result = `${normalizedMethod} requests cannot include json body in raw mode.`;
 						break;
 					}
 

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -105,8 +105,8 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 						result = "method/contentType overrides are only supported in raw payload mode.";
 						break;
 					}
-					if (payloadMode === "raw" && methodAllowsBody && !params.json) {
-						result = `Raw payload mode requires json for ${normalizedMethod} requests.`;
+					if (payloadMode === "raw" && !methodDisallowsBody && !params.json) {
+						result = `Raw payload mode requires json${normalizedMethod ? ` for ${normalizedMethod}` : ""} requests.`;
 						break;
 					}
 					if (payloadMode === "raw" && methodDisallowsBody && params.json) {

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -4,17 +4,32 @@
 
 // ── Channel message ─────────────────────────────────────────────
 
+export type ChannelPayloadMode = "envelope" | "raw";
+
+export interface WebhookRequestOptions {
+	/** Override HTTP method for this message (e.g. POST, PUT, PATCH). */
+	method?: string;
+	/** Override Content-Type header for this message body. */
+	contentType?: string;
+}
+
 export interface ChannelMessage {
 	/** Adapter name: "telegram", "webhook", or a custom adapter */
 	adapter: string;
 	/** Recipient — adapter-specific (chat ID, webhook URL, email address, etc.) */
 	recipient: string;
-	/** Message text to deliver */
-	text: string;
+	/** Message text to deliver (optional when using raw payload mode) */
+	text?: string;
 	/** Where this came from (e.g. "cron:daily-standup") */
 	source?: string;
 	/** Arbitrary metadata for adapter handlers */
 	metadata?: Record<string, unknown>;
+	/** Payload mode hint for adapters that support multiple body formats */
+	payloadMode?: ChannelPayloadMode;
+	/** First-class custom body payload (used by webhook adapter in raw mode) */
+	rawBody?: unknown;
+	/** Webhook transport overrides for this message */
+	webhook?: WebhookRequestOptions;
 }
 
 // ── Incoming message (from external → pi) ───────────────────────


### PR DESCRIPTION
Allows sending arbitrary JSON via the webhook adapter by passing a  parameter to the notify tool.

Usage:
```
notify send adapter=webhook recipient=https://example.com/hook json='{"event": "deploy", "status": "success"}'
```

The webhook adapter will send this JSON directly as the request body instead of the default {text, source, metadata, timestamp} structure.