### PR TITLE
fix(pi-github): support git worktrees in pr-fix and pr-merge commands

### DIFF
--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -627,6 +627,22 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 			abortController = null;
 			cleanupTempFiles();
 		},
+
+		async syncBotCommands(commands: Array<{ command: string; description: string }>): Promise<void> {
+			try {
+				const res = await fetch(`${apiBase}/setMyCommands`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ commands }),
+				});
+				if (!res.ok) {
+					const err = await res.text().catch(() => "unknown error");
+					console.error(`[pi-channels] Failed to sync bot commands: ${res.status} ${err}`);
+				}
+			} catch (err: any) {
+				console.error(`[pi-channels] Failed to sync bot commands: ${err.message}`);
+			}
+		},
 	};
 }
 

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -40,6 +40,7 @@ import { ChannelRegistry } from "./registry.ts";
 import { registerChannelEvents, setBridge } from "./events.ts";
 import { registerChannelTool } from "./tool.ts";
 import { ChatBridge } from "./bridge/bridge.ts";
+import { getAllCommands } from "./bridge/commands.ts";
 import { createLogger } from "./logger.ts";
 
 export default function (pi: ExtensionAPI) {
@@ -75,6 +76,10 @@ export default function (pi: ExtensionAPI) {
 
 		// Start incoming/bidirectional adapters
 		await registry.startListening();
+
+		// Sync bot commands with platforms (e.g. Telegram /command menu)
+		const botCommands = getAllCommands().map(c => ({ command: c.name, description: c.description }));
+		await registry.syncBotCommands(botCommands);
 
 		const startErrors = registry.getErrors().filter(e => e.error.startsWith("Failed to start"));
 		for (const err of startErrors) {

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -99,6 +99,19 @@ export class ChannelRegistry {
 		}
 	}
 
+	/** Sync bot commands on all adapters that support it. */
+	async syncBotCommands(commands: Array<{ command: string; description: string }>): Promise<void> {
+		for (const [name, adapter] of this.adapters) {
+			if (adapter.syncBotCommands) {
+				try {
+					await adapter.syncBotCommands(commands);
+				} catch (err: any) {
+					this.errors.push({ adapter: name, error: `Failed to sync commands: ${err.message}` });
+				}
+			}
+		}
+	}
+
 	/** Stop all adapters. */
 	async stopAll(): Promise<void> {
 		for (const adapter of this.adapters.values()) {

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -103,6 +103,11 @@ export interface ChannelAdapter {
 	 * Optional — only supported by adapters that have real-time presence (e.g. Telegram).
 	 */
 	sendTyping?(recipient: string): Promise<void>;
+	/**
+	 * Sync bot commands with the platform (e.g. Telegram's /command menu).
+	 * Optional — only supported by adapters with a command menu API.
+	 */
+	syncBotCommands?(commands: Array<{ command: string; description: string }>): Promise<void>;
 }
 
 // ── Config (lives under "pi-channels" key in pi settings.json) ──

--- a/extensions/pi-github/src/gh.ts
+++ b/extensions/pi-github/src/gh.ts
@@ -89,3 +89,27 @@ export async function getCurrentBranch(cwd?: string): Promise<string | null> {
 		});
 	});
 }
+
+/**
+ * Find the worktree path for a branch, if it's checked out in one.
+ * Returns the worktree path or null if the branch isn't in any worktree.
+ */
+export async function findWorktreeForBranch(branch: string, cwd: string): Promise<string | null> {
+	const result = await gitExec(["worktree", "list", "--porcelain"], cwd);
+	if (!result.ok) return null;
+
+	// Parse porcelain output: blocks separated by blank lines
+	// Each block has: worktree <path>, HEAD <sha>, branch refs/heads/<name>
+	let currentPath: string | null = null;
+	for (const line of result.stdout.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			currentPath = line.slice("worktree ".length);
+		} else if (line.startsWith("branch refs/heads/")) {
+			const branchName = line.slice("branch refs/heads/".length);
+			if (branchName === branch) return currentPath;
+		} else if (line === "") {
+			currentPath = null;
+		}
+	}
+	return null;
+}

--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -14,7 +14,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { ghJson, ghGraphql, gitExec, getCurrentBranch } from "./gh.ts";
+import { ghJson, ghGraphql, gitExec, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
 import { registerDualCommand } from "./commands.ts";
 import { extractRepoRef, resolveRepo, resolveLocalClone, repoFlag } from "./repo-ref.ts";
 
@@ -359,30 +359,50 @@ export function registerPrFixCommand(pi: ExtensionAPI, log: LogFn, getCwd: () =>
 			const currentBranch = await getCurrentBranch(localPath);
 
 			if (currentBranch !== prBranch) {
-				const status = await gitExec(["status", "--porcelain"], localPath);
-				if (status.ok && status.stdout.length > 0) {
-					ctx.ui.notify(`❌ Working tree at ${localPath} has uncommitted changes. Commit or stash before running /gh-pr-fix.`, "error");
-					return;
-				}
+				// Check if the branch is checked out in a worktree
+				const worktreePath = await findWorktreeForBranch(prBranch, localPath);
+				if (worktreePath) {
+					localPath = worktreePath;
+					ctx.ui.notify(`Branch \`${prBranch}\` is in worktree at \`${worktreePath}\`. Working there.`, "info");
+				} else {
+					const status = await gitExec(["status", "--porcelain"], localPath);
+					if (status.ok && status.stdout.length > 0) {
+						ctx.ui.notify(`❌ Working tree at ${localPath} has uncommitted changes. Commit or stash before running /gh-pr-fix.`, "error");
+						return;
+					}
 
-				ctx.ui.notify(`Switching to branch \`${prBranch}\` in ${localPath}…`, "info");
-				const checkout = await gitExec(["checkout", prBranch], localPath);
-				if (!checkout.ok) {
-					const localExists = await gitExec(["branch", "--list", prBranch], localPath);
-					if (localExists.ok && localExists.stdout.length > 0) {
-						ctx.ui.notify(`❌ Could not checkout branch \`${prBranch}\`: ${checkout.stderr}`, "error");
-						return;
+					ctx.ui.notify(`Switching to branch \`${prBranch}\` in ${localPath}…`, "info");
+					const checkout = await gitExec(["checkout", prBranch], localPath);
+					if (!checkout.ok) {
+						const localExists = await gitExec(["branch", "--list", prBranch], localPath);
+						if (localExists.ok && localExists.stdout.length > 0) {
+							ctx.ui.notify(`❌ Could not checkout branch \`${prBranch}\`: ${checkout.stderr}`, "error");
+							return;
+						}
+						const fetchResult = await gitExec(["fetch", "origin", prBranch], localPath, 30_000);
+						if (!fetchResult.ok) {
+							ctx.ui.notify(`❌ Failed to fetch branch \`${prBranch}\` from origin: ${fetchResult.stderr}`, "error");
+							return;
+						}
+						const retry = await gitExec(["checkout", "-b", prBranch, `origin/${prBranch}`], localPath);
+						if (!retry.ok) {
+							ctx.ui.notify(`❌ Could not checkout branch \`${prBranch}\`: ${retry.stderr}`, "error");
+							return;
+						}
 					}
-					const fetchResult = await gitExec(["fetch", "origin", prBranch], localPath, 30_000);
-					if (!fetchResult.ok) {
-						ctx.ui.notify(`❌ Failed to fetch branch \`${prBranch}\` from origin: ${fetchResult.stderr}`, "error");
-						return;
-					}
-					const retry = await gitExec(["checkout", "-b", prBranch, `origin/${prBranch}`], localPath);
-					if (!retry.ok) {
-						ctx.ui.notify(`❌ Could not checkout branch \`${prBranch}\`: ${retry.stderr}`, "error");
-						return;
-					}
+				}
+			}
+
+			// ── Step 5b: Pull latest from origin ────────────
+			const pullStatus = await gitExec(["status", "--porcelain"], localPath);
+			if (pullStatus.ok && pullStatus.stdout.length > 0) {
+				ctx.ui.notify(`⚠️ Working tree at \`${localPath}\` has uncommitted changes — skipping pull.`, "warning");
+			} else {
+				ctx.ui.notify(`Pulling latest \`${prBranch}\` from origin…`, "info");
+				const pull = await gitExec(["pull", "--ff-only", "origin", prBranch], localPath, 30_000);
+				if (!pull.ok) {
+					// Non-fatal — local might have unpushed commits, warn and continue
+					ctx.ui.notify(`⚠️ Could not fast-forward \`${prBranch}\`: ${pull.stderr}. Continuing with local state.`, "warning");
 				}
 			}
 

--- a/extensions/pi-github/src/pr-merge.ts
+++ b/extensions/pi-github/src/pr-merge.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { gh, ghJson, gitExec, getCurrentBranch } from "./gh.ts";
+import { gh, ghJson, gitExec, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
 import { registerDualCommand } from "./commands.ts";
 import { extractRepoRef, resolveRepo, repoFlag } from "./repo-ref.ts";
 
@@ -206,6 +206,7 @@ async function cleanupBranches(
 
 	// Switch to base branch and pull
 	let onBaseBranch = false;
+	let pullCwd = cwd; // where to run pull — may differ if base is in a worktree
 	const currentBranch = await getCurrentBranch(cwd);
 	if (currentBranch === baseBranch) {
 		onBaseBranch = true;
@@ -214,12 +215,20 @@ async function cleanupBranches(
 		if (checkout.ok) {
 			onBaseBranch = true;
 		} else {
-			errors.push(`Failed to checkout ${baseBranch}: ${checkout.stderr}`);
+			// Check if the base branch is checked out in a worktree
+			const worktreePath = await findWorktreeForBranch(baseBranch, cwd);
+			if (worktreePath) {
+				onBaseBranch = true;
+				pullCwd = worktreePath;
+				ctx.ui.notify(`Branch \`${baseBranch}\` is in worktree at \`${worktreePath}\`. Pulling there.`, "info");
+			} else {
+				errors.push(`Failed to checkout ${baseBranch}: ${checkout.stderr}`);
+			}
 		}
 	}
 
 	if (onBaseBranch) {
-		const pull = await gitExec(["pull", "--ff-only"], cwd, 30_000);
+		const pull = await gitExec(["pull", "--ff-only"], pullCwd, 30_000);
 		if (pull.ok) {
 			ctx.ui.notify(`⬇️ Pulled latest \`${baseBranch}\`.`, "info");
 		} else {
@@ -229,30 +238,38 @@ async function cleanupBranches(
 		// Delete local branch (if it exists and we're not on it).
 		// Use -D (force) because squash/rebase merges on GitHub don't create
 		// a local merge commit, so git branch -d thinks it's "not fully merged".
-		const nowOn = await getCurrentBranch(cwd);
-		if (nowOn !== headBranch) {
-			// Guard: warn about local-only commits before force-deleting.
-			// Only warn for true merge strategy where SHAs are preserved.
-			// Squash/rebase always diverge (different SHAs), so just log at debug level.
-			if (strategy === "merge") {
-				const localOnly = await gitExec(["log", `${baseBranch}..${headBranch}`, "--oneline"], cwd);
-				if (localOnly.ok && localOnly.stdout.trim().length > 0) {
-					const localCommits = localOnly.stdout.split("\n").filter(Boolean);
-					if (localCommits.length > 0) {
-						ctx.ui.notify(`⚠️ Local branch \`${headBranch}\` has ${localCommits.length} commit(s) not in \`${baseBranch}\`:\n${localCommits.map(c => `  ${c}`).join("\n")}`, "warning");
+		//
+		// If the head branch is checked out in a worktree, we can't delete it —
+		// the worktree must be removed first. Warn and skip.
+		const headWorktree = await findWorktreeForBranch(headBranch, cwd);
+		if (headWorktree) {
+			ctx.ui.notify(`⚠️ Branch \`${headBranch}\` is checked out in worktree at \`${headWorktree}\`. Remove the worktree first to delete the branch: \`git worktree remove ${headWorktree}\``, "warning");
+		} else {
+			const nowOn = await getCurrentBranch(cwd);
+			if (nowOn !== headBranch) {
+				// Guard: warn about local-only commits before force-deleting.
+				// Only warn for true merge strategy where SHAs are preserved.
+				// Squash/rebase always diverge (different SHAs), so just log at debug level.
+				if (strategy === "merge") {
+					const localOnly = await gitExec(["log", `${baseBranch}..${headBranch}`, "--oneline"], cwd);
+					if (localOnly.ok && localOnly.stdout.trim().length > 0) {
+						const localCommits = localOnly.stdout.split("\n").filter(Boolean);
+						if (localCommits.length > 0) {
+							ctx.ui.notify(`⚠️ Local branch \`${headBranch}\` has ${localCommits.length} commit(s) not in \`${baseBranch}\`:\n${localCommits.map(c => `  ${c}`).join("\n")}`, "warning");
+						}
 					}
+				} else {
+					log("pr-merge-local-commits", { prNumber, headBranch, baseBranch, strategy, note: "skipped local-only check (squash/rebase SHAs diverge)" });
 				}
-			} else {
-				log("pr-merge-local-commits", { prNumber, headBranch, baseBranch, strategy, note: "skipped local-only check (squash/rebase SHAs diverge)" });
-			}
 
-			const localDelete = await gitExec(["branch", "-D", headBranch], cwd);
-			if (localDelete.ok) {
-				ctx.ui.notify(`🗑️ Deleted local branch \`${headBranch}\`.`, "info");
-			} else if (localDelete.stderr.includes("not found")) {
-				// Branch doesn't exist locally — fine
-			} else {
-				errors.push(`Could not delete local branch \`${headBranch}\` (branch is still safe): ${localDelete.stderr}`);
+				const localDelete = await gitExec(["branch", "-D", headBranch], cwd);
+				if (localDelete.ok) {
+					ctx.ui.notify(`🗑️ Deleted local branch \`${headBranch}\`.`, "info");
+				} else if (localDelete.stderr.includes("not found")) {
+					// Branch doesn't exist locally — fine
+				} else {
+					errors.push(`Could not delete local branch \`${headBranch}\` (branch is still safe): ${localDelete.stderr}`);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

`/gh-pr-fix` and `/gh-pr-merge` fail when the target branch is checked out in a git worktree:

```
❌ Could not checkout branch `fix/memory-tools`: fatal: 'fix/memory-tools' is already used by worktree at '/Users/espen/Dev/pilot-wt-memory'
```

## Changes

### `gh.ts` — new helper
- `findWorktreeForBranch(branch, cwd)` — parses `git worktree list --porcelain` to find worktree path for a branch

### `pr-fix.ts`
- Detects worktree → uses its path as working directory instead of failing on checkout
- Pulls latest from origin (ff-only) before presenting review feedback, so fixes are based on latest remote state

### `pr-merge.ts` cleanup
- Base branch in worktree → pulls there instead of failing on checkout
- Head branch in worktree → warns with `git worktree remove` instructions instead of failing on `branch -D`

Closes td-525890