### PR TITLE
fix: retry git operations on lock errors in pr-merge cleanup

### DIFF
--- a/extensions/pi-github/src/gh.ts
+++ b/extensions/pi-github/src/gh.ts
@@ -97,7 +97,7 @@ export async function gitExecRetry(
 		const result = await gitExec(args, cwd, timeoutMs);
 		if (result.ok) return result;
 
-		const isLockError = result.stderr.includes("index.lock") || result.stderr.includes("Unable to create") && result.stderr.includes(".lock");
+		const isLockError = result.stderr.includes("index.lock") || (result.stderr.includes("Unable to create") && result.stderr.includes(".lock"));
 		if (!isLockError || attempt === maxRetries) return result;
 
 		await new Promise((resolve) => setTimeout(resolve, delayMs));

--- a/extensions/pi-github/src/gh.ts
+++ b/extensions/pi-github/src/gh.ts
@@ -81,6 +81,32 @@ export function gitExec(args: string[], cwd: string, timeoutMs = 15_000): Promis
 	});
 }
 
+/**
+ * Run a git command with retries on lock errors.
+ * Git operations can fail transiently when an IDE or file watcher holds
+ * .git/index.lock. Retries up to `maxRetries` times with a short sleep.
+ */
+export async function gitExecRetry(
+	args: string[],
+	cwd: string,
+	opts?: { timeoutMs?: number; maxRetries?: number; delayMs?: number },
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+	const { timeoutMs = 15_000, maxRetries = 3, delayMs = 500 } = opts ?? {};
+
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		const result = await gitExec(args, cwd, timeoutMs);
+		if (result.ok) return result;
+
+		const isLockError = result.stderr.includes("index.lock") || result.stderr.includes("Unable to create") && result.stderr.includes(".lock");
+		if (!isLockError || attempt === maxRetries) return result;
+
+		await new Promise((resolve) => setTimeout(resolve, delayMs));
+	}
+
+	// Unreachable, but satisfies TS
+	return { ok: false, stdout: "", stderr: "retry exhausted" };
+}
+
 /** Get the current git branch name. */
 export async function getCurrentBranch(cwd?: string): Promise<string | null> {
 	return new Promise((resolve) => {

--- a/extensions/pi-github/src/pr-merge.ts
+++ b/extensions/pi-github/src/pr-merge.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { gh, ghJson, gitExec, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
+import { gh, ghJson, gitExec, gitExecRetry, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
 import { registerDualCommand } from "./commands.ts";
 import { extractRepoRef, resolveRepo, repoFlag } from "./repo-ref.ts";
 
@@ -211,7 +211,7 @@ async function cleanupBranches(
 	if (currentBranch === baseBranch) {
 		onBaseBranch = true;
 	} else {
-		const checkout = await gitExec(["checkout", baseBranch], cwd);
+		const checkout = await gitExecRetry(["checkout", baseBranch], cwd);
 		if (checkout.ok) {
 			onBaseBranch = true;
 		} else {
@@ -228,7 +228,7 @@ async function cleanupBranches(
 	}
 
 	if (onBaseBranch) {
-		const pull = await gitExec(["pull", "--ff-only"], pullCwd, 30_000);
+		const pull = await gitExecRetry(["pull", "--ff-only"], pullCwd, { timeoutMs: 30_000 });
 		if (pull.ok) {
 			ctx.ui.notify(`⬇️ Pulled latest \`${baseBranch}\`.`, "info");
 		} else {
@@ -262,7 +262,7 @@ async function cleanupBranches(
 					log("pr-merge-local-commits", { prNumber, headBranch, baseBranch, strategy, note: "skipped local-only check (squash/rebase SHAs diverge)" });
 				}
 
-				const localDelete = await gitExec(["branch", "-D", headBranch], cwd);
+				const localDelete = await gitExecRetry(["branch", "-D", headBranch], cwd);
 				if (localDelete.ok) {
 					ctx.ui.notify(`🗑️ Deleted local branch \`${headBranch}\`.`, "info");
 				} else if (localDelete.stderr.includes("not found")) {


### PR DESCRIPTION
Git operations in cleanupBranches (checkout, pull, branch -D) can fail
transiently when an IDE or file watcher holds .git/index.lock.

Add gitExecRetry() helper that detects lock errors and retries up to 3
times with 500ms delay between attempts. Applied to the three lock-prone
operations in the post-merge branch cleanup flow.
