### PR TITLE
feat(pi-channels): check env vars before settings.json for secrets

### DIFF
--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -6,12 +6,18 @@
  *   - envelope (default): { text, source, metadata, timestamp }
  *   - raw: send rawBody as-is (string) or JSON-serialized (non-string)
  *
+ * Authentication:
+ *   - Explicit headers config takes priority.
+ *   - If no Authorization header is set, the `secret` config field (or
+ *     WEBHOOK_SECRET env var) is used as a Bearer token automatically.
+ *
  * Config:
  * {
  *   "type": "webhook",
  *   "method": "POST",
  *   "contentType": "application/json",
  *   "payloadMode": "envelope",
+ *   "secret": "your-secret-or-use-WEBHOOK_SECRET-env-var",
  *   "headers": { "Authorization": "Bearer ..." }
  * }
  */
@@ -21,8 +27,17 @@ import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelPayloadMode 
 export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
 	const defaultMethod = (config.method as string) ?? "POST";
 	const defaultContentType = (config.contentType as string) ?? "application/json";
-	const extraHeaders = (config.headers as Record<string, string>) ?? {};
+	const configHeaders = (config.headers as Record<string, string>) ?? {};
+	const secret = config.secret as string | undefined;
 	const defaultPayloadMode: ChannelPayloadMode = config.payloadMode === "raw" ? "raw" : "envelope";
+
+	// Build effective headers: if no Authorization header is explicitly set and a
+	// secret is available (from config or WEBHOOK_SECRET env var), add Bearer auth.
+	const hasAuthHeader = Object.keys(configHeaders).some(k => k.toLowerCase() === "authorization");
+	const extraHeaders: Record<string, string> = { ...configHeaders };
+	if (!hasAuthHeader && secret) {
+		extraHeaders["Authorization"] = `Bearer ${secret}`;
+	}
 
 	return {
 		direction: "outgoing" as const,

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -5,6 +5,10 @@
  * which merges global (~/.pi/agent/settings.json) and project
  * (.pi/settings.json) configs automatically.
  *
+ * Environment variable overrides (checked first, before settings.json):
+ *   - TELEGRAM_BOT_TOKEN → adapters.telegram.botToken
+ *   - WEBHOOK_SECRET     → adapters.webhook.secret
+ *
  * Example settings.json:
  * {
  *   "pi-channels": {
@@ -58,7 +62,39 @@ export function loadConfig(cwd: string): ChannelConfig {
 		} as ChannelConfig["bridge"],
 	};
 
+	// Env vars override settings.json values
+	applyEnvOverrides(merged);
+
 	return merged;
+}
+
+/**
+ * Apply environment variable overrides to the merged config.
+ *
+ * Checked before settings.json — if the env var is set, it wins.
+ *
+ *   TELEGRAM_BOT_TOKEN → adapters.telegram.botToken
+ *   WEBHOOK_SECRET     → adapters.webhook.secret
+ *
+ * Adapter entries are auto-created with a default type if they don't already exist
+ * in settings, so you can run purely from env vars without any settings.json config.
+ */
+function applyEnvOverrides(config: ChannelConfig): void {
+	const telegramToken = process.env.TELEGRAM_BOT_TOKEN;
+	if (telegramToken) {
+		if (!config.adapters.telegram) {
+			config.adapters.telegram = { type: "telegram" };
+		}
+		config.adapters.telegram.botToken = telegramToken;
+	}
+
+	const webhookSecret = process.env.WEBHOOK_SECRET;
+	if (webhookSecret) {
+		if (!config.adapters.webhook) {
+			config.adapters.webhook = { type: "webhook" };
+		}
+		config.adapters.webhook.secret = webhookSecret;
+	}
 }
 
 /**

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -5,7 +5,7 @@
  * which merges global (~/.pi/agent/settings.json) and project
  * (.pi/settings.json) configs automatically.
  *
- * Environment variable overrides (checked first, before settings.json):
+ * Environment variable overrides (highest priority, override settings.json):
  *   - TELEGRAM_BOT_TOKEN → adapters.telegram.botToken
  *   - WEBHOOK_SECRET     → adapters.webhook.secret
  *
@@ -71,7 +71,7 @@ export function loadConfig(cwd: string): ChannelConfig {
 /**
  * Apply environment variable overrides to the merged config.
  *
- * Checked before settings.json — if the env var is set, it wins.
+ * Env vars take highest priority, overriding any value from settings.json.
  *
  *   TELEGRAM_BOT_TOKEN → adapters.telegram.botToken
  *   WEBHOOK_SECRET     → adapters.webhook.secret


### PR DESCRIPTION
TELEGRAM_BOT_TOKEN env var overrides adapters.telegram.botToken.
WEBHOOK_SECRET env var overrides adapters.webhook.secret, used as
Bearer token in Authorization header when no explicit header is set.

Adapter entries are auto-created if they don't exist in settings,
so the extension can be configured purely via env vars.
