### PR TITLE
feat(pi-channels): use pi's built-in OpenAI auth for transcription

### DIFF
--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- OpenAI transcription now automatically uses pi's built-in OpenAI authentication if available (no need for explicit `apiKey` in config)
+- Users who have run `/login openai` can enable transcription without additional configuration
+
+### Changed
+
+- **BREAKING:** Environment variables referenced via `"env:VAR_NAME"` now require `PI_` prefix for security (e.g. `"env:PI_TELEGRAM_BOT_TOKEN"`)
+- Adapter factories are now async to support modelRegistry API key resolution
+- Transcription providers use static `create()` factory methods instead of constructors
+
+### Security
+
+- Enforce `PI_` prefix for environment variables to prevent accidental exposure of system-wide credentials
+
 ## [0.1.1] - 2026-02-19 (7442720)
 
 ### Added

--- a/extensions/pi-channels/README.md
+++ b/extensions/pi-channels/README.md
@@ -39,7 +39,11 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
 }
 ```
 
-Use `"env:VAR_NAME"` to reference environment variables. Project settings override global ones.
+**Environment variables:**
+- Use `"env:PI_VAR_NAME"` to reference environment variables
+- All environment variables **must** start with `PI_` prefix for security
+- Example: `"env:PI_TELEGRAM_BOT_TOKEN"` resolves to `process.env.PI_TELEGRAM_BOT_TOKEN`
+- Project settings override global ones
 
 ### Adapter types
 
@@ -51,6 +55,38 @@ Use `"env:VAR_NAME"` to reference environment variables. Project settings overri
 
 > Webhook migration note: custom `Content-Type` should be set via `contentType`.
 > If both `contentType` and `headers["Content-Type"]` are provided, `contentType` wins.
+
+### Transcription (Voice & Audio)
+
+The Telegram adapter supports transcribing voice messages and audio files. Add to the telegram adapter config:
+
+```json
+{
+  "telegram": {
+    "type": "telegram",
+    "botToken": "env:PI_TELEGRAM_BOT_TOKEN",
+    "transcription": {
+      "enabled": true,
+      "provider": "openai"
+    }
+  }
+}
+```
+
+**Providers:**
+
+| Provider | Requirements | Notes |
+|----------|--------------|-------|
+| `apple` | macOS only | Free, offline, uses SFSpeechRecognizer. No API key needed. |
+| `openai` | OpenAI API key | **Automatically uses pi's built-in OpenAI authentication** if you've run `/login openai`. No explicit `apiKey` needed! Override with `apiKey: "env:PI_OPENAI_API_KEY"` if you want to use a separate key. |
+| `elevenlabs` | ElevenLabs API key | Requires `apiKey: "env:PI_ELEVENLABS_API_KEY"` in config. |
+
+**Transcription options:**
+- `enabled` — Enable transcription (default: `false`)
+- `provider` — `"apple"`, `"openai"`, or `"elevenlabs"` (required)
+- `apiKey` — For OpenAI: **optional** (uses pi's auth). For ElevenLabs: required as `"env:PI_*"`.
+- `model` — Model name, e.g. `"whisper-1"` (OpenAI), `"scribe_v1"` (ElevenLabs)
+- `language` — ISO 639-1 code, e.g. `"en"`, `"no"` (optional)
 
 ### Bridge settings
 

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -45,6 +45,7 @@ import type {
 	AdapterConfig,
 	OnIncomingMessage,
 } from "../types.ts";
+import type { AdapterFactoryContext } from "../registry.ts";
 import { getChannelSetting } from "../config.ts";
 
 const MAX_LENGTH = 3000; // Slack block text limit; actual API limit is 4000 but leave margin
@@ -86,7 +87,8 @@ interface SlackCommandPayload {
 
 export type SlackAdapterLogger = (event: string, data: Record<string, unknown>, level?: string) => void;
 
-export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: SlackAdapterLogger): ChannelAdapter {
+export async function createSlackAdapter(config: AdapterConfig, context: AdapterFactoryContext): Promise<ChannelAdapter> {
+	const { cwd, log } = context;
 	// Tokens live in settings under pi-channels.slack (not in the adapter config block)
 	const appToken = (cwd ? getChannelSetting(cwd, "slack.appToken") as string : null)
 		?? config.appToken as string;

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -37,6 +37,7 @@ import type {
 	IncomingAttachment,
 	TranscriptionConfig,
 } from "../types.ts";
+import type { AdapterFactoryContext } from "../registry.ts";
 import { createTranscriptionProvider, type TranscriptionProvider } from "./transcription.ts";
 
 const MAX_LENGTH = 4096;
@@ -100,7 +101,7 @@ function isTextDocument(mimeType: string | undefined, filename: string | undefin
 	return false;
 }
 
-export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
+export async function createTelegramAdapter(config: AdapterConfig, context: AdapterFactoryContext): Promise<ChannelAdapter> {
 	const botToken = config.botToken as string;
 	const parseMode = config.parseMode as string | undefined;
 	const pollingEnabled = config.polling === true;
@@ -117,7 +118,7 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 	let transcriberError: string | null = null;
 	if (transcriptionConfig?.enabled) {
 		try {
-			transcriber = createTranscriptionProvider(transcriptionConfig);
+			transcriber = await createTranscriptionProvider(transcriptionConfig, context.modelRegistry);
 		} catch (err: any) {
 			transcriberError = err.message ?? "Unknown transcription config error";
 			console.error(`[pi-channels] Transcription config error: ${transcriberError}`);

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -14,6 +14,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFile } from "node:child_process";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { TranscriptionConfig } from "../types.ts";
 
 // ── Public interface ────────────────────────────────────────────
@@ -28,15 +29,22 @@ export interface TranscriptionProvider {
 	transcribe(filePath: string, language?: string): Promise<TranscriptionResult>;
 }
 
-/** Create a transcription provider from config. */
-export function createTranscriptionProvider(config: TranscriptionConfig): TranscriptionProvider {
+/**
+ * Create a transcription provider from config.
+ * If modelRegistry is provided, OpenAI provider will use pi's built-in
+ * authentication instead of requiring explicit API keys in config.
+ */
+export async function createTranscriptionProvider(
+	config: TranscriptionConfig,
+	modelRegistry?: ModelRegistry
+): Promise<TranscriptionProvider> {
 	switch (config.provider) {
 		case "apple":
 			return new AppleProvider(config);
 		case "openai":
-			return new OpenAIProvider(config);
+			return await OpenAIProvider.create(config, modelRegistry);
 		case "elevenlabs":
-			return new ElevenLabsProvider(config);
+			return await ElevenLabsProvider.create(config, modelRegistry);
 		default:
 			throw new Error(`Unknown transcription provider: ${config.provider}`);
 	}
@@ -44,13 +52,40 @@ export function createTranscriptionProvider(config: TranscriptionConfig): Transc
 
 // ── Helpers ─────────────────────────────────────────────────────
 
-/** Resolve "env:VAR_NAME" patterns to actual environment variable values. */
-function resolveEnvValue(value: string | undefined): string | undefined {
-	if (!value) return undefined;
+/**
+ * Resolve API key from config value.
+ * Priority:
+ * 1. If no value provided and modelRegistry available → use pi's built-in auth
+ * 2. "env:PI_VAR_NAME" → environment variable (PI_ prefix required for security)
+ * 3. Plain string → literal value
+ */
+async function resolveApiKey(
+	value: string | undefined,
+	provider: string,
+	modelRegistry?: ModelRegistry
+): Promise<string | undefined> {
+	// No explicit config → try pi's built-in authentication
+	if (!value) {
+		if (modelRegistry) {
+			const key = await modelRegistry.getApiKeyForProvider(provider);
+			if (key) return key;
+		}
+		return undefined;
+	}
+
+	// "env:PI_VAR_NAME" → use environment variable with PI_ prefix requirement
 	if (value.startsWith("env:")) {
 		const envVar = value.slice(4);
+		if (!envVar.startsWith("PI_")) {
+			throw new Error(
+				`Environment variable must start with PI_ prefix (got: ${envVar}). ` +
+				`Use "env:PI_${envVar}" instead.`
+			);
+		}
 		return process.env[envVar] || undefined;
 	}
+
+	// Plain value
 	return value;
 }
 
@@ -196,12 +231,24 @@ class OpenAIProvider implements TranscriptionProvider {
 	private model: string;
 	private language: string | undefined;
 
-	constructor(config: TranscriptionConfig) {
-		const key = resolveEnvValue(config.apiKey);
-		if (!key) throw new Error("OpenAI transcription requires apiKey");
-		this.apiKey = key;
-		this.model = config.model || "whisper-1";
-		this.language = config.language;
+	private constructor(apiKey: string, model: string, language?: string) {
+		this.apiKey = apiKey;
+		this.model = model;
+		this.language = language;
+	}
+
+	static async create(
+		config: TranscriptionConfig,
+		modelRegistry?: ModelRegistry
+	): Promise<OpenAIProvider> {
+		const key = await resolveApiKey(config.apiKey, "openai", modelRegistry);
+		if (!key) {
+			throw new Error(
+				"OpenAI transcription requires API key. " +
+				"Either configure OpenAI in pi (run: /login openai) or set apiKey in transcription config."
+			);
+		}
+		return new OpenAIProvider(key, config.model || "whisper-1", config.language);
 	}
 
 	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {
@@ -247,12 +294,24 @@ class ElevenLabsProvider implements TranscriptionProvider {
 	private model: string;
 	private language: string | undefined;
 
-	constructor(config: TranscriptionConfig) {
-		const key = resolveEnvValue(config.apiKey);
-		if (!key) throw new Error("ElevenLabs transcription requires apiKey");
-		this.apiKey = key;
-		this.model = config.model || "scribe_v1";
-		this.language = config.language;
+	private constructor(apiKey: string, model: string, language?: string) {
+		this.apiKey = apiKey;
+		this.model = model;
+		this.language = language;
+	}
+
+	static async create(
+		config: TranscriptionConfig,
+		modelRegistry?: ModelRegistry
+	): Promise<ElevenLabsProvider> {
+		const key = await resolveApiKey(config.apiKey, "elevenlabs", modelRegistry);
+		if (!key) {
+			throw new Error(
+				"ElevenLabs transcription requires API key. " +
+				"Set apiKey in config as 'env:PI_ELEVENLABS_API_KEY'."
+			);
+		}
+		return new ElevenLabsProvider(key, config.model || "scribe_v1", config.language);
 	}
 
 	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {

--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -17,8 +17,9 @@
  */
 
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelPayloadMode } from "../types.ts";
+import type { AdapterFactoryContext } from "../registry.ts";
 
-export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
+export async function createWebhookAdapter(config: AdapterConfig, _context: AdapterFactoryContext): Promise<ChannelAdapter> {
 	const defaultMethod = (config.method as string) ?? "POST";
 	const defaultContentType = (config.contentType as string) ?? "application/json";
 	const extraHeaders = (config.headers as Record<string, string>) ?? {};

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -65,7 +65,8 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		const config = loadConfig(ctx.cwd);
-		registry.loadConfig(config, ctx.cwd);
+		registry.setModelRegistry(ctx.modelRegistry);
+		await registry.loadConfig(config, ctx.cwd);
 
 		const errors = registry.getErrors();
 		for (const err of errors) {

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -2,6 +2,7 @@
  * pi-channels — Adapter registry + route resolution.
  */
 
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelConfig, AdapterDirection, OnIncomingMessage, IncomingMessage } from "./types.ts";
 import { createTelegramAdapter } from "./adapters/telegram.ts";
 import { createWebhookAdapter } from "./adapters/webhook.ts";
@@ -11,7 +12,13 @@ import { createSlackAdapter } from "./adapters/slack.ts";
 
 export type AdapterLogger = (event: string, data: Record<string, unknown>, level?: string) => void;
 
-type AdapterFactory = (config: AdapterConfig, cwd?: string, log?: AdapterLogger) => ChannelAdapter;
+export interface AdapterFactoryContext {
+	cwd?: string;
+	log?: AdapterLogger;
+	modelRegistry?: ModelRegistry;
+}
+
+type AdapterFactory = (config: AdapterConfig, context: AdapterFactoryContext) => Promise<ChannelAdapter>;
 
 const builtinFactories: Record<string, AdapterFactory> = {
 	telegram: createTelegramAdapter,
@@ -27,6 +34,7 @@ export class ChannelRegistry {
 	private errors: Array<{ adapter: string; error: string }> = [];
 	private onIncoming: OnIncomingMessage = () => {};
 	private log?: AdapterLogger;
+	private modelRegistry?: ModelRegistry;
 
 	/**
 	 * Set the callback for incoming messages (called by the extension entry).
@@ -43,10 +51,17 @@ export class ChannelRegistry {
 	}
 
 	/**
+	 * Set the model registry for API key resolution.
+	 */
+	setModelRegistry(modelRegistry: ModelRegistry): void {
+		this.modelRegistry = modelRegistry;
+	}
+
+	/**
 	 * Load adapters + routes from config. Custom adapters (registered via events) are preserved.
 	 * @param cwd — working directory, passed to adapter factories for settings resolution.
 	 */
-	loadConfig(config: ChannelConfig, cwd?: string): void {
+	async loadConfig(config: ChannelConfig, cwd?: string): Promise<void> {
 		this.errors = [];
 
 		// Stop existing adapters
@@ -77,7 +92,12 @@ export class ChannelRegistry {
 				continue;
 			}
 			try {
-				this.adapters.set(name, factory(adapterConfig, cwd, this.log));
+				const adapter = await factory(adapterConfig, {
+					cwd,
+					log: this.log,
+					modelRegistry: this.modelRegistry,
+				});
+				this.adapters.set(name, adapter);
 			} catch (err: any) {
 				this.errors.push({ adapter: name, error: err.message });
 			}

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -55,11 +55,15 @@ export interface TranscriptionConfig {
 	/**
 	 * Transcription provider:
 	 * - "apple"      — macOS SFSpeechRecognizer (free, offline, no API key)
-	 * - "openai"     — Whisper API
-	 * - "elevenlabs" — Scribe API
+	 * - "openai"     — Whisper API (uses pi's built-in auth if available, or explicit apiKey)
+	 * - "elevenlabs" — Scribe API (requires explicit apiKey)
 	 */
 	provider: "apple" | "openai" | "elevenlabs";
-	/** API key for cloud providers (supports env:VAR_NAME). Not needed for apple. */
+	/**
+	 * API key for cloud providers. Optional for OpenAI if pi has authentication configured.
+	 * Supports "env:PI_VAR_NAME" for environment variables (PI_ prefix required).
+	 * Not needed for apple provider.
+	 */
 	apiKey?: string;
 	/** Model name (e.g. "whisper-1", "scribe_v1"). Provider-specific default used if omitted. */
 	model?: string;


### PR DESCRIPTION
BREAKING CHANGE: Environment variables now require PI_ prefix

- Transcription: OpenAI provider automatically uses pi's modelRegistry
  for authentication (no apiKey needed if /login openai was run)
- Adapter factories are now async to support API key resolution
- All env vars must use PI_ prefix: env:PI_TELEGRAM_BOT_TOKEN
- Transcription providers use static create() factory pattern
- ElevenLabs still requires explicit env:PI_ELEVENLABS_API_KEY

Benefits:
- Users with OpenAI configured in pi get transcription for free
- Better integration with pi's auth system
- Prevents accidental exposure of system-wide credentials
