### PR TITLE
fix(pi-td): align tool with td CLI — add missing actions, auto-retry, docs

### DIFF
--- a/extensions/pi-td/AGENTS.md
+++ b/extensions/pi-td/AGENTS.md
@@ -26,18 +26,29 @@ Extension that wraps the `td` CLI as a structured LLM tool, enforces mandatory t
 
 | Group | Actions |
 |-------|---------|
-| **Query** | `status`, `list`, `show`, `ready`, `next`, `reviewable` |
+| **Query** | `status`, `list`, `show`, `ready`, `next`, `reviewable`, `search` |
 | **Lifecycle** | `create`, `start`, `log`, `handoff`, `review`, `approve`, `reject`, `close` |
+| **Modify** | `update`, `delete` |
+| **Focus** | `focus`, `unfocus` |
 | **Other** | `block`, `unblock`, `reopen`, `comment` |
 
 ### Key parameters
 
 - `id` — Required for most lifecycle/query actions (format: `td-abc123`)
-- `title`, `type` (task/bug/feature/epic/chore), `priority` (P0–P4) — for `create`
+- `title`, `type` (task/bug/feature/epic/chore), `priority` (P0–P4) — for `create` and `update`
 - `minor: true` — marks task as minor; enables self-review via `approve`
 - `done`, `remaining`, `decisions`, `uncertain` — arrays for `handoff`
 - `log_type` — progress/blocker/decision/hypothesis/tried/result for `log`
-- `show_all`, `filter_type`, `filter_priority`, `filter_status` — for `list`
+- `show_all`, `filter_type`, `filter_priority`, `filter_status`, `filter_labels`, `filter_mine`, `filter_epic` — for `list`
+- `query` — search text for `search` action or `--search` filter on `list`
+- `sort`, `limit` — result ordering and pagination for `list`/`search`
+- `self_close` — allow closing own implemented work (for `close` action)
+- `reason` — optional for `approve`, `reject`, `close`, `block`
+
+### Auto-retry behavior
+
+- `approve` and `reject` auto-create a new review session (`td session --new`) and retry when td reports "cannot approve/reject" (same session as implementer).
+- `close` supports `self_close: true` which maps to `--self-close-exception` for closing own work.
 
 ### System prompt injection
 
@@ -99,5 +110,5 @@ When `crossProjectRoot` is configured, the dashboard shows tasks from all projec
 - No direct SQLite — all task data lives in the `td` CLI's `.todos` folder. Extension only shells out to `td`.
 - `sessionCwd` is updated on `session_switch` and `session_fork` — always use `getCwd()` in tool handlers.
 - `td` stdout starting with `ERROR:` or `Warning: cannot` is treated as an error even on exit code 0.
-- Approve/reject handlers auto-create a review session (`td session --new`) if td reports "cannot approve/reject".
+- Both the tool and REST API approve/reject handlers auto-create a review session (`td session --new`) if td reports "cannot approve/reject".
 - No console.log — errors surface through tool result strings.

--- a/extensions/pi-td/README.md
+++ b/extensions/pi-td/README.md
@@ -71,8 +71,18 @@ Enable `webui: true` in settings, start the web server with `/web`, then open `h
 
 ## Requirements
 
-- `td` CLI in `$PATH`
+- [`td` CLI](https://github.com/marcus/td) in `$PATH` — a local-first task management CLI for AI-assisted development workflows
 - [`pi-webserver`](../pi-webserver) extension (only needed for web UI)
+
+### Installing td
+
+```bash
+# With Go installed:
+go install github.com/marcus/td@latest
+
+# Verify:
+td --version
+```
 
 ## Install
 

--- a/extensions/pi-td/README.md
+++ b/extensions/pi-td/README.md
@@ -37,11 +37,12 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
 | Action | Required params | Description |
 |--------|----------------|-------------|
 | `status` | — | Current session and task summary |
-| `list` | — | List open issues (filterable by type/priority/status) |
+| `list` | — | List open issues (filterable by type/priority/status/labels/epic) |
 | `show` | `id` | Show full issue detail |
 | `ready` | — | Issues ready to start |
 | `next` | — | Best next issue to work on |
 | `reviewable` | — | Issues awaiting review |
+| `search` | `query` | Full-text search across issues |
 
 ### Lifecycle actions
 
@@ -51,10 +52,24 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
 | `start` | `id` | Mark in-progress |
 | `log` | `message` | Add a progress log entry (`log_type`: progress/blocker/decision/hypothesis/tried/result) |
 | `handoff` | `id` | Record handoff (`done`, `remaining`, `decisions`, `uncertain`) |
-| `review` | `id` | Submit for review |
-| `approve` | `id` | Approve and close |
-| `reject` | `id`, `reason` | Reject with reason |
-| `close` | `id` | Close task |
+| `review` | `id` | Submit for review (`minor` to allow self-review) |
+| `approve` | `id` | Approve and close (auto-creates review session if needed) |
+| `reject` | `id` | Reject with optional `reason` (auto-creates review session if needed) |
+| `close` | `id` | Close task (`self_close: true` to close own work) |
+
+### Modify actions
+
+| Action | Required params | Description |
+|--------|----------------|-------------|
+| `update` | `id` | Update task fields (`title`, `type`, `priority`, `description`, `labels`, `parent`) |
+| `delete` | `id` | Soft-delete an issue |
+
+### Focus actions
+
+| Action | Required params | Description |
+|--------|----------------|-------------|
+| `focus` | `id` | Set current working issue (without starting) |
+| `unfocus` | — | Clear focus |
 
 ### Other actions
 
@@ -64,6 +79,21 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
 | `unblock` | `id` | Remove blocked status |
 | `reopen` | `id` | Reopen a closed issue |
 | `comment` | `id`, `message` | Add a comment |
+
+### List/search filters
+
+| Parameter | Description |
+|-----------|-------------|
+| `show_all` | Include closed issues |
+| `filter_type` | Filter by issue type |
+| `filter_priority` | Filter by priority |
+| `filter_status` | Filter by status |
+| `filter_labels` | Filter by labels (comma-separated) |
+| `filter_mine` | Show only issues assigned to current session |
+| `filter_epic` | Filter by parent epic ID |
+| `sort` | Sort by field (e.g. priority, created, updated) |
+| `limit` | Max number of results |
+| `query` | Search text (for `search` action, or `--search` filter for `list`) |
 
 ## Web UI
 

--- a/extensions/pi-td/src/tool.ts
+++ b/extensions/pi-td/src/tool.ts
@@ -102,6 +102,12 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 			decisions: Type.Optional(Type.Array(Type.String(), { description: "Key decisions made" })),
 			uncertain: Type.Optional(Type.Array(Type.String(), { description: "Open questions" })),
 
+			// Update fields
+			status: Type.Optional(StringEnum(
+				["open", "in_progress", "in_review", "blocked", "closed"] as const,
+				{ description: "New status (for update action)" },
+			)),
+
 			// Reject/close/approve fields
 			reason: Type.Optional(Type.String({ description: "Reason for reject/close/block/approve" })),
 			self_close: Type.Optional(Type.Boolean({ description: "Allow closing your own implemented work (for close action)" })),
@@ -277,9 +283,11 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 					case "close": {
 						if (!params.id) return text("❌ `id` is required for close.");
 						const args = ["close", params.id];
-						if (params.reason) args.push("--reason", params.reason);
 						if (params.self_close) {
+							// --self-close-exception takes the reason directly; don't also pass --reason
 							args.push("--self-close-exception", params.reason || "Agent self-close");
+						} else if (params.reason) {
+							args.push("--reason", params.reason);
 						}
 						const result = await exec(pi, args, cwd);
 						return text(result);
@@ -296,8 +304,8 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 						if (params.description) args.push("--description", params.description);
 						if (params.labels) args.push("--labels", params.labels);
 						if (params.parent) args.push("--parent", params.parent);
-						if (params.filter_status) args.push("--status", params.filter_status);
-						if (args.length === 2) return text("❌ No fields to update. Provide title, type, priority, description, labels, or parent.");
+						if (params.status) args.push("--status", params.status);
+						if (args.length === 2) return text("❌ No fields to update. Provide title, type, priority, description, labels, parent, or status.");
 						const result = await exec(pi, args, cwd);
 						return text(result);
 					}

--- a/extensions/pi-td/src/tool.ts
+++ b/extensions/pi-td/src/tool.ts
@@ -3,6 +3,8 @@
  *
  * Exposes td operations as a structured tool so the agent can
  * create, track, and manage tasks without raw bash commands.
+ *
+ * CLI reference: https://github.com/marcus/td
  */
 
 import { Type } from "@sinclair/typebox";
@@ -28,7 +30,7 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 				"3. `td({ action: \"start\", id: \"td-xxx\" })` — start the task\n" +
 				"4. Create a git feature branch: `git checkout -b <task-id>/<short-description>`\n" +
 				"5. Do the work, commit to the feature branch\n" +
-				"6. `td({ action: \"log\", id: \"td-xxx\", message: \"what you did\" })` — log progress\n" +
+				"6. `td({ action: \"log\", message: \"what you did\" })` — log progress (uses focused issue)\n" +
 				"7. `td({ action: \"handoff\", id: \"td-xxx\", done: [\"...\"] })` — record handoff\n" +
 				"8. Push branch and create PR: `git push origin <branch>` then `gh pr create --fill`\n" +
 				"9. `td({ action: \"review\", id: \"td-xxx\" })` — submit for review\n\n" +
@@ -41,8 +43,10 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 				"- **Always create a PR** after pushing the branch\n" +
 				"- **PR review fixes go on the PR branch** — don't create a new branch\n\n" +
 				"### Actions:\n" +
-				"- **Query:** status, list, show, ready, next, reviewable\n" +
+				"- **Query:** status, list, show, ready, next, reviewable, search\n" +
 				"- **Lifecycle:** create, start, log, handoff, review, approve, reject, close\n" +
+				"- **Modify:** update, delete\n" +
+				"- **Focus:** focus, unfocus\n" +
 				"- **Other:** block, unblock, reopen, comment\n",
 		};
 	});
@@ -56,9 +60,13 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 		parameters: Type.Object({
 			action: StringEnum([
 				// Query
-				"status", "list", "show", "ready", "next", "reviewable",
+				"status", "list", "show", "ready", "next", "reviewable", "search",
 				// Lifecycle
 				"create", "start", "log", "handoff", "review", "approve", "reject", "close",
+				// Modify
+				"update", "delete",
+				// Focus
+				"focus", "unfocus",
 				// Other
 				"block", "unblock", "reopen", "comment",
 			] as const, { description: "Task action to perform" }),
@@ -76,13 +84,13 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 				["P0", "P1", "P2", "P3", "P4"] as const,
 				{ description: "Priority: P0=critical, P1=high, P2=default, P3=low, P4=minimal" },
 			)),
-			description: Type.Optional(Type.String({ description: "Description (for create/comment)" })),
+			description: Type.Optional(Type.String({ description: "Description (for create/update)" })),
 			labels: Type.Optional(Type.String({ description: "Comma-separated labels" })),
 			parent: Type.Optional(Type.String({ description: "Parent epic ID" })),
 			minor: Type.Optional(Type.Boolean({ description: "Mark as minor task — allows self-review/approve" })),
 
 			// Log fields
-			message: Type.Optional(Type.String({ description: "Log message or comment text" })),
+			message: Type.Optional(Type.String({ description: "Log message, comment text, or reason" })),
 			log_type: Type.Optional(StringEnum(
 				["progress", "blocker", "decision", "hypothesis", "tried", "result"] as const,
 				{ description: "Log entry type (default: progress)" },
@@ -94,14 +102,21 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 			decisions: Type.Optional(Type.Array(Type.String(), { description: "Key decisions made" })),
 			uncertain: Type.Optional(Type.Array(Type.String(), { description: "Open questions" })),
 
-			// Reject/close fields
+			// Reject/close/approve fields
 			reason: Type.Optional(Type.String({ description: "Reason for reject/close/block/approve" })),
+			self_close: Type.Optional(Type.Boolean({ description: "Allow closing your own implemented work (for close action)" })),
 
-			// List filters
+			// List/search filters
 			show_all: Type.Optional(Type.Boolean({ description: "Include closed issues in list" })),
 			filter_type: Type.Optional(Type.String({ description: "Filter by issue type" })),
 			filter_priority: Type.Optional(Type.String({ description: "Filter by priority" })),
 			filter_status: Type.Optional(Type.String({ description: "Filter by status" })),
+			filter_labels: Type.Optional(Type.String({ description: "Filter by labels (comma-separated)" })),
+			filter_mine: Type.Optional(Type.Boolean({ description: "Show only issues assigned to current session" })),
+			filter_epic: Type.Optional(Type.String({ description: "Filter by parent epic ID" })),
+			query: Type.Optional(Type.String({ description: "Search query text (for search action)" })),
+			sort: Type.Optional(Type.String({ description: "Sort field (e.g. priority, created, updated)" })),
+			limit: Type.Optional(Type.Number({ description: "Limit number of results" })),
 		}),
 
 		execute: async (_toolCallId: string, params: any) => {
@@ -124,6 +139,12 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 						if (params.filter_type) args.push("--type", params.filter_type);
 						if (params.filter_priority) args.push("--priority", params.filter_priority);
 						if (params.filter_status) args.push("--status", params.filter_status);
+						if (params.filter_labels) args.push("--labels", params.filter_labels);
+						if (params.filter_mine) args.push("--mine");
+						if (params.filter_epic) args.push("--epic", params.filter_epic);
+						if (params.sort) args.push("--sort", params.sort);
+						if (params.limit) args.push("--limit", String(params.limit));
+						if (params.query) args.push("--search", params.query);
 						const result = await exec(pi, args, cwd);
 						return text(result);
 					}
@@ -147,6 +168,18 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 					case "reviewable": {
 						const result = await exec(pi, ["reviewable"], cwd);
 						return text(result || "No issues available for review.");
+					}
+
+					case "search": {
+						if (!params.query) return text("❌ `query` is required for search.");
+						const args = ["search", params.query];
+						if (params.filter_type) args.push("--type", params.filter_type);
+						if (params.filter_priority) args.push("--priority", params.filter_priority);
+						if (params.filter_status) args.push("--status", params.filter_status);
+						if (params.filter_labels) args.push("--labels", params.filter_labels);
+						if (params.limit) args.push("--limit", String(params.limit));
+						const result = await exec(pi, args, cwd);
+						return text(result || "No results found.");
 					}
 
 					// ── Lifecycle actions ─────────────────────
@@ -194,7 +227,10 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 
 					case "review": {
 						if (!params.id) return text("❌ `id` is required for review.");
-						const result = await exec(pi, ["review", params.id], cwd);
+						const args = ["review", params.id];
+						if (params.minor) args.push("--minor");
+						if (params.reason) args.push("--reason", params.reason);
+						const result = await exec(pi, args, cwd);
 						return text(result);
 					}
 
@@ -202,15 +238,39 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 						if (!params.id) return text("❌ `id` is required for approve.");
 						const args = ["approve", params.id];
 						if (params.reason) args.push("--reason", params.reason);
-						const result = await exec(pi, args, cwd);
+						// Auto-retry: if td says "cannot approve" (same session as implementer),
+						// create a new review session and retry.
+						let result: string;
+						try {
+							result = await exec(pi, args, cwd);
+						} catch (err: any) {
+							if (err.message?.includes("cannot approve")) {
+								await exec(pi, ["session", "--new"], cwd);
+								result = await exec(pi, args, cwd);
+							} else {
+								throw err;
+							}
+						}
 						return text(result);
 					}
 
 					case "reject": {
 						if (!params.id) return text("❌ `id` is required for reject.");
-						if (!params.reason) return text("❌ `reason` is required for reject.");
-						const args = ["reject", params.id, "--reason", params.reason];
-						const result = await exec(pi, args, cwd);
+						const args = ["reject", params.id];
+						if (params.reason) args.push("--reason", params.reason);
+						// Auto-retry: if td says "cannot reject" (same session as implementer),
+						// create a new review session and retry.
+						let result: string;
+						try {
+							result = await exec(pi, args, cwd);
+						} catch (err: any) {
+							if (err.message?.includes("cannot reject")) {
+								await exec(pi, ["session", "--new"], cwd);
+								result = await exec(pi, args, cwd);
+							} else {
+								throw err;
+							}
+						}
 						return text(result);
 					}
 
@@ -218,7 +278,46 @@ export function registerTdTool(pi: ExtensionAPI, getCwd: () => string): void {
 						if (!params.id) return text("❌ `id` is required for close.");
 						const args = ["close", params.id];
 						if (params.reason) args.push("--reason", params.reason);
+						if (params.self_close) {
+							args.push("--self-close-exception", params.reason || "Agent self-close");
+						}
 						const result = await exec(pi, args, cwd);
+						return text(result);
+					}
+
+					// ── Modify actions ────────────────────────
+
+					case "update": {
+						if (!params.id) return text("❌ `id` is required for update.");
+						const args = ["update", params.id];
+						if (params.title) args.push("--title", params.title);
+						if (params.type) args.push("--type", params.type);
+						if (params.priority) args.push("--priority", params.priority);
+						if (params.description) args.push("--description", params.description);
+						if (params.labels) args.push("--labels", params.labels);
+						if (params.parent) args.push("--parent", params.parent);
+						if (params.filter_status) args.push("--status", params.filter_status);
+						if (args.length === 2) return text("❌ No fields to update. Provide title, type, priority, description, labels, or parent.");
+						const result = await exec(pi, args, cwd);
+						return text(result);
+					}
+
+					case "delete": {
+						if (!params.id) return text("❌ `id` is required for delete.");
+						const result = await exec(pi, ["delete", params.id], cwd);
+						return text(result);
+					}
+
+					// ── Focus actions ─────────────────────────
+
+					case "focus": {
+						if (!params.id) return text("❌ `id` is required for focus.");
+						const result = await exec(pi, ["focus", params.id], cwd);
+						return text(result);
+					}
+
+					case "unfocus": {
+						const result = await exec(pi, ["unfocus"], cwd);
 						return text(result);
 					}
 


### PR DESCRIPTION
Fixes #50

The pi-td tool for LLM access had diverged from both the REST API handlers and the actual td CLI, causing frequent errors.

## Changes

### tool.ts — CLI alignment
- **approve/reject auto-retry**: creates a new review session (`td session --new`) and retries when td reports "cannot approve/reject" (same session as implementer). The REST API already did this but the tool didn't.
- **reject reason now optional**: was incorrectly forced as required; td CLI doesn't mandate it
- **close self_close param**: maps to `--self-close-exception` so agents can close their own work
- **review --minor flag**: mark tasks as minor at review time

### New actions
- **update** — change task fields after creation (title, type, priority, description, labels, parent)
- **delete** — soft-delete issues
- **search** — full-text search across issues
- **focus/unfocus** — manage working issue without starting

### New list/search filters
- `filter_labels`, `filter_mine`, `filter_epic`
- `sort`, `limit`, `query` (as `--search` filter on `list`)

### Documentation
- README: link to [github.com/marcus/td](https://github.com/marcus/td) with install instructions
- README: document all new actions, filters, and auto-retry behavior
- AGENTS.md: updated action groups table and key parameters