### PR TITLE
chore: remove env: var support from extensions, use settings.json directly

### DIFF
--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- OpenAI transcription now automatically uses pi's built-in OpenAI authentication if available (no need for explicit `apiKey` in config)
+- Users who have run `/login openai` can enable transcription without additional configuration
+
+### Changed
+
+- **BREAKING:** Environment variables referenced via `"env:VAR_NAME"` now require `PI_` prefix for security (e.g. `"env:PI_TELEGRAM_BOT_TOKEN"`)
+- Adapter factories are now async to support modelRegistry API key resolution
+- Transcription providers use static `create()` factory methods instead of constructors
+
+### Security
+
+- Enforce `PI_` prefix for environment variables to prevent accidental exposure of system-wide credentials
+
 ## [0.1.1] - 2026-02-19 (7442720)
 
 ### Added

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -14,13 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **BREAKING:** Environment variables referenced via `"env:VAR_NAME"` now require `PI_` prefix for security (e.g. `"env:PI_TELEGRAM_BOT_TOKEN"`)
+- **BREAKING:** `env:VAR_NAME` substitution in settings is no longer supported. Set secret values (tokens, API keys) directly in `settings.json` instead of using `"env:..."` references.
 - Adapter factories are now async to support modelRegistry API key resolution
 - Transcription providers use static `create()` factory methods instead of constructors
-
-### Security
-
-- Enforce `PI_` prefix for environment variables to prevent accidental exposure of system-wide credentials
 
 ## [0.1.1] - 2026-02-19 (7442720)
 

--- a/extensions/pi-channels/README.md
+++ b/extensions/pi-channels/README.md
@@ -39,7 +39,11 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
 }
 ```
 
-Use `"env:VAR_NAME"` to reference environment variables. Project settings override global ones.
+**Environment variables:**
+- Use `"env:PI_VAR_NAME"` to reference environment variables
+- All environment variables **must** start with `PI_` prefix for security
+- Example: `"env:PI_TELEGRAM_BOT_TOKEN"` resolves to `process.env.PI_TELEGRAM_BOT_TOKEN`
+- Project settings override global ones
 
 ### Adapter types
 
@@ -51,6 +55,38 @@ Use `"env:VAR_NAME"` to reference environment variables. Project settings overri
 
 > Webhook migration note: custom `Content-Type` should be set via `contentType`.
 > If both `contentType` and `headers["Content-Type"]` are provided, `contentType` wins.
+
+### Transcription (Voice & Audio)
+
+The Telegram adapter supports transcribing voice messages and audio files. Add to the telegram adapter config:
+
+```json
+{
+  "telegram": {
+    "type": "telegram",
+    "botToken": "env:PI_TELEGRAM_BOT_TOKEN",
+    "transcription": {
+      "enabled": true,
+      "provider": "openai"
+    }
+  }
+}
+```
+
+**Providers:**
+
+| Provider | Requirements | Notes |
+|----------|--------------|-------|
+| `apple` | macOS only | Free, offline, uses SFSpeechRecognizer. No API key needed. |
+| `openai` | OpenAI API key | **Automatically uses pi's built-in OpenAI authentication** if you've run `/login openai`. No explicit `apiKey` needed! Override with `apiKey: "env:PI_OPENAI_API_KEY"` if you want to use a separate key. |
+| `elevenlabs` | ElevenLabs API key | Requires `apiKey: "env:PI_ELEVENLABS_API_KEY"` in config. |
+
+**Transcription options:**
+- `enabled` — Enable transcription (default: `false`)
+- `provider` — `"apple"`, `"openai"`, or `"elevenlabs"` (required)
+- `apiKey` — For OpenAI: **optional** (uses pi's auth). For ElevenLabs: required as `"env:PI_*"`.
+- `model` — Model name, e.g. `"whisper-1"` (OpenAI), `"scribe_v1"` (ElevenLabs)
+- `language` — ISO 639-1 code, e.g. `"en"`, `"no"` (optional)
 
 ### Bridge settings
 

--- a/extensions/pi-channels/README.md
+++ b/extensions/pi-channels/README.md
@@ -21,12 +21,12 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
     "adapters": {
       "telegram": {
         "type": "telegram",
-        "botToken": "env:TELEGRAM_BOT_TOKEN",
+        "botToken": "your-telegram-bot-token",
         "polling": true
       },
       "alerts": {
         "type": "webhook",
-        "headers": { "Authorization": "env:WEBHOOK_SECRET" }
+        "headers": { "Authorization": "Bearer your-webhook-secret" }
       }
     },
     "routes": {
@@ -39,10 +39,8 @@ Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
 }
 ```
 
-**Environment variables:**
-- Use `"env:PI_VAR_NAME"` to reference environment variables
-- All environment variables **must** start with `PI_` prefix for security
-- Example: `"env:PI_TELEGRAM_BOT_TOKEN"` resolves to `process.env.PI_TELEGRAM_BOT_TOKEN`
+**Secrets:**
+- Set secret values (tokens, keys) directly in `settings.json`
 - Project settings override global ones
 
 ### Adapter types
@@ -64,7 +62,7 @@ The Telegram adapter supports transcribing voice messages and audio files. Add t
 {
   "telegram": {
     "type": "telegram",
-    "botToken": "env:PI_TELEGRAM_BOT_TOKEN",
+    "botToken": "your-telegram-bot-token",
     "transcription": {
       "enabled": true,
       "provider": "openai"
@@ -78,13 +76,13 @@ The Telegram adapter supports transcribing voice messages and audio files. Add t
 | Provider | Requirements | Notes |
 |----------|--------------|-------|
 | `apple` | macOS only | Free, offline, uses SFSpeechRecognizer. No API key needed. |
-| `openai` | OpenAI API key | **Automatically uses pi's built-in OpenAI authentication** if you've run `/login openai`. No explicit `apiKey` needed! Override with `apiKey: "env:PI_OPENAI_API_KEY"` if you want to use a separate key. |
-| `elevenlabs` | ElevenLabs API key | Requires `apiKey: "env:PI_ELEVENLABS_API_KEY"` in config. |
+| `openai` | OpenAI API key | **Automatically uses pi's built-in OpenAI authentication** if you've run `/login openai`. No explicit `apiKey` needed! Override with `apiKey` in config if you want to use a separate key. |
+| `elevenlabs` | ElevenLabs API key | Requires `apiKey` set directly in config. |
 
 **Transcription options:**
 - `enabled` — Enable transcription (default: `false`)
 - `provider` — `"apple"`, `"openai"`, or `"elevenlabs"` (required)
-- `apiKey` — For OpenAI: **optional** (uses pi's auth). For ElevenLabs: required as `"env:PI_*"`.
+- `apiKey` — For OpenAI: **optional** (uses pi's auth). For ElevenLabs: required (set directly in settings.json).
 - `model` — Model name, e.g. `"whisper-1"` (OpenAI), `"scribe_v1"` (ElevenLabs)
 - `language` — ISO 639-1 code, e.g. `"en"`, `"no"` (optional)
 

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -45,6 +45,7 @@ import type {
 	AdapterConfig,
 	OnIncomingMessage,
 } from "../types.ts";
+import type { AdapterFactoryContext } from "../registry.ts";
 import { getChannelSetting } from "../config.ts";
 
 const MAX_LENGTH = 3000; // Slack block text limit; actual API limit is 4000 but leave margin
@@ -86,7 +87,8 @@ interface SlackCommandPayload {
 
 export type SlackAdapterLogger = (event: string, data: Record<string, unknown>, level?: string) => void;
 
-export function createSlackAdapter(config: AdapterConfig, cwd?: string, log?: SlackAdapterLogger): ChannelAdapter {
+export async function createSlackAdapter(config: AdapterConfig, context: AdapterFactoryContext): Promise<ChannelAdapter> {
+	const { cwd, log } = context;
 	// Tokens live in settings under pi-channels.slack (not in the adapter config block)
 	const appToken = (cwd ? getChannelSetting(cwd, "slack.appToken") as string : null)
 		?? config.appToken as string;

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -37,6 +37,7 @@ import type {
 	IncomingAttachment,
 	TranscriptionConfig,
 } from "../types.ts";
+import type { AdapterFactoryContext } from "../registry.ts";
 import { createTranscriptionProvider, type TranscriptionProvider } from "./transcription.ts";
 
 const MAX_LENGTH = 4096;
@@ -100,7 +101,7 @@ function isTextDocument(mimeType: string | undefined, filename: string | undefin
 	return false;
 }
 
-export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
+export async function createTelegramAdapter(config: AdapterConfig, context: AdapterFactoryContext): Promise<ChannelAdapter> {
 	const botToken = config.botToken as string;
 	const parseMode = config.parseMode as string | undefined;
 	const pollingEnabled = config.polling === true;
@@ -117,7 +118,7 @@ export function createTelegramAdapter(config: AdapterConfig): ChannelAdapter {
 	let transcriberError: string | null = null;
 	if (transcriptionConfig?.enabled) {
 		try {
-			transcriber = createTranscriptionProvider(transcriptionConfig);
+			transcriber = await createTranscriptionProvider(transcriptionConfig, context.modelRegistry);
 		} catch (err: any) {
 			transcriberError = err.message ?? "Unknown transcription config error";
 			console.error(`[pi-channels] Transcription config error: ${transcriberError}`);

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -14,6 +14,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFile } from "node:child_process";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { TranscriptionConfig } from "../types.ts";
 
 // ── Public interface ────────────────────────────────────────────
@@ -28,15 +29,22 @@ export interface TranscriptionProvider {
 	transcribe(filePath: string, language?: string): Promise<TranscriptionResult>;
 }
 
-/** Create a transcription provider from config. */
-export function createTranscriptionProvider(config: TranscriptionConfig): TranscriptionProvider {
+/**
+ * Create a transcription provider from config.
+ * If modelRegistry is provided, OpenAI provider will use pi's built-in
+ * authentication instead of requiring explicit API keys in config.
+ */
+export async function createTranscriptionProvider(
+	config: TranscriptionConfig,
+	modelRegistry?: ModelRegistry
+): Promise<TranscriptionProvider> {
 	switch (config.provider) {
 		case "apple":
 			return new AppleProvider(config);
 		case "openai":
-			return new OpenAIProvider(config);
+			return await OpenAIProvider.create(config, modelRegistry);
 		case "elevenlabs":
-			return new ElevenLabsProvider(config);
+			return await ElevenLabsProvider.create(config, modelRegistry);
 		default:
 			throw new Error(`Unknown transcription provider: ${config.provider}`);
 	}
@@ -44,13 +52,40 @@ export function createTranscriptionProvider(config: TranscriptionConfig): Transc
 
 // ── Helpers ─────────────────────────────────────────────────────
 
-/** Resolve "env:VAR_NAME" patterns to actual environment variable values. */
-function resolveEnvValue(value: string | undefined): string | undefined {
-	if (!value) return undefined;
+/**
+ * Resolve API key from config value.
+ * Priority:
+ * 1. If no value provided and modelRegistry available → use pi's built-in auth
+ * 2. "env:PI_VAR_NAME" → environment variable (PI_ prefix required for security)
+ * 3. Plain string → literal value
+ */
+async function resolveApiKey(
+	value: string | undefined,
+	provider: string,
+	modelRegistry?: ModelRegistry
+): Promise<string | undefined> {
+	// No explicit config → try pi's built-in authentication
+	if (!value) {
+		if (modelRegistry) {
+			const key = await modelRegistry.getApiKeyForProvider(provider);
+			if (key) return key;
+		}
+		return undefined;
+	}
+
+	// "env:PI_VAR_NAME" → use environment variable with PI_ prefix requirement
 	if (value.startsWith("env:")) {
 		const envVar = value.slice(4);
+		if (!envVar.startsWith("PI_")) {
+			throw new Error(
+				`Environment variable must start with PI_ prefix (got: ${envVar}). ` +
+				`Use "env:PI_${envVar}" instead.`
+			);
+		}
 		return process.env[envVar] || undefined;
 	}
+
+	// Plain value
 	return value;
 }
 
@@ -196,12 +231,24 @@ class OpenAIProvider implements TranscriptionProvider {
 	private model: string;
 	private language: string | undefined;
 
-	constructor(config: TranscriptionConfig) {
-		const key = resolveEnvValue(config.apiKey);
-		if (!key) throw new Error("OpenAI transcription requires apiKey");
-		this.apiKey = key;
-		this.model = config.model || "whisper-1";
-		this.language = config.language;
+	private constructor(apiKey: string, model: string, language?: string) {
+		this.apiKey = apiKey;
+		this.model = model;
+		this.language = language;
+	}
+
+	static async create(
+		config: TranscriptionConfig,
+		modelRegistry?: ModelRegistry
+	): Promise<OpenAIProvider> {
+		const key = await resolveApiKey(config.apiKey, "openai", modelRegistry);
+		if (!key) {
+			throw new Error(
+				"OpenAI transcription requires API key. " +
+				"Either configure OpenAI in pi (run: /login openai) or set apiKey in transcription config."
+			);
+		}
+		return new OpenAIProvider(key, config.model || "whisper-1", config.language);
 	}
 
 	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {
@@ -247,12 +294,24 @@ class ElevenLabsProvider implements TranscriptionProvider {
 	private model: string;
 	private language: string | undefined;
 
-	constructor(config: TranscriptionConfig) {
-		const key = resolveEnvValue(config.apiKey);
-		if (!key) throw new Error("ElevenLabs transcription requires apiKey");
-		this.apiKey = key;
-		this.model = config.model || "scribe_v1";
-		this.language = config.language;
+	private constructor(apiKey: string, model: string, language?: string) {
+		this.apiKey = apiKey;
+		this.model = model;
+		this.language = language;
+	}
+
+	static async create(
+		config: TranscriptionConfig,
+		modelRegistry?: ModelRegistry
+	): Promise<ElevenLabsProvider> {
+		const key = await resolveApiKey(config.apiKey, "elevenlabs", modelRegistry);
+		if (!key) {
+			throw new Error(
+				"ElevenLabs transcription requires API key. " +
+				"Set apiKey in config as 'env:PI_ELEVENLABS_API_KEY'."
+			);
+		}
+		return new ElevenLabsProvider(key, config.model || "scribe_v1", config.language);
 	}
 
 	async transcribe(filePath: string, language?: string): Promise<TranscriptionResult> {

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -56,8 +56,7 @@ export async function createTranscriptionProvider(
  * Resolve API key from config value.
  * Priority:
  * 1. If no value provided and modelRegistry available → use pi's built-in auth
- * 2. "env:PI_VAR_NAME" → environment variable (PI_ prefix required for security)
- * 3. Plain string → literal value
+ * 2. Plain string → literal value (put secrets directly in settings.json)
  */
 async function resolveApiKey(
 	value: string | undefined,
@@ -73,19 +72,6 @@ async function resolveApiKey(
 		return undefined;
 	}
 
-	// "env:PI_VAR_NAME" → use environment variable with PI_ prefix requirement
-	if (value.startsWith("env:")) {
-		const envVar = value.slice(4);
-		if (!envVar.startsWith("PI_")) {
-			throw new Error(
-				`Environment variable must start with PI_ prefix (got: ${envVar}). ` +
-				`Use "env:PI_${envVar}" instead.`
-			);
-		}
-		return process.env[envVar] || undefined;
-	}
-
-	// Plain value
 	return value;
 }
 
@@ -308,7 +294,7 @@ class ElevenLabsProvider implements TranscriptionProvider {
 		if (!key) {
 			throw new Error(
 				"ElevenLabs transcription requires API key. " +
-				"Set apiKey in config as 'env:PI_ELEVENLABS_API_KEY'."
+				"Set apiKey in settings.json under pi-channels transcription config."
 			);
 		}
 		return new ElevenLabsProvider(key, config.model || "scribe_v1", config.language);

--- a/extensions/pi-channels/src/adapters/webhook.ts
+++ b/extensions/pi-channels/src/adapters/webhook.ts
@@ -17,8 +17,9 @@
  */
 
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelPayloadMode } from "../types.ts";
+import type { AdapterFactoryContext } from "../registry.ts";
 
-export function createWebhookAdapter(config: AdapterConfig): ChannelAdapter {
+export async function createWebhookAdapter(config: AdapterConfig, _context: AdapterFactoryContext): Promise<ChannelAdapter> {
 	const defaultMethod = (config.method as string) ?? "POST";
 	const defaultContentType = (config.contentType as string) ?? "application/json";
 	const extraHeaders = (config.headers as Record<string, string>) ?? {};

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -65,7 +65,8 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		const config = loadConfig(ctx.cwd);
-		registry.loadConfig(config, ctx.cwd);
+		registry.setModelRegistry(ctx.modelRegistry);
+		await registry.loadConfig(config, ctx.cwd);
 
 		const errors = registry.getErrors();
 		for (const err of errors) {

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -2,6 +2,7 @@
  * pi-channels — Adapter registry + route resolution.
  */
 
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelConfig, AdapterDirection, OnIncomingMessage, IncomingMessage } from "./types.ts";
 import { createTelegramAdapter } from "./adapters/telegram.ts";
 import { createWebhookAdapter } from "./adapters/webhook.ts";
@@ -11,7 +12,13 @@ import { createSlackAdapter } from "./adapters/slack.ts";
 
 export type AdapterLogger = (event: string, data: Record<string, unknown>, level?: string) => void;
 
-type AdapterFactory = (config: AdapterConfig, cwd?: string, log?: AdapterLogger) => ChannelAdapter;
+export interface AdapterFactoryContext {
+	cwd?: string;
+	log?: AdapterLogger;
+	modelRegistry?: ModelRegistry;
+}
+
+type AdapterFactory = (config: AdapterConfig, context: AdapterFactoryContext) => Promise<ChannelAdapter>;
 
 const builtinFactories: Record<string, AdapterFactory> = {
 	telegram: createTelegramAdapter,
@@ -27,6 +34,7 @@ export class ChannelRegistry {
 	private errors: Array<{ adapter: string; error: string }> = [];
 	private onIncoming: OnIncomingMessage = () => {};
 	private log?: AdapterLogger;
+	private modelRegistry?: ModelRegistry;
 
 	/**
 	 * Set the callback for incoming messages (called by the extension entry).
@@ -43,10 +51,17 @@ export class ChannelRegistry {
 	}
 
 	/**
+	 * Set the model registry for API key resolution.
+	 */
+	setModelRegistry(modelRegistry: ModelRegistry): void {
+		this.modelRegistry = modelRegistry;
+	}
+
+	/**
 	 * Load adapters + routes from config. Custom adapters (registered via events) are preserved.
 	 * @param cwd — working directory, passed to adapter factories for settings resolution.
 	 */
-	loadConfig(config: ChannelConfig, cwd?: string): void {
+	async loadConfig(config: ChannelConfig, cwd?: string): Promise<void> {
 		this.errors = [];
 
 		// Stop existing adapters
@@ -77,7 +92,12 @@ export class ChannelRegistry {
 				continue;
 			}
 			try {
-				this.adapters.set(name, factory(adapterConfig, cwd, this.log));
+				const adapter = await factory(adapterConfig, {
+					cwd,
+					log: this.log,
+					modelRegistry: this.modelRegistry,
+				});
+				this.adapters.set(name, adapter);
 			} catch (err: any) {
 				this.errors.push({ adapter: name, error: err.message });
 			}

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -61,8 +61,7 @@ export interface TranscriptionConfig {
 	provider: "apple" | "openai" | "elevenlabs";
 	/**
 	 * API key for cloud providers. Optional for OpenAI if pi has authentication configured.
-	 * Supports "env:PI_VAR_NAME" for environment variables (PI_ prefix required).
-	 * Not needed for apple provider.
+	 * Put the key value directly in settings.json. Not needed for apple provider.
 	 */
 	apiKey?: string;
 	/** Model name (e.g. "whisper-1", "scribe_v1"). Provider-specific default used if omitted. */

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -55,11 +55,15 @@ export interface TranscriptionConfig {
 	/**
 	 * Transcription provider:
 	 * - "apple"      — macOS SFSpeechRecognizer (free, offline, no API key)
-	 * - "openai"     — Whisper API
-	 * - "elevenlabs" — Scribe API
+	 * - "openai"     — Whisper API (uses pi's built-in auth if available, or explicit apiKey)
+	 * - "elevenlabs" — Scribe API (requires explicit apiKey)
 	 */
 	provider: "apple" | "openai" | "elevenlabs";
-	/** API key for cloud providers (supports env:VAR_NAME). Not needed for apple. */
+	/**
+	 * API key for cloud providers. Optional for OpenAI if pi has authentication configured.
+	 * Supports "env:PI_VAR_NAME" for environment variables (PI_ prefix required).
+	 * Not needed for apple provider.
+	 */
 	apiKey?: string;
 	/** Model name (e.g. "whisper-1", "scribe_v1"). Provider-specific default used if omitted. */
 	model?: string;

--- a/extensions/pi-gmail/src/auth.ts
+++ b/extensions/pi-gmail/src/auth.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import * as crypto from "node:crypto";
 import type { OAuthTokens, GmailSettings } from "./types.ts";
-import { resolveEnv } from "./utils.ts";
+
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -112,7 +112,7 @@ export async function clearTokens(agentDir: string): Promise<void> {
 // ── OAuth flow ──────────────────────────────────────────────────
 
 export function getConsentUrl(settings: GmailSettings, redirectUri: string): string {
-	const clientId = resolveEnv(settings.clientId ?? "");
+	const clientId = settings.clientId ?? "";
 	if (!clientId) throw new Error("Gmail clientId not configured");
 
 	const state = generateOAuthState();
@@ -136,8 +136,8 @@ export async function exchangeCode(
 	redirectUri: string,
 	agentDir: string,
 ): Promise<OAuthTokens> {
-	const clientId = resolveEnv(settings.clientId ?? "");
-	const clientSecret = resolveEnv(settings.clientSecret ?? "");
+	const clientId = settings.clientId ?? "";
+	const clientSecret = settings.clientSecret ?? "";
 
 	if (!clientId || !clientSecret) {
 		throw new Error("Gmail clientId/clientSecret not configured");
@@ -206,8 +206,8 @@ async function refreshAccessToken(
 	agentDir: string,
 	tokens: OAuthTokens,
 ): Promise<string> {
-	const clientId = resolveEnv(settings.clientId ?? "");
-	const clientSecret = resolveEnv(settings.clientSecret ?? "");
+	const clientId = settings.clientId ?? "";
+	const clientSecret = settings.clientSecret ?? "";
 
 	if (!clientId || !clientSecret) {
 		throw new Error("Gmail clientId/clientSecret not configured for token refresh");

--- a/extensions/pi-gmail/src/index.ts
+++ b/extensions/pi-gmail/src/index.ts
@@ -37,7 +37,7 @@ import {
 import type { GmailSettings } from "./types.ts";
 import * as client from "./client.ts";
 import { formatSearchResult } from "./formatter.ts";
-import { resolveEnv, openUrl } from "./utils.ts";
+import { openUrl } from "./utils.ts";
 
 // ── Settings ────────────────────────────────────────────────────
 
@@ -187,7 +187,7 @@ export default function (pi: ExtensionAPI) {
 		const agentDir = getAgentDir();
 		cachedSettings = getSettings(ctx.cwd);
 
-		const clientId = resolveEnv(cachedSettings.clientId);
+		const clientId = cachedSettings.clientId ?? "";
 		if (!clientId) {
 			log("init", { status: "no clientId configured" }, "WARN");
 			ctx.ui.setStatus("gmail", "Gmail: not configured");
@@ -235,7 +235,7 @@ export default function (pi: ExtensionAPI) {
 		handler: async (_args, ctx) => {
 			const agentDir = getAgentDir();
 			const settings = getSettings(ctx.cwd);
-			const clientId = resolveEnv(settings.clientId);
+			const clientId = settings.clientId ?? "";
 
 			if (!clientId) {
 				ctx.ui.notify(

--- a/extensions/pi-gmail/src/index.ts
+++ b/extensions/pi-gmail/src/index.ts
@@ -11,8 +11,8 @@
  *
  * Settings (in settings.json):
  *   "pi-gmail": {
- *     "clientId": "env:GMAIL_CLIENT_ID",
- *     "clientSecret": "env:GMAIL_CLIENT_SECRET",
+ *     "clientId": "your-client-id",
+ *     "clientSecret": "your-client-secret",
  *     "maxResults": 20,
  *     "notifications": {
  *       "enabled": false,

--- a/extensions/pi-gmail/src/utils.ts
+++ b/extensions/pi-gmail/src/utils.ts
@@ -21,15 +21,14 @@ export function escapeHtml(str: string): string {
 	return str.replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch]!);
 }
 
-// ── Environment variable resolution ─────────────────────────────
+// ── Config value helpers ────────────────────────────────────────
 
 /**
- * Resolve a value that may use the `env:VAR_NAME` pattern.
- * Returns the environment variable value, or the original string.
+ * Return a config value as-is (empty string if undefined).
+ * Values should be set directly in settings.json.
  */
 export function resolveEnv(value: string | undefined): string {
 	if (!value) return "";
-	if (value.startsWith("env:")) return process.env[value.slice(4)] ?? "";
 	return value;
 }
 

--- a/extensions/pi-gmail/src/utils.ts
+++ b/extensions/pi-gmail/src/utils.ts
@@ -21,17 +21,6 @@ export function escapeHtml(str: string): string {
 	return str.replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch]!);
 }
 
-// ── Config value helpers ────────────────────────────────────────
-
-/**
- * Return a config value as-is (empty string if undefined).
- * Values should be set directly in settings.json.
- */
-export function resolveEnv(value: string | undefined): string {
-	if (!value) return "";
-	return value;
-}
-
 // ── Cross-platform URL opener ───────────────────────────────────
 
 /**

--- a/extensions/pi-gmail/src/web.ts
+++ b/extensions/pi-gmail/src/web.ts
@@ -120,12 +120,12 @@ ${
 <li>Enable the <strong>Gmail API</strong></li>
 <li>Create OAuth 2.0 credentials (Desktop app or Web app)</li>
 <li>Add <code>${getRedirectUri()}</code> as an authorized redirect URI</li>
-<li>Set <code>GMAIL_CLIENT_ID</code> and <code>GMAIL_CLIENT_SECRET</code> environment variables, or add to <code>settings.json</code>:
+<li>Add credentials to <code>settings.json</code>:
 <pre style="background:#161b22;padding:12px;border-radius:6px;overflow-x:auto">
 {
   "pi-gmail": {
-    "clientId": "env:GMAIL_CLIENT_ID",
-    "clientSecret": "env:GMAIL_CLIENT_SECRET"
+    "clientId": "your-client-id",
+    "clientSecret": "your-client-secret"
   }
 }</pre>
 </li>


### PR DESCRIPTION
Remove custom `env:` prefix resolution from pi-channels and pi-gmail. Extensions should read config values directly from settings.json — no env var indirection.

## Changes

- **pi-channels/transcription.ts** — Removed `env:PI_*` resolution from `resolveApiKey()`, now returns value as-is
- **pi-channels/types.ts** — Updated `apiKey` JSDoc
- **pi-gmail/utils.ts** — Removed `env:` prefix resolution from `resolveEnv()`
- **pi-gmail/index.ts** — Updated doc examples
- **pi-gmail/web.ts** — Updated web UI setup instructions

## Not touched
- Core `resolveConfigValue()` (model API keys/auth) — different mechanism
- `process.env` spreading in child process spawning — standard Node.js pattern, needed for PATH/HOME/etc.