### PR TITLE
feat(pi-a2a): include sender identity in A2A messages via metadata

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -99,6 +99,18 @@ export class PiAgentExecutor implements AgentExecutor {
 			}
 		}
 
+		// Check for sender identity in message metadata (A2A spec extension)
+		const senderMeta = (userMessage.metadata as Record<string, unknown> | undefined)?.["pi:sender"] as
+			| { name?: string; description?: string }
+			| undefined;
+		if (senderMeta?.name) {
+			const desc = senderMeta.description ? ` (${senderMeta.description})` : "";
+			textSegments.unshift(
+				`[This message is from agent "${senderMeta.name}"${desc}, not from the human user.]`,
+			);
+			this.log("executor_sender_identity", { taskId, senderName: senderMeta.name });
+		}
+
 		if (textSegments.length === 0) {
 			if (!task) {
 				const initialTask: Task = {

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -1,0 +1,174 @@
+/**
+ * pi-a2a — A2A client for sending messages to remote agents.
+ *
+ * Sends A2A JSON-RPC `message/send` requests to remote agent endpoints.
+ * Handles Bearer auth when a credential is provided.
+ */
+
+import type { LogFn } from "./logger.ts";
+
+/** Sender identity to include in message metadata. */
+export interface SenderIdentity {
+	/** Agent display name (e.g. "Aivena"). */
+	name: string;
+	/** Agent description (optional). */
+	description?: string;
+}
+
+export interface SendMessageOptions {
+	/** Remote agent's A2A endpoint URL. */
+	url: string;
+	/** Message text to send. */
+	message: string;
+	/** Bearer token for authenticating with the remote agent. */
+	credential?: string | null;
+	/** Timeout in milliseconds. Defaults to 120_000 (2 min). */
+	timeoutMs?: number;
+	/** Local agent identity to include as sender metadata. */
+	sender?: SenderIdentity;
+}
+
+export interface SendMessageResult {
+	ok: boolean;
+	/** Extracted text from the agent's response artifacts/status. */
+	response?: string;
+	/** The raw JSON-RPC result for inspection. */
+	raw?: unknown;
+	/** Error message if the request failed. */
+	error?: string;
+}
+
+/**
+ * Send a message to a remote A2A agent via `message/send`.
+ *
+ * Returns the agent's response text extracted from artifacts,
+ * or the status message if no artifacts are present.
+ */
+export async function sendA2AMessage(
+	opts: SendMessageOptions,
+	log: LogFn,
+): Promise<SendMessageResult> {
+	const { url, message, credential, timeoutMs = 120_000, sender } = opts;
+
+	// Build the message object, optionally including sender identity in metadata
+	const msg: Record<string, unknown> = {
+		kind: "message",
+		messageId: crypto.randomUUID(),
+		role: "user",
+		parts: [{ kind: "text", text: message }],
+	};
+	if (sender) {
+		msg.metadata = {
+			"pi:sender": {
+				name: sender.name,
+				...(sender.description ? { description: sender.description } : {}),
+			},
+		};
+	}
+
+	const payload = {
+		jsonrpc: "2.0" as const,
+		method: "message/send",
+		params: { message: msg },
+		id: 1,
+	};
+
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (credential) {
+		headers["Authorization"] = `Bearer ${credential}`;
+	}
+
+	log("a2a_send_start", { url, messageLength: message.length, hasCredential: !!credential });
+
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+
+		if (res.status === 401) {
+			log("a2a_send_unauthorized", { url }, "ERROR");
+			return { ok: false, error: "Unauthorized — the remote agent rejected the credential" };
+		}
+
+		if (!res.ok) {
+			const text = await res.text();
+			log("a2a_send_http_error", { url, status: res.status, body: text.slice(0, 500) }, "ERROR");
+			return { ok: false, error: `HTTP ${res.status}: ${text.slice(0, 200)}` };
+		}
+
+		const data = await res.json() as {
+			jsonrpc: "2.0";
+			result?: Record<string, unknown>;
+			error?: { code: number; message: string; data?: unknown };
+			id: number;
+		};
+
+		if (data.error) {
+			log("a2a_send_rpc_error", { url, code: data.error.code, message: data.error.message }, "ERROR");
+			return { ok: false, error: `RPC error ${data.error.code}: ${data.error.message}`, raw: data };
+		}
+
+		if (!data.result) {
+			return { ok: false, error: "Empty result from remote agent", raw: data };
+		}
+
+		// Extract response text from the A2A task result
+		const responseText = extractResponseText(data.result);
+		log("a2a_send_success", { url, responseLength: responseText.length });
+
+		return { ok: true, response: responseText, raw: data.result };
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		log("a2a_send_error", { url, error: msg }, "ERROR");
+		return { ok: false, error: msg };
+	}
+}
+
+/**
+ * Extract readable text from an A2A task result.
+ *
+ * Looks for text in: artifacts → status.message → fallback to JSON.
+ */
+function extractResponseText(result: Record<string, unknown>): string {
+	const parts: string[] = [];
+
+	// Try artifacts first (primary response content)
+	const artifacts = result.artifacts as Array<{ parts?: Array<{ kind: string; text?: string }> }> | undefined;
+	if (artifacts?.length) {
+		for (const artifact of artifacts) {
+			if (artifact.parts) {
+				for (const part of artifact.parts) {
+					if (part.kind === "text" && part.text) {
+						parts.push(part.text);
+					}
+				}
+			}
+		}
+	}
+
+	if (parts.length > 0) {
+		return parts.join("\n");
+	}
+
+	// Fall back to status message
+	const status = result.status as { message?: { parts?: Array<{ kind: string; text?: string }> } } | undefined;
+	if (status?.message?.parts) {
+		for (const part of status.message.parts) {
+			if (part.kind === "text" && part.text) {
+				parts.push(part.text);
+			}
+		}
+	}
+
+	if (parts.length > 0) {
+		return parts.join("\n");
+	}
+
+	// Last resort: serialize the whole result
+	return JSON.stringify(result, null, 2);
+}

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -5,6 +5,7 @@
  * Handles Bearer auth when a credential is provided.
  */
 
+import { randomUUID } from "node:crypto";
 import type { LogFn } from "./logger.ts";
 
 /** Sender identity to include in message metadata. */
@@ -53,7 +54,7 @@ export async function sendA2AMessage(
 	// Build the message object, optionally including sender identity in metadata
 	const msg: Record<string, unknown> = {
 		kind: "message",
-		messageId: crypto.randomUUID(),
+		messageId: randomUUID(),
 		role: "user",
 		parts: [{ kind: "text", text: message }],
 	};

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -5,53 +5,43 @@
  * JSON-RPC 2.0 API. Hub config comes from settings.json.
  *
  * The hub only needs the agent's public URL — it fetches the Agent Card
- * from /.well-known/agent.json itself.
+ * from /.well-known/agent.json itself. Optionally, the agent's API key
+ * is sent as `credential` so the hub can share it with other agents
+ * that need to call this agent.
  */
 
-import type { HubConfig } from "./types.ts";
+import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail } from "./types.ts";
 import type { LogFn } from "./logger.ts";
 
 interface HubRpcResponse {
 	jsonrpc: "2.0";
-	result?: { agentId: string; status: string; message?: string };
+	result?: Record<string, unknown>;
 	error?: { code: number; message: string; data?: unknown };
 	id: number;
 }
 
-/**
- * Register this agent with the A2A Hub.
- *
- * Sends the agent's public URL plus hub-specific metadata (categories,
- * tags, visibility). The hub fetches and validates the Agent Card from
- * the agent's /.well-known/agent.json endpoint.
- */
-export async function registerWithHub(
-	agentUrl: string,
-	hubConfig: HubConfig,
+// ── Helpers ─────────────────────────────────────────────────────
+
+function hubRpcUrl(hubConfig: HubConfig): string {
+	return `${hubConfig.url.replace(/\/$/, "")}/rpc`;
+}
+
+async function hubRpc(
+	rpcUrl: string,
+	method: string,
+	params: Record<string, unknown>,
+	hubApiKey: string,
 	log: LogFn,
-): Promise<{ agentId: string; status: string } | null> {
-	const rpcUrl = `${hubConfig.url.replace(/\/$/, "")}/rpc`;
-
-	const payload = {
-		jsonrpc: "2.0" as const,
-		method: "agents.register",
-		params: {
-			url: agentUrl,
-			category: hubConfig.categories ?? ["development-tools"],
-			tags: hubConfig.tags ?? [],
-			visibility: hubConfig.visibility ?? "public",
-		},
-		id: 1,
-	};
-
-	log("hub_register_start", { url: rpcUrl, agentUrl });
+	logPrefix: string,
+): Promise<Record<string, unknown> | null> {
+	const payload = { jsonrpc: "2.0" as const, method, params, id: 1 };
 
 	try {
 		const res = await fetch(rpcUrl, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"X-API-Key": hubConfig.apiKey,
+				"X-API-Key": hubApiKey,
 			},
 			body: JSON.stringify(payload),
 			signal: AbortSignal.timeout(10_000),
@@ -59,27 +49,178 @@ export async function registerWithHub(
 
 		if (!res.ok) {
 			const text = await res.text();
-			log("hub_register_http_error", { status: res.status, body: text.slice(0, 500) }, "ERROR");
+			log(`${logPrefix}_http_error`, { status: res.status, body: text.slice(0, 500) }, "ERROR");
 			return null;
 		}
 
 		const data = (await res.json()) as HubRpcResponse;
 
 		if (data.error) {
-			log("hub_register_rpc_error", { code: data.error.code, message: data.error.message, data: data.error.data }, "ERROR");
+			log(`${logPrefix}_rpc_error`, { code: data.error.code, message: data.error.message, data: data.error.data }, "ERROR");
 			return null;
 		}
 
 		if (data.result) {
-			log("hub_register_success", { agentId: data.result.agentId, status: data.result.status });
 			return data.result;
 		}
 
-		log("hub_register_unexpected", { response: JSON.stringify(data).slice(0, 500) }, "WARN");
+		log(`${logPrefix}_unexpected`, { response: JSON.stringify(data).slice(0, 500) }, "WARN");
 		return null;
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
-		log("hub_register_error", { error: msg }, "ERROR");
+		log(`${logPrefix}_error`, { error: msg }, "ERROR");
 		return null;
 	}
+}
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Register this agent with the A2A Hub.
+ *
+ * Sends the agent's public URL plus hub-specific metadata (categories,
+ * tags, visibility). The hub fetches and validates the Agent Card from
+ * the agent's /.well-known/agent.json endpoint.
+ *
+ * When `agentApiKey` is provided, it is sent as `credential` so the hub
+ * can share it with other agents that want to call this agent's A2A endpoint.
+ */
+export async function registerWithHub(
+	agentUrl: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+	agentApiKey?: string,
+): Promise<{ agentId: string; status: string } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	const params: Record<string, unknown> = {
+		url: agentUrl,
+		category: hubConfig.categories ?? ["development-tools"],
+		tags: hubConfig.tags ?? [],
+		visibility: hubConfig.visibility ?? "public",
+	};
+	if (agentApiKey) {
+		params.credential = agentApiKey;
+	}
+
+	log("hub_register_start", { url: rpcUrl, agentUrl, hasCredential: !!agentApiKey });
+
+	const result = await hubRpc(rpcUrl, "agents.register", params, hubConfig.apiKey, log, "hub_register");
+	if (result) {
+		const agentId = result.agentId as string;
+		const status = result.status as string;
+		log("hub_register_success", { agentId, status });
+		return { agentId, status };
+	}
+	return null;
+}
+
+/**
+ * Search for agents on the hub.
+ *
+ * Wraps `agents.search` — returns a paginated list of agent summaries
+ * matching the query, categories, or tags.
+ */
+export async function discoverAgentsOnHub(
+	hubConfig: HubConfig,
+	log: LogFn,
+	options?: { q?: string; category?: string[]; tags?: string[]; limit?: number },
+): Promise<{ agents: RemoteAgentSummary[]; total: number } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const params: Record<string, unknown> = {};
+	if (options?.q) params.q = options.q;
+	if (options?.category?.length) params.category = options.category;
+	if (options?.tags?.length) params.tags = options.tags;
+	if (options?.limit) params.limit = options.limit;
+
+	log("hub_discover_start", { q: options?.q ?? "*" });
+
+	const result = await hubRpc(rpcUrl, "agents.search", params, hubConfig.apiKey, log, "hub_discover");
+	if (result) {
+		return {
+			agents: result.agents as RemoteAgentSummary[],
+			total: result.total as number,
+		};
+	}
+	return null;
+}
+
+/**
+ * Get full agent detail from the hub by ID.
+ */
+export async function getAgentFromHub(
+	agentId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<RemoteAgentDetail | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	const result = await hubRpc(rpcUrl, "agents.get", { agentId }, hubConfig.apiKey, log, "hub_get_agent");
+	if (result) {
+		return result as unknown as RemoteAgentDetail;
+	}
+	return null;
+}
+
+/**
+ * Retrieve the stored credential for a remote agent.
+ *
+ * Only works for agents owned by the authenticated user (or admin).
+ * Returns the decrypted plaintext credential.
+ */
+export async function getCredentialFromHub(
+	agentId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ credential: string | null; hasCredential: boolean } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	log("hub_get_credential_start", { agentId });
+
+	const result = await hubRpc(rpcUrl, "agents.getCredential", { agentId }, hubConfig.apiKey, log, "hub_get_credential");
+	if (result) {
+		return {
+			credential: (result.credential as string | null) ?? null,
+			hasCredential: result.hasCredential as boolean,
+		};
+	}
+	return null;
+}
+
+/**
+ * Update the credential stored on the hub for this agent.
+ *
+ * Uses the dedicated `agents.setCredential` method so the agent card
+ * and other metadata are left untouched.
+ *
+ * Pass `null` as credential to remove the stored credential.
+ */
+export async function setCredentialOnHub(
+	agentId: string,
+	credential: string | null,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ agentId: string; hasCredential: boolean; credentialUpdatedAt: string | null } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	log("hub_set_credential_start", { agentId, action: credential === null ? "remove" : "set" });
+
+	const result = await hubRpc(
+		rpcUrl,
+		"agents.setCredential",
+		{ agentId, credential },
+		hubConfig.apiKey,
+		log,
+		"hub_set_credential",
+	);
+	if (result) {
+		const out = {
+			agentId: result.agentId as string,
+			hasCredential: result.hasCredential as boolean,
+			credentialUpdatedAt: (result.credentialUpdatedAt as string | null) ?? null,
+		};
+		log("hub_set_credential_success", out);
+		return out;
+	}
+	return null;
 }

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -32,6 +32,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
 import {
 	DefaultRequestHandler,
 	InMemoryTaskStore,
@@ -43,10 +44,16 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub } from "./hub.ts";
+import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub } from "./hub.ts";
+import { sendA2AMessage } from "./client.ts";
 import { createLogger } from "./logger.ts";
+import type { RemoteAgentSummary } from "./types.ts";
 
 const DEFAULT_PORT = 3100;
+
+function txt(s: string) {
+	return { content: [{ type: "text" as const, text: s }], details: {} };
+}
 
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
@@ -131,9 +138,9 @@ export default function (pi: ExtensionAPI) {
 		// Deferred enrichment
 		queueMicrotask(() => enrichCard());
 
-		// Optional: register with A2A Hub
+		// Optional: register with A2A Hub (send agent apiKey as credential)
 		if (config.hub && config.hub.apiKey && (config.hub.autoRegister !== false)) {
-			const result = await registerWithHub(publicUrl, config.hub, log);
+			const result = await registerWithHub(publicUrl, config.hub, log, config.apiKey);
 			if (result) {
 				ctx.ui.notify(`pi-a2a: Registered with hub (${result.status})`, "info");
 			}
@@ -162,10 +169,135 @@ export default function (pi: ExtensionAPI) {
 		}
 	});
 
+	// ── Tools ─────────────────────────────────────────────────
+
+	/** In-memory cache of discovered agents from the hub. */
+	let discoveredAgents: RemoteAgentSummary[] = [];
+
+	pi.registerTool({
+		name: "a2a_discover",
+		label: "A2A Discover",
+		description:
+			"Discover remote agents registered on the A2A Hub. " +
+			"Returns a list of available agents with their names, descriptions, skills, and health status. " +
+			"Use this before a2a_send to find agents you can communicate with.",
+		parameters: Type.Object({
+			q: Type.Optional(Type.String({ description: "Search query (optional — omit to list all agents)" })),
+			category: Type.Optional(Type.Array(Type.String(), { description: "Filter by category slugs" })),
+			tags: Type.Optional(Type.Array(Type.String(), { description: "Filter by tags" })),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			if (!config.hub?.apiKey) {
+				return txt("Error: No hub configured. Set pi-a2a.hub in settings.json.");
+			}
+
+			const result = await discoverAgentsOnHub(config.hub, log, {
+				q: params.q,
+				category: params.category,
+				tags: params.tags,
+				limit: 50,
+			});
+
+			if (!result) {
+				return txt("Error: Failed to query the hub. Check logs.");
+			}
+
+			discoveredAgents = result.agents;
+
+			if (result.agents.length === 0) {
+				return txt("No agents found on the hub.");
+			}
+
+			const lines = result.agents.map((a) =>
+				`• **${a.name}** (id: ${a.id})\n  ${a.description}\n  URL: ${a.url} | Health: ${a.healthStatus} | Tags: ${a.tags.join(", ") || "none"}`
+			);
+
+			return txt(`Found ${result.total} agent(s) on the hub:\n\n${lines.join("\n\n")}`);
+		},
+	});
+
+	pi.registerTool({
+		name: "a2a_send",
+		label: "A2A Send",
+		description:
+			"Send a message to a remote A2A agent. " +
+			"Specify the agent by name (from a2a_discover results) or by agentId/URL. " +
+			"The hub provides the agent's URL and credential automatically.",
+		parameters: Type.Object({
+			agent: Type.String({
+				description: "Agent name, agent ID (UUID), or direct URL. Names are matched against discovered agents.",
+			}),
+			message: Type.String({ description: "Message to send to the remote agent" }),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			if (!config.hub?.apiKey) {
+				return txt("Error: No hub configured. Set pi-a2a.hub in settings.json.");
+			}
+
+			// Resolve agent URL
+			let agentUrl: string | null = null;
+			let agentId: string | null = null;
+			let agentName: string = params.agent;
+
+			// Direct URL?
+			if (params.agent.startsWith("http://") || params.agent.startsWith("https://")) {
+				agentUrl = params.agent;
+			} else {
+				// Try to match from discovered agents cache
+				const match = discoveredAgents.find((a) =>
+					a.id === params.agent || a.name.toLowerCase() === params.agent.toLowerCase()
+				);
+
+				if (match) {
+					agentUrl = match.url;
+					agentId = match.id;
+					agentName = match.name;
+				} else {
+					// Not cached — try as agentId via hub lookup
+					const detail = await getAgentFromHub(params.agent, config.hub, log);
+					if (detail) {
+						agentUrl = (detail.agentCard as { url?: string }).url ?? null;
+						agentId = detail.id;
+						agentName = (detail.agentCard as { name?: string }).name ?? params.agent;
+					}
+				}
+			}
+
+			if (!agentUrl) {
+				return txt(`Error: Could not resolve agent "${params.agent}". Run a2a_discover first, or provide a direct URL.`);
+			}
+
+			// Get credential from hub if we have an agentId
+			let credential: string | null = null;
+			if (agentId) {
+				const cred = await getCredentialFromHub(agentId, config.hub, log);
+				if (cred?.credential) {
+					credential = cred.credential;
+				}
+			}
+
+			// Send the message with sender identity
+			const result = await sendA2AMessage({
+				url: agentUrl,
+				message: params.message,
+				credential,
+				sender: { name: config.name ?? "Pi Agent", description: config.description },
+			}, log);
+
+			if (!result.ok) {
+				return txt(`Error sending to ${agentName}: ${result.error}`);
+			}
+
+			return txt(`**Response from ${agentName}:**\n\n${result.response}`);
+		},
+	});
+
 	// ── Commands ──────────────────────────────────────────────
 
 	pi.registerCommand("a2a", {
-		description: "Manage the A2A protocol server. Usage: /a2a status | /a2a card | /a2a refresh | /a2a register",
+		description: "Manage the A2A protocol server. Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a discover [query]",
 		handler: async (args, ctx) => {
 			const action = args.trim();
 			const { config } = loadConfig(cwd);
@@ -213,7 +345,7 @@ export default function (pi: ExtensionAPI) {
 					return;
 				}
 
-				const result = await registerWithHub(publicUrl, config.hub, log);
+				const result = await registerWithHub(publicUrl, config.hub, log, config.apiKey);
 				if (result) {
 					ctx.ui.notify(`Registered with hub: agentId=${result.agentId}, status=${result.status}`, "info");
 				} else {
@@ -222,7 +354,65 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
-			ctx.ui.notify("Usage: /a2a status | /a2a card | /a2a refresh | /a2a register", "info");
+			if (action === "credential") {
+				if (!config.hub?.apiKey) {
+					ctx.ui.notify("No hub config — set pi-a2a.hub.url and pi-a2a.hub.apiKey", "warning");
+					return;
+				}
+				if (!config.apiKey) {
+					ctx.ui.notify("No pi-a2a.apiKey configured — nothing to push to hub", "warning");
+					return;
+				}
+
+				// We need the agentId. Re-register to get it (idempotent on the hub).
+				const reg = await registerWithHub(publicUrl, config.hub, log, config.apiKey);
+				if (!reg) {
+					ctx.ui.notify("Could not determine agentId — registration failed", "warning");
+					return;
+				}
+
+				const result = await setCredentialOnHub(reg.agentId, config.apiKey, config.hub, log);
+				if (result) {
+					ctx.ui.notify(
+						`Credential updated on hub: hasCredential=${result.hasCredential}, ` +
+						`updatedAt=${result.credentialUpdatedAt ?? "n/a"}`,
+						"info",
+					);
+				} else {
+					ctx.ui.notify("Failed to update credential on hub — check logs", "warning");
+				}
+				return;
+			}
+
+			if (action === "discover" || action.startsWith("discover ")) {
+				if (!config.hub?.apiKey) {
+					ctx.ui.notify("No hub config — set pi-a2a.hub.url and pi-a2a.hub.apiKey", "warning");
+					return;
+				}
+
+				const query = action === "discover" ? undefined : action.slice("discover ".length).trim() || undefined;
+				const result = await discoverAgentsOnHub(config.hub, log, { q: query, limit: 50 });
+
+				if (!result) {
+					ctx.ui.notify("Failed to query the hub — check logs", "warning");
+					return;
+				}
+
+				discoveredAgents = result.agents;
+
+				if (result.agents.length === 0) {
+					ctx.ui.notify("No agents found on the hub.", "info");
+					return;
+				}
+
+				const lines = result.agents.map((a) =>
+					`  ${a.name} (${a.id.slice(0, 8)}…) — ${a.description.slice(0, 60)}${a.description.length > 60 ? "…" : ""} [${a.healthStatus}]`
+				);
+				ctx.ui.notify(`Found ${result.total} agent(s):\n${lines.join("\n")}`, "info");
+				return;
+			}
+
+			ctx.ui.notify("Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a discover [query]", "info");
 		},
 	});
 }

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -46,3 +46,36 @@ export interface HubConfig {
 	/** Auto-register on session start. Defaults to true when hub config is present. */
 	autoRegister?: boolean;
 }
+
+// ── Remote Agent Types (from hub API responses) ─────────────────
+
+export interface RemoteAgentSummary {
+	id: string;
+	name: string;
+	description: string;
+	url: string;
+	category: string[];
+	tags: string[];
+	iconUrl: string | null;
+	healthStatus: "healthy" | "degraded" | "down" | "unknown";
+	popularity: number;
+	featured: boolean;
+}
+
+export interface RemoteAgentDetail {
+	id: string;
+	agentCard: Record<string, unknown>;
+	status: "pending" | "active" | "suspended" | "archived";
+	visibility: "public" | "private" | "unlisted";
+	category: string[];
+	tags: string[];
+	featured: boolean;
+	popularity: number;
+	healthStatus: "healthy" | "degraded" | "down" | "unknown";
+	uptimePercentage: number;
+	validationStatus: "valid" | "invalid" | "warning" | "unknown";
+	hasCredential: boolean;
+	credentialUpdatedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+}


### PR DESCRIPTION
## Summary

When agent A sends a message to agent B via A2A, agent B now knows who sent it — not just assuming it's the human user.

### Changes

**Sender side (client.ts)**
- New `sendA2AMessage()` function that sets `message.metadata['pi:sender']` with the sending agent's name and description
- Handles Bearer auth, timeouts, response text extraction from artifacts

**Receiver side (agent-executor.ts)**
- Checks incoming messages for `pi:sender` metadata
- Prepends context: `[This message is from agent "X" (description), not from the human user.]`

**Hub improvements (hub.ts)**
- Extracted `hubRpc()` helper to DRY up all hub API calls
- Added `discoverAgentsOnHub()`, `getAgentFromHub()`, `getCredentialFromHub()`, `setCredentialOnHub()`
- Registration now sends agent apiKey as credential to the hub

**New tools (index.ts)**
- `a2a_discover` — search/list agents on the hub
- `a2a_send` — send messages to remote agents with auto-credential resolution

**New commands**
- `/a2a credential` — push agent apiKey to hub
- `/a2a discover [query]` — list agents from hub

**Types (types.ts)**
- Added `RemoteAgentSummary` and `RemoteAgentDetail` interfaces

Spec-compliant — uses the existing `metadata` field on the A2A Message type. No protocol changes needed.

Closes td-4ccb15