### PR TITLE
feat(pi-a2a): add telemetry reporting to hub

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -245,7 +245,9 @@ export class PiAgentExecutor implements AgentExecutor {
 			this.publishError(taskId, contextId, eventBus, msg);
 			this.log("executor_error", { taskId, error: msg }, "ERROR");
 
-			// Record telemetry for hub reporting (no duration available)
+			// Record telemetry for hub reporting — clear stale duration
+			// to avoid pairing a previous task's timing with this failure
+			this.lastTaskDurationMs = undefined;
 			this.lastTaskStatus = "failed";
 			this.onTaskFinished?.();
 		}

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -20,6 +20,7 @@ import type { AgentExecutor, ExecutionEventBus, RequestContext } from "@a2a-js/s
 import type { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from "@a2a-js/sdk";
 import { runPrompt, type SubprocessHandle } from "./subprocess.ts";
 import type { LogFn } from "./logger.ts";
+import type { TelemetrySnapshot } from "./types.ts";
 
 /** Max concurrent subprocess executions. */
 const MAX_CONCURRENT = 3;
@@ -34,10 +35,32 @@ export class PiAgentExecutor implements AgentExecutor {
 	private log: LogFn;
 	/** Track running subprocesses for cancellation and concurrency. */
 	private running = new Map<string, RunningTask>();
+	/** Last completed/failed task duration for telemetry reporting. */
+	private lastTaskDurationMs?: number;
+	/** Last completed/failed task status for telemetry reporting. */
+	private lastTaskStatus?: "completed" | "failed";
+	/** Optional callback invoked after each task completes or fails. */
+	onTaskFinished?: () => void;
 
 	constructor(cwd: string, log: LogFn) {
 		this.cwd = cwd;
 		this.log = log;
+	}
+
+	/** Return a snapshot of current telemetry state for hub reporting. */
+	getTelemetrySnapshot(): TelemetrySnapshot {
+		const snapshot: TelemetrySnapshot = {
+			queueDepth: 0,  // Tasks are rejected, not queued — always 0
+			activeTasks: this.running.size,
+			maxConcurrent: MAX_CONCURRENT,
+		};
+		if (this.lastTaskDurationMs !== undefined) {
+			snapshot.lastTaskDurationMs = this.lastTaskDurationMs;
+		}
+		if (this.lastTaskStatus !== undefined) {
+			snapshot.lastTaskStatus = this.lastTaskStatus;
+		}
+		return snapshot;
 	}
 
 	/** Abort all running tasks. Call before discarding the executor. */
@@ -202,15 +225,29 @@ export class PiAgentExecutor implements AgentExecutor {
 				};
 				eventBus.publish(completedUpdate);
 				this.log("executor_completed", { taskId, responseLength: result.response.length, durationMs: result.durationMs });
+
+				// Record telemetry for hub reporting
+				this.lastTaskDurationMs = result.durationMs;
+				this.lastTaskStatus = "completed";
+				this.onTaskFinished?.();
 			} else {
 				this.publishError(taskId, contextId, eventBus, result.error ?? "Unknown error");
 				this.log("executor_failed", { taskId, error: result.error ?? "Unknown", durationMs: result.durationMs }, "ERROR");
+
+				// Record telemetry for hub reporting
+				this.lastTaskDurationMs = result.durationMs;
+				this.lastTaskStatus = "failed";
+				this.onTaskFinished?.();
 			}
 		} catch (err: unknown) {
 			this.running.delete(taskId);
 			const msg = err instanceof Error ? err.message : String(err);
 			this.publishError(taskId, contextId, eventBus, msg);
 			this.log("executor_error", { taskId, error: msg }, "ERROR");
+
+			// Record telemetry for hub reporting (no duration available)
+			this.lastTaskStatus = "failed";
+			this.onTaskFinished?.();
 		}
 
 		// ── Step 6: Signal execution finished ──

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -10,7 +10,7 @@
  * that need to call this agent.
  */
 
-import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail } from "./types.ts";
+import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot } from "./types.ts";
 import type { LogFn } from "./logger.ts";
 
 interface HubRpcResponse {
@@ -221,6 +221,42 @@ export async function setCredentialOnHub(
 		};
 		log("hub_set_credential_success", out);
 		return out;
+	}
+	return null;
+}
+
+/**
+ * Report telemetry to the A2A Hub.
+ *
+ * Sends the agent's current operational state (queue depth, active tasks,
+ * response times) so the hub can compute availability and rank agents
+ * in search results. If the agent doesn't report for 5 minutes, the hub
+ * resets its telemetry to unknown.
+ */
+export async function reportTelemetryToHub(
+	agentId: string,
+	telemetry: TelemetrySnapshot,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ telemetryUpdatedAt: string } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	const params: Record<string, unknown> = {
+		agentId,
+		queueDepth: telemetry.queueDepth,
+		activeTasks: telemetry.activeTasks,
+		maxConcurrent: telemetry.maxConcurrent,
+	};
+	if (telemetry.lastTaskDurationMs !== undefined) {
+		params.lastTaskDurationMs = telemetry.lastTaskDurationMs;
+	}
+	if (telemetry.lastTaskStatus !== undefined) {
+		params.lastTaskStatus = telemetry.lastTaskStatus;
+	}
+
+	const result = await hubRpc(rpcUrl, "agents.reportTelemetry", params, hubConfig.apiKey, log, "hub_telemetry");
+	if (result) {
+		return { telemetryUpdatedAt: result.telemetryUpdatedAt as string };
 	}
 	return null;
 }

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -195,9 +195,12 @@ export default function (pi: ExtensionAPI) {
 		if (hubAgentId) {
 			const { config } = loadConfig(cwd);
 			if (config.hub?.apiKey) {
+				const idleSnap = executor
+					? { ...executor.getTelemetrySnapshot(), queueDepth: 0, activeTasks: 0 }
+					: { queueDepth: 0, activeTasks: 0, maxConcurrent: 3 };
 				await reportTelemetryToHub(
 					hubAgentId,
-					{ queueDepth: 0, activeTasks: 0, maxConcurrent: 3 },
+					idleSnap,
 					config.hub,
 					log,
 				).catch(() => {});

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -44,7 +44,7 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub } from "./hub.ts";
+import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub } from "./hub.ts";
 import { sendA2AMessage } from "./client.ts";
 import { createLogger } from "./logger.ts";
 import type { RemoteAgentSummary } from "./types.ts";
@@ -61,6 +61,8 @@ export default function (pi: ExtensionAPI) {
 	let cardEnriched = false;
 	let firstTurnEnriched = false;
 	let executor: PiAgentExecutor | null = null;
+	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
+	let hubAgentId: string | null = null;
 
 	/**
 	 * Enrich the agent card with dynamically discovered tools.
@@ -81,6 +83,13 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
+	/** Send a telemetry snapshot to the hub. Failures are logged but never thrown. */
+	async function sendTelemetry(config: ReturnType<typeof loadConfig>["config"]): Promise<void> {
+		if (!hubAgentId || !executor || !config.hub?.apiKey) return;
+		const snapshot = executor.getTelemetrySnapshot();
+		await reportTelemetryToHub(hubAgentId, snapshot, config.hub, log);
+	}
+
 	// ── Lifecycle ─────────────────────────────────────────────
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -88,7 +97,12 @@ export default function (pi: ExtensionAPI) {
 		cardEnriched = false;
 		firstTurnEnriched = false;
 
-		// Clean restart: abort any running tasks and stop existing server
+		// Clean restart: abort any running tasks, stop telemetry, stop server
+		if (telemetryInterval) {
+			clearInterval(telemetryInterval);
+			telemetryInterval = null;
+		}
+		hubAgentId = null;
 		if (executor) {
 			executor.abortAll();
 			executor = null;
@@ -142,7 +156,17 @@ export default function (pi: ExtensionAPI) {
 		if (config.hub && config.hub.apiKey && (config.hub.autoRegister !== false)) {
 			const result = await registerWithHub(publicUrl, config.hub, log, config.apiKey);
 			if (result) {
+				hubAgentId = result.agentId;
 				ctx.ui.notify(`pi-a2a: Registered with hub (${result.status})`, "info");
+
+				// Start periodic telemetry reporting (every 30s)
+				telemetryInterval = setInterval(() => { sendTelemetry(config).catch(() => {}); }, 30_000);
+
+				// Wire up immediate telemetry report after each task completes
+				executor.onTaskFinished = () => { sendTelemetry(config).catch(() => {}); };
+
+				// Send initial telemetry report
+				sendTelemetry(config).catch(() => {});
 			}
 		}
 	});
@@ -160,6 +184,27 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async () => {
 		cardEnriched = false;
+
+		// Stop telemetry interval
+		if (telemetryInterval) {
+			clearInterval(telemetryInterval);
+			telemetryInterval = null;
+		}
+
+		// Send final "idle" telemetry report before shutting down
+		if (hubAgentId) {
+			const { config } = loadConfig(cwd);
+			if (config.hub?.apiKey) {
+				await reportTelemetryToHub(
+					hubAgentId,
+					{ queueDepth: 0, activeTasks: 0, maxConcurrent: 3 },
+					config.hub,
+					log,
+				).catch(() => {});
+			}
+		}
+		hubAgentId = null;
+
 		if (executor) {
 			executor.abortAll();
 			executor = null;
@@ -209,9 +254,14 @@ export default function (pi: ExtensionAPI) {
 				return txt("No agents found on the hub.");
 			}
 
-			const lines = result.agents.map((a) =>
-				`• **${a.name}** (id: ${a.id})\n  ${a.description}\n  URL: ${a.url} | Health: ${a.healthStatus} | Tags: ${a.tags.join(", ") || "none"}`
-			);
+			const availabilityEmoji: Record<string, string> = { idle: "🟢", busy: "🟡", saturated: "🔴", unknown: "⚪" };
+
+			const lines = result.agents.map((a) => {
+				const emoji = availabilityEmoji[a.availability] ?? "⚪";
+				const availLabel = a.availability.charAt(0).toUpperCase() + a.availability.slice(1);
+				const avgResp = a.avgResponseMs != null ? ` | Avg Response: ${(a.avgResponseMs / 1000).toFixed(1)}s` : "";
+				return `• **${a.name}** (id: ${a.id}) ${emoji} ${availLabel}\n  ${a.description}\n  URL: ${a.url} | Health: ${a.healthStatus}${avgResp} | Tags: ${a.tags.join(", ") || "none"}`;
+			});
 
 			return txt(`Found ${result.total} agent(s) on the hub:\n\n${lines.join("\n\n")}`);
 		},
@@ -308,13 +358,22 @@ export default function (pi: ExtensionAPI) {
 				if (isRunning()) {
 					const card = getAgentCard();
 					const skillCount = card?.skills.length ?? 0;
-					ctx.ui.notify(
+					let statusMsg =
 						`A2A server running on port ${port}\n` +
 						`Agent Card: ${publicUrl}/.well-known/agent-card.json\n` +
 						`Protocol: A2A v0.3.0 | Transport: JSON-RPC\n` +
-						`Skills: ${skillCount} | Streaming: ✓ | Push Notifications: ✓`,
-						"info",
-					);
+						`Skills: ${skillCount} | Streaming: ✓ | Push Notifications: ✓`;
+
+					if (hubAgentId && executor) {
+						const snap = executor.getTelemetrySnapshot();
+						const avgPart = snap.lastTaskDurationMs != null ? ` | avg ${(snap.lastTaskDurationMs / 1000).toFixed(1)}s` : "";
+						statusMsg += `\nHub: registered (agentId=${hubAgentId})\n` +
+							`Telemetry: ${snap.activeTasks} active / ${snap.maxConcurrent} max | ${snap.queueDepth} queued${avgPart}`;
+					} else if (config.hub?.apiKey) {
+						statusMsg += "\nHub: configured but not registered";
+					}
+
+					ctx.ui.notify(statusMsg, "info");
 				} else {
 					ctx.ui.notify("A2A server is not running", "info");
 				}

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -60,6 +60,12 @@ export interface RemoteAgentSummary {
 	healthStatus: "healthy" | "degraded" | "down" | "unknown";
 	popularity: number;
 	featured: boolean;
+	queueDepth: number;
+	activeTasks: number;
+	maxConcurrent: number;
+	avgResponseMs: number | null;
+	availability: "idle" | "busy" | "saturated" | "unknown";
+	telemetryUpdatedAt: string | null;
 }
 
 export interface RemoteAgentDetail {
@@ -78,4 +84,22 @@ export interface RemoteAgentDetail {
 	credentialUpdatedAt: string | null;
 	createdAt: string;
 	updatedAt: string;
+	queueDepth: number;
+	activeTasks: number;
+	maxConcurrent: number;
+	avgResponseMs: number | null;
+	totalTasks: number;
+	totalFailures: number;
+	availability: "idle" | "busy" | "saturated" | "unknown";
+	telemetryUpdatedAt: string | null;
+}
+
+// ── Telemetry Snapshot ──────────────────────────────────────────
+
+export interface TelemetrySnapshot {
+	queueDepth: number;
+	activeTasks: number;
+	maxConcurrent: number;
+	lastTaskDurationMs?: number;
+	lastTaskStatus?: "completed" | "failed";
 }


### PR DESCRIPTION
## Summary

Implements periodic telemetry reporting from the pi-a2a extension to the A2A Hub via the new `agents.reportTelemetry` RPC method. The hub uses this data to compute agent availability (idle/busy/saturated/unknown) and rank agents in search results.

## Changes

### `src/hub.ts` — `reportTelemetryToHub()`
New exported function following the same pattern as `registerWithHub()`, `discoverAgentsOnHub()`, etc. Calls `agents.reportTelemetry` via the existing `hubRpc()` helper.

### `src/agent-executor.ts` — Telemetry tracking
- Added `getTelemetrySnapshot()` method returning current queue depth, active tasks, max concurrent, and last task duration/status
- Tracks `lastTaskDurationMs` and `lastTaskStatus` after each task completes or fails
- Added `onTaskFinished` callback for immediate telemetry reporting

### `src/index.ts` — Lifecycle integration
- Starts 30s telemetry interval after successful hub registration
- Reports telemetry immediately after each task completes (via `onTaskFinished` callback)
- Sends initial telemetry report on registration
- Sends final idle report on `session_shutdown`
- Cleans up interval on shutdown and restart
- Updated `a2a_discover` output to show availability emoji (🟢🟡🔴⚪) and avg response time
- Updated `/a2a status` to show hub registration state and telemetry snapshot

### `src/types.ts` — Type updates
- Added telemetry fields to `RemoteAgentSummary`: queueDepth, activeTasks, maxConcurrent, avgResponseMs, availability, telemetryUpdatedAt
- Added telemetry fields to `RemoteAgentDetail`: same plus totalTasks, totalFailures
- Added `TelemetrySnapshot` interface

## Task
td-ecfa3a