### PR TITLE
feat(pi-a2a): async fire-and-forget messaging with callback pattern

### DIFF
--- a/extensions/pi-a2a/AGENTS.md
+++ b/extensions/pi-a2a/AGENTS.md
@@ -32,6 +32,7 @@ src/
 - **Self-contained HTTP server** — Uses `node:http` directly. No dependency on pi-webserver, pi-kysely, or any other extension. Binds to `127.0.0.1` by default; optional API key auth for external access.
 - **Dynamic agent card** — Starts with a basic card from config, then enriches it with registered extension tools after all extensions load. Uses a two-phase approach: `queueMicrotask` after `session_start` catches most tools, `agent_start` catches stragglers.
 - **Subprocess isolation** — Each `message/send` spawns a fresh `pi --mode rpc -ne` process. No shared state, no extension leakage. Cancellation kills the subprocess via `AbortController`.
+- **Async fire-and-forget messaging** — Outbound `a2a_send` sends with `blocking: false` (A2A spec §3.3.3). The receiver returns a submitted task immediately; the sender goes idle. When processing completes, the receiver sends results back via a callback POST to the sender's A2A endpoint (`pi:callback` metadata). The sender's server intercepts callbacks (`pi:isCallback` metadata) and injects the response directly into the conversation.
 - **Settings-driven** — All config via `pi-a2a` key in settings.json. No env vars.
 - **Static agent registry** — Manually configured remote agents in `staticAgents[]`. Agent cards are fetched from `/.well-known/agent-card.json` on session start and cached in memory. No hub required. Refresh via `/a2a agents refresh` command. Static agents are resolved first in `a2a_send`, before hub lookup.
 

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -61,8 +61,10 @@ export class PiAgentExecutor implements AgentExecutor {
 	private lastTaskDurationMs?: number;
 	/** Last completed/failed task status for telemetry reporting. */
 	private lastTaskStatus?: "completed" | "failed";
-	/** Optional callback invoked after each task completes or fails. */
+	/** Optional callback invoked after each task completes or fails (used for telemetry). */
 	onTaskFinished?: () => void;
+	/** Optional callback invoked when a task completes with a response and the sender requested a callback. */
+	onResultReady?: (taskId: string, response: string, callbackInfo: { url: string; credential?: string }) => void;
 
 	constructor(log: LogFn, processMessage: ProcessMessage) {
 		this.log = log;
@@ -219,6 +221,14 @@ export class PiAgentExecutor implements AgentExecutor {
 					final: true,
 				} as TaskStatusUpdateEvent);
 				this.log("executor_completed", { taskId, responseLength: result.response.length, durationMs: result.durationMs });
+
+				// Send callback to sender if requested via pi:callback metadata
+				const callbackMeta = (userMessage.metadata as Record<string, unknown> | undefined)?.["pi:callback"] as
+					| { url?: string; credential?: string }
+					| undefined;
+				if (callbackMeta?.url && this.onResultReady) {
+					this.onResultReady(taskId, result.response, { url: callbackMeta.url, credential: callbackMeta.credential });
+				}
 
 				// Record telemetry for hub reporting
 				this.lastTaskDurationMs = result.durationMs;

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -27,6 +27,12 @@ export interface SendMessageOptions {
 	timeoutMs?: number;
 	/** Local agent identity to include as sender metadata. */
 	sender?: SenderIdentity;
+	/** If false, server returns immediately with a submitted task. Defaults to true. */
+	blocking?: boolean;
+	/** Callback URL for the receiver to send results back (used with blocking: false). */
+	callbackUrl?: string;
+	/** Credential for authenticating the callback to our endpoint. */
+	callbackCredential?: string;
 }
 
 export interface SendMessageResult {
@@ -39,6 +45,10 @@ export interface SendMessageResult {
 	error?: string;
 	/** True when the remote agent returned HTTP 401 — credential may be stale. */
 	unauthorized?: boolean;
+	/** Task state if the response is a non-completed task (async processing). */
+	taskState?: string;
+	/** Task ID if the response is a task. */
+	taskId?: string;
 }
 
 /**
@@ -51,28 +61,42 @@ export async function sendA2AMessage(
 	opts: SendMessageOptions,
 	log: LogFn,
 ): Promise<SendMessageResult> {
-	const { url, message, credential, timeoutMs = 120_000, sender } = opts;
+	const { url, message, credential, timeoutMs = 120_000, sender, blocking = true, callbackUrl, callbackCredential } = opts;
 
-	// Build the message object, optionally including sender identity in metadata
+	// Build the message object, optionally including sender identity and callback info in metadata
+	const metadata: Record<string, unknown> = {};
+	if (sender) {
+		metadata["pi:sender"] = {
+			name: sender.name,
+			...(sender.description ? { description: sender.description } : {}),
+		};
+	}
+	if (callbackUrl) {
+		metadata["pi:callback"] = {
+			url: callbackUrl,
+			...(callbackCredential ? { credential: callbackCredential } : {}),
+		};
+	}
+
 	const msg: Record<string, unknown> = {
 		kind: "message",
 		messageId: randomUUID(),
 		role: "user",
 		parts: [{ kind: "text", text: message }],
 	};
-	if (sender) {
-		msg.metadata = {
-			"pi:sender": {
-				name: sender.name,
-				...(sender.description ? { description: sender.description } : {}),
-			},
-		};
+	if (Object.keys(metadata).length > 0) {
+		msg.metadata = metadata;
+	}
+
+	const params: Record<string, unknown> = { message: msg };
+	if (!blocking) {
+		params.configuration = { blocking: false };
 	}
 
 	const payload = {
 		jsonrpc: "2.0" as const,
 		method: "message/send",
-		params: { message: msg },
+		params,
 		id: randomUUID(),
 	};
 
@@ -120,6 +144,16 @@ export async function sendA2AMessage(
 			return { ok: false, error: "Empty result from remote agent", raw: data };
 		}
 
+		// Check if response is a task in a non-terminal state (async processing)
+		const resultObj = data.result as Record<string, unknown>;
+		const taskStatus = resultObj.status as { state?: string } | undefined;
+		const terminalStates = ["completed", "failed", "canceled", "rejected"];
+		if (taskStatus?.state && !terminalStates.includes(taskStatus.state)) {
+			const taskId = resultObj.id as string | undefined;
+			log("a2a_send_async", { url, taskId, state: taskStatus.state });
+			return { ok: true, response: "", taskId, taskState: taskStatus.state, raw: data.result };
+		}
+
 		// Extract response text from the A2A task result
 		const responseText = extractResponseText(data.result);
 		log("a2a_send_success", { url, responseLength: responseText.length });
@@ -129,6 +163,76 @@ export async function sendA2AMessage(
 		const msg = err instanceof Error ? err.message : String(err);
 		log("a2a_send_error", { url, error: msg }, "ERROR");
 		return { ok: false, error: msg };
+	}
+}
+
+/**
+ * Send a callback with results to the original sender.
+ *
+ * Used by the receiver after async processing completes.
+ * The callback is a standard message/send with `pi:isCallback: true` metadata,
+ * which the sender's server intercepts and injects directly into the conversation.
+ */
+export async function sendA2ACallback(
+	opts: {
+		url: string;
+		credential?: string | null;
+		taskId: string;
+		response: string;
+		sender?: SenderIdentity;
+	},
+	log: LogFn,
+): Promise<void> {
+	const { url, credential, taskId, response, sender } = opts;
+	const metadata: Record<string, unknown> = {
+		"pi:isCallback": true,
+		"pi:taskId": taskId,
+	};
+	if (sender) {
+		metadata["pi:sender"] = {
+			name: sender.name,
+			...(sender.description ? { description: sender.description } : {}),
+		};
+	}
+
+	const msg = {
+		kind: "message",
+		messageId: randomUUID(),
+		role: "user",
+		parts: [{ kind: "text", text: response }],
+		metadata,
+	};
+
+	const payload = {
+		jsonrpc: "2.0" as const,
+		method: "message/send",
+		params: { message: msg },
+		id: randomUUID(),
+	};
+
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (credential) {
+		headers["Authorization"] = `Bearer ${credential}`;
+	}
+
+	log("a2a_callback_start", { url, taskId, responseLength: response.length });
+
+	try {
+		const res = await fetch(url, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(30_000),
+		});
+
+		if (!res.ok) {
+			log("a2a_callback_failed", { url, taskId, status: res.status }, "ERROR");
+		} else {
+			log("a2a_callback_sent", { url, taskId });
+		}
+	} catch (err: unknown) {
+		const errMsg = err instanceof Error ? err.message : String(err);
+		log("a2a_callback_error", { url, taskId, error: errMsg }, "ERROR");
 	}
 }
 

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -47,7 +47,7 @@ import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
 import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub } from "./hub.ts";
-import { sendA2AMessage, type SenderIdentity } from "./client.ts";
+import { sendA2AMessage, sendA2ACallback, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
 import type { HubConfig, RemoteAgentSummary } from "./types.ts";
@@ -91,6 +91,8 @@ export default function (pi: ExtensionAPI) {
 	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
 	let staticRegistry: StaticAgentRegistry | null = null;
+	/** Public URL of our A2A server (for async callbacks). */
+	let serverPublicUrl: string | null = null;
 
 	// ── Main-process message handling ─────────────────────────
 	//
@@ -291,6 +293,7 @@ export default function (pi: ExtensionAPI) {
 		}
 		hubAgentId = null;
 		staticRegistry = null;
+		serverPublicUrl = null;
 		if (executor) {
 			executor.abortAll();
 			executor = null;
@@ -303,10 +306,27 @@ export default function (pi: ExtensionAPI) {
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
 		const port = config.port ?? DEFAULT_PORT;
 		const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
+		serverPublicUrl = publicUrl;
 		const agentCard = buildAgentCard(config, publicUrl);
 
 		// Set up executor with main-process callback
 		executor = new PiAgentExecutor(log, processMessage);
+
+		// Wire async callback: when a task completes and the sender requested a callback,
+		// send the result back to the sender's A2A endpoint.
+		executor.onResultReady = (taskId, response, callbackInfo) => {
+			sendA2ACallback(
+				{
+					url: callbackInfo.url,
+					credential: callbackInfo.credential,
+					taskId,
+					response,
+					sender: { name: config.name ?? "Pi Agent", description: config.description },
+				},
+				log,
+			).catch(() => {}); // fire and forget
+		};
+
 		const taskStore = new InMemoryTaskStore();
 		const pushNotificationStore = new InMemoryPushNotificationStore();
 		const pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
@@ -329,7 +349,22 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.notify("pi-a2a: WARNING — binding to external interface without apiKey. Set pi-a2a.apiKey in settings.json.", "warning");
 		}
 		try {
-			await startServer({ port, bind, apiKey: config.apiKey, agentCard, rpcHandler, log });
+			await startServer({
+				port, bind, apiKey: config.apiKey, agentCard, rpcHandler, log,
+				// Handle async callback responses from remote agents
+				onCallback: (text, senderName, taskId) => {
+					log("a2a_callback_received", { senderName, taskId, responseLength: text.length });
+					pi.sendMessage(
+						{
+							customType: "a2a-response-received",
+							content: `📨 **A2A response from ${senderName}** (async):\n\n${text}`,
+							display: true,
+						},
+						{ triggerTurn: true },
+					);
+					updateStatusLine();
+				},
+			});
 			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${port}`, "info");
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
@@ -634,6 +669,12 @@ export default function (pi: ExtensionAPI) {
 				message: params.message,
 				credential,
 				sender: { name: config.name ?? "Pi Agent", description: config.description } as SenderIdentity,
+				// Send non-blocking with callback so we don't hold the connection open.
+				// The receiver returns immediately with a submitted task, then sends
+				// the result back to our A2A endpoint when processing completes.
+				blocking: false,
+				callbackUrl: serverPublicUrl ?? undefined,
+				callbackCredential: config.apiKey,
 			};
 
 			(async () => {
@@ -659,15 +700,29 @@ export default function (pi: ExtensionAPI) {
 				const dur = fmtDuration(Date.now() - sendStart);
 
 				if (result.ok) {
-					pi.sendMessage(
-						{
-							customType: "a2a-response-received",
-							content:
-								`📨 **A2A response from ${resolvedName}** (${dur}):\n\n${result.response}`,
-							display: true,
-						},
-						{ triggerTurn: true },
-					);
+					if (result.taskState && result.taskState !== "completed") {
+						// Non-blocking: task accepted, response will arrive via async callback
+						pi.sendMessage(
+							{
+								customType: "a2a-submitted",
+								content:
+									`✅ **${resolvedName}** accepted the request. Response will arrive when processing completes.`,
+								display: true,
+							},
+							{ triggerTurn: false },
+						);
+					} else {
+						// Blocking fallback or fast completion: full response available
+						pi.sendMessage(
+							{
+								customType: "a2a-response-received",
+								content:
+									`📨 **A2A response from ${resolvedName}** (${dur}):\n\n${result.response}`,
+								display: true,
+							},
+							{ triggerTurn: true },
+						);
+					}
 				} else {
 					pi.sendMessage(
 						{

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -45,7 +45,7 @@ import {
 import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
-import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
+import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard, generateCallbackToken } from "./server.ts";
 import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub } from "./hub.ts";
 import { sendA2AMessage, sendA2ACallback, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
@@ -674,7 +674,9 @@ export default function (pi: ExtensionAPI) {
 				// the result back to our A2A endpoint when processing completes.
 				blocking: false,
 				callbackUrl: serverPublicUrl ?? undefined,
-				callbackCredential: config.apiKey,
+				// Issue a scoped HMAC callback token instead of sending the full API key.
+				// This token only grants access to the callback intercept path.
+				callbackCredential: config.apiKey ? generateCallbackToken(config.apiKey) : undefined,
 			};
 
 			(async () => {

--- a/extensions/pi-a2a/src/server.ts
+++ b/extensions/pi-a2a/src/server.ts
@@ -13,6 +13,7 @@
  */
 
 import * as http from "node:http";
+import { randomUUID } from "node:crypto";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { AgentCard } from "@a2a-js/sdk";
 import type { JsonRpcTransportHandler } from "@a2a-js/sdk/server";
@@ -30,6 +31,8 @@ export interface ServerOptions {
 	/** SDK JSON-RPC transport handler for A2A protocol dispatch. */
 	rpcHandler: JsonRpcTransportHandler;
 	log: LogFn;
+	/** Handler for A2A callback messages (async responses from remote agents). */
+	onCallback?: (text: string, senderName: string, taskId: string) => void;
 }
 
 let server: http.Server | null = null;
@@ -129,6 +132,41 @@ export function startServer(opts: ServerOptions): Promise<void> {
 							id: null,
 						}));
 						return;
+					}
+
+					// Intercept callback messages — async responses from remote agents.
+					// These have pi:isCallback in message metadata and should be injected
+					// directly into the conversation without going through the executor.
+					if (opts.onCallback) {
+						const rpc = parsed as { method?: string; params?: { message?: Record<string, unknown> }; id?: unknown };
+						if (rpc.method === "message/send") {
+							const meta = rpc.params?.message?.metadata as Record<string, unknown> | undefined;
+							if (meta?.["pi:isCallback"] === true) {
+								const parts = rpc.params?.message?.parts as Array<{ kind: string; text?: string }> | undefined;
+								const text = parts?.find((p) => p.kind === "text")?.text ?? "";
+								const senderMeta = meta["pi:sender"] as { name?: string } | undefined;
+								const senderName = senderMeta?.name ?? "Unknown agent";
+								const taskId = (meta["pi:taskId"] as string) ?? "";
+
+								opts.onCallback(text, senderName, taskId);
+
+								// Return ACK — don't pass to SDK handler
+								res.writeHead(200, { "Content-Type": "application/json" });
+								res.end(JSON.stringify({
+									jsonrpc: "2.0",
+									id: rpc.id ?? null,
+									result: {
+										message: {
+											kind: "message",
+											messageId: randomUUID(),
+											role: "agent",
+											parts: [{ kind: "text", text: "Callback received" }],
+										},
+									},
+								}));
+								return;
+							}
+						}
 					}
 
 					const result = await opts.rpcHandler.handle(parsed);

--- a/extensions/pi-a2a/src/server.ts
+++ b/extensions/pi-a2a/src/server.ts
@@ -108,17 +108,6 @@ export function startServer(opts: ServerOptions): Promise<void> {
 						opts.log("a2a_version_mismatch", { clientVersion, supported: "0.3.x" }, "WARN");
 					}
 
-					// API key auth when configured
-					if (opts.apiKey) {
-						const authHeader = req.headers.authorization ?? "";
-						const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
-						if (!constantTimeEqual(token, opts.apiKey)) {
-							res.writeHead(401, { "Content-Type": "application/json" });
-							res.end(JSON.stringify({ error: "Unauthorized" }));
-							return;
-						}
-					}
-
 					const body = await readBody(req);
 
 					let parsed: unknown;
@@ -137,13 +126,33 @@ export function startServer(opts: ServerOptions): Promise<void> {
 					// Intercept callback messages — async responses from remote agents.
 					// These have pi:isCallback in message metadata and should be injected
 					// directly into the conversation without going through the executor.
+					// Callbacks authenticate with a scoped HMAC token, not the full API key.
 					if (opts.onCallback) {
 						const rpc = parsed as { method?: string; params?: { message?: Record<string, unknown> }; id?: unknown };
 						if (rpc.method === "message/send") {
 							const meta = rpc.params?.message?.metadata as Record<string, unknown> | undefined;
 							if (meta?.["pi:isCallback"] === true) {
+								// Validate scoped callback token (not the full API key)
+								if (opts.apiKey) {
+									const authHeader = req.headers.authorization ?? "";
+									const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+									if (!validateCallbackToken(token, opts.apiKey)) {
+										res.writeHead(401, { "Content-Type": "application/json" });
+										res.end(JSON.stringify({ error: "Unauthorized — invalid callback token" }));
+										return;
+									}
+								}
+
 								const parts = rpc.params?.message?.parts as Array<{ kind: string; text?: string }> | undefined;
-								const text = parts?.find((p) => p.kind === "text")?.text ?? "";
+								let text = parts?.find((p) => p.kind === "text")?.text ?? "";
+
+								// Guard against unbounded callback payloads
+								const MAX_CALLBACK_TEXT = 64 * 1024; // 64 KB
+								if (text.length > MAX_CALLBACK_TEXT) {
+									opts.log("callback_text_truncated", { original: text.length, max: MAX_CALLBACK_TEXT }, "WARN");
+									text = text.slice(0, MAX_CALLBACK_TEXT) + "\n\n⚠️ Response truncated (exceeded 64 KB limit)";
+								}
+
 								const senderMeta = meta["pi:sender"] as { name?: string } | undefined;
 								const senderName = senderMeta?.name ?? "Unknown agent";
 								const taskId = (meta["pi:taskId"] as string) ?? "";
@@ -166,6 +175,17 @@ export function startServer(opts: ServerOptions): Promise<void> {
 								}));
 								return;
 							}
+						}
+					}
+
+					// API key auth for all non-callback requests
+					if (opts.apiKey) {
+						const authHeader = req.headers.authorization ?? "";
+						const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+						if (!constantTimeEqual(token, opts.apiKey)) {
+							res.writeHead(401, { "Content-Type": "application/json" });
+							res.end(JSON.stringify({ error: "Unauthorized" }));
+							return;
 						}
 					}
 
@@ -280,6 +300,31 @@ function constantTimeEqual(a: string, b: string): boolean {
 	const hb = createHmac("sha256", key).update(b).digest();
 	// HMAC outputs are always 32 bytes — no length leak
 	return timingSafeEqual(ha, hb);
+}
+
+/**
+ * Generate a scoped callback token: `nonce:hmac`.
+ *
+ * Unlike the static API key, this token is single-purpose — it only grants
+ * access to the callback intercept path, not the full A2A server.
+ */
+export function generateCallbackToken(apiKey: string): string {
+	const nonce = randomUUID();
+	const hmac = createHmac("sha256", apiKey).update(nonce).digest("hex");
+	return `${nonce}:${hmac}`;
+}
+
+/**
+ * Validate a callback token against the server's API key.
+ * Returns true if the token is a valid `nonce:hmac` pair.
+ */
+function validateCallbackToken(token: string, apiKey: string): boolean {
+	const sepIdx = token.indexOf(":");
+	if (sepIdx < 1) return false;
+	const nonce = token.slice(0, sepIdx);
+	const providedHmac = token.slice(sepIdx + 1);
+	const expectedHmac = createHmac("sha256", apiKey).update(nonce).digest("hex");
+	return constantTimeEqual(providedHmac, expectedHmac);
 }
 
 class PayloadTooLargeError extends Error {


### PR DESCRIPTION
Implements A2A spec §3.3.3 async processing. Sender no longer holds
an HTTP connection open waiting for the receiver to finish.

Flow:
1. Sender sends message/send with configuration.blocking=false
   and pi:callback metadata (our A2A URL + credential)
2. Receiver's SDK returns immediately with a submitted task
3. Sender accepts it and goes idle — no timeout risk
4. Receiver processes in background via the main agent
5. When done, executor calls onResultReady → sends result back
   to sender's callback URL via sendA2ACallback()
6. Sender's server intercepts the callback (pi:isCallback metadata)
   and injects the response directly into the conversation

Changes:
- client.ts: blocking option, callback metadata in message, async
  task detection in response, new sendA2ACallback() function
- agent-executor.ts: onResultReady callback after task completion,
  extracts pi:callback metadata from sender's message
- server.ts: intercepts callback messages before SDK handler,
  injects response text via onCallback option
- index.ts: wires everything — onCallback in server, onResultReady
  on executor, non-blocking sendOpts with callback URL in a2a_send,
  handles submitted task vs completed task in response handler
