### PR TITLE
feat(pi-github): auto-remove worktrees during pr-merge cleanup

### DIFF
--- a/extensions/pi-github/package-lock.json
+++ b/extensions/pi-github/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "pi-github",
+  "name": "@e9n/pi-github",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pi-github",
+      "name": "@e9n/pi-github",
       "version": "0.2.0",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"
       },

--- a/extensions/pi-github/src/pr-merge.ts
+++ b/extensions/pi-github/src/pr-merge.ts
@@ -10,6 +10,8 @@
  *   6. Clean up: delete remote/local branch, pull base, prune
  */
 
+import { rmdir } from "node:fs/promises";
+import { resolve as resolvePath } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { gh, ghJson, gitExec, gitExecRetry, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
 import { registerDualCommand } from "./commands.ts";
@@ -239,12 +241,38 @@ async function cleanupBranches(
 		// Use -D (force) because squash/rebase merges on GitHub don't create
 		// a local merge commit, so git branch -d thinks it's "not fully merged".
 		//
-		// If the head branch is checked out in a worktree, we can't delete it —
-		// the worktree must be removed first. Warn and skip.
-		const headWorktree = await findWorktreeForBranch(headBranch, cwd);
+		// If the head branch is checked out in a worktree, remove the worktree
+		// first so the branch can be deleted. If we're currently inside the
+		// worktree, we can't remove it — warn and skip.
+		let headWorktree = await findWorktreeForBranch(headBranch, cwd);
 		if (headWorktree) {
-			ctx.ui.notify(`⚠️ Branch \`${headBranch}\` is checked out in worktree at \`${headWorktree}\`. Remove the worktree first to delete the branch: \`git worktree remove ${headWorktree}\``, "warning");
-		} else {
+			const resolvedCwd = resolvePath(cwd);
+			const resolvedWorktree = resolvePath(headWorktree);
+			if (resolvedCwd === resolvedWorktree || resolvedCwd.startsWith(resolvedWorktree + "/")) {
+				// We're running from inside the worktree — can't remove it
+				ctx.ui.notify(`⚠️ Branch \`${headBranch}\` is checked out in the current worktree at \`${headWorktree}\`. Can't auto-remove — run from the main repo or remove manually: \`git worktree remove ${headWorktree}\``, "warning");
+			} else {
+				// Safe to auto-remove the worktree
+				const wtPath = headWorktree; // save before nulling
+				const wtRemove = await gitExec(["worktree", "remove", wtPath], cwd, 15_000);
+				if (wtRemove.ok) {
+					ctx.ui.notify(`🗑️ Removed worktree at \`${wtPath}\`.`, "info");
+					headWorktree = null; // cleared — proceed to branch deletion below
+
+					// Try to clean up the empty parent directory (e.g. ../pi-worktrees/td-xxx/)
+					try {
+						const parentDir = resolvePath(wtPath, "..");
+						await rmdir(parentDir); // only succeeds if empty
+					} catch {
+						// Not empty or doesn't exist — fine
+					}
+				} else {
+					errors.push(`Could not remove worktree at \`${wtPath}\`: ${wtRemove.stderr}`);
+				}
+			}
+		}
+
+		if (!headWorktree) {
 			const nowOn = await getCurrentBranch(cwd);
 			if (nowOn !== headBranch) {
 				// Guard: warn about local-only commits before force-deleting.

--- a/extensions/pi-github/src/pr-merge.ts
+++ b/extensions/pi-github/src/pr-merge.ts
@@ -206,7 +206,39 @@ async function cleanupBranches(
 		errors.push(`Failed to delete remote branch: ${remoteDelete.stderr}`);
 	}
 
-	// Switch to base branch and pull
+	// ── Remove head-branch worktree (if any) ────────────────
+	// Do this BEFORE checkout/pull so the branch is unlocked and
+	// we don't fail trying to checkout or delete it later.
+	let worktreeBlocking = false;
+	const headWorktree = await findWorktreeForBranch(headBranch, cwd);
+	if (headWorktree) {
+		const resolvedCwd = resolvePath(cwd);
+		const resolvedWorktree = resolvePath(headWorktree);
+		if (resolvedCwd === resolvedWorktree || resolvedCwd.startsWith(resolvedWorktree + "/")) {
+			// We're running from inside the worktree — can't remove it
+			worktreeBlocking = true;
+			ctx.ui.notify(`⚠️ Branch \`${headBranch}\` is checked out in the current worktree at \`${headWorktree}\`. Can't auto-remove — run from the main repo or remove manually: \`git worktree remove ${headWorktree}\``, "warning");
+		} else {
+			// Safe to auto-remove the worktree
+			const wtRemove = await gitExec(["worktree", "remove", headWorktree], cwd, 15_000);
+			if (wtRemove.ok) {
+				ctx.ui.notify(`🗑️ Removed worktree at \`${headWorktree}\`.`, "info");
+
+				// Try to clean up the empty parent directory (e.g. ../pi-worktrees/td-xxx/)
+				try {
+					const parentDir = resolvePath(headWorktree, "..");
+					await rmdir(parentDir); // only succeeds if empty
+				} catch {
+					// Not empty or doesn't exist — fine
+				}
+			} else {
+				worktreeBlocking = true;
+				errors.push(`Could not remove worktree at \`${headWorktree}\`: ${wtRemove.stderr}`);
+			}
+		}
+	}
+
+	// ── Switch to base branch and pull ──────────────────────
 	let onBaseBranch = false;
 	let pullCwd = cwd; // where to run pull — may differ if base is in a worktree
 	const currentBranch = await getCurrentBranch(cwd);
@@ -218,11 +250,11 @@ async function cleanupBranches(
 			onBaseBranch = true;
 		} else {
 			// Check if the base branch is checked out in a worktree
-			const worktreePath = await findWorktreeForBranch(baseBranch, cwd);
-			if (worktreePath) {
+			const baseWorktree = await findWorktreeForBranch(baseBranch, cwd);
+			if (baseWorktree) {
 				onBaseBranch = true;
-				pullCwd = worktreePath;
-				ctx.ui.notify(`Branch \`${baseBranch}\` is in worktree at \`${worktreePath}\`. Pulling there.`, "info");
+				pullCwd = baseWorktree;
+				ctx.ui.notify(`Branch \`${baseBranch}\` is in worktree at \`${baseWorktree}\`. Pulling there.`, "info");
 			} else {
 				errors.push(`Failed to checkout ${baseBranch}: ${checkout.stderr}`);
 			}
@@ -237,42 +269,11 @@ async function cleanupBranches(
 			errors.push(`Failed to pull ${baseBranch}: ${pull.stderr}`);
 		}
 
-		// Delete local branch (if it exists and we're not on it).
+		// ── Delete local head branch ────────────────────────
 		// Use -D (force) because squash/rebase merges on GitHub don't create
 		// a local merge commit, so git branch -d thinks it's "not fully merged".
-		//
-		// If the head branch is checked out in a worktree, remove the worktree
-		// first so the branch can be deleted. If we're currently inside the
-		// worktree, we can't remove it — warn and skip.
-		let headWorktree = await findWorktreeForBranch(headBranch, cwd);
-		if (headWorktree) {
-			const resolvedCwd = resolvePath(cwd);
-			const resolvedWorktree = resolvePath(headWorktree);
-			if (resolvedCwd === resolvedWorktree || resolvedCwd.startsWith(resolvedWorktree + "/")) {
-				// We're running from inside the worktree — can't remove it
-				ctx.ui.notify(`⚠️ Branch \`${headBranch}\` is checked out in the current worktree at \`${headWorktree}\`. Can't auto-remove — run from the main repo or remove manually: \`git worktree remove ${headWorktree}\``, "warning");
-			} else {
-				// Safe to auto-remove the worktree
-				const wtPath = headWorktree; // save before nulling
-				const wtRemove = await gitExec(["worktree", "remove", wtPath], cwd, 15_000);
-				if (wtRemove.ok) {
-					ctx.ui.notify(`🗑️ Removed worktree at \`${wtPath}\`.`, "info");
-					headWorktree = null; // cleared — proceed to branch deletion below
-
-					// Try to clean up the empty parent directory (e.g. ../pi-worktrees/td-xxx/)
-					try {
-						const parentDir = resolvePath(wtPath, "..");
-						await rmdir(parentDir); // only succeeds if empty
-					} catch {
-						// Not empty or doesn't exist — fine
-					}
-				} else {
-					errors.push(`Could not remove worktree at \`${wtPath}\`: ${wtRemove.stderr}`);
-				}
-			}
-		}
-
-		if (!headWorktree) {
+		// Skip if the worktree couldn't be removed (branch is still locked).
+		if (!worktreeBlocking) {
 			const nowOn = await getCurrentBranch(cwd);
 			if (nowOn !== headBranch) {
 				// Guard: warn about local-only commits before force-deleting.


### PR DESCRIPTION
When the head branch is checked out in a worktree, /gh-pr-merge now
automatically removes the worktree (and cleans up the empty parent
directory) before deleting the local branch.

If the command is running from inside the worktree itself, it falls
back to the previous behavior of warning the user to remove it manually.
