### PR TITLE
feat(pi-a2a): add lastSeenAt support and wire up executor.onTaskFinished hook

### DIFF
--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -352,6 +352,18 @@ export default function (pi: ExtensionAPI) {
 
 		// Set up executor with main-process callback
 		executor = new PiAgentExecutor(log, processMessage);
+
+		// When the executor finishes an A2A task, refresh TUI status and
+		// send telemetry so the hub sees "idle" immediately — agent_end
+		// fires before the executor clears activeTaskId, so this callback
+		// is the earliest reliable point where executor.isBusy() is false.
+		executor.onTaskFinished = () => {
+			updateStatusLine();
+			if (hubAgentId) {
+				sendTelemetry(config).catch(() => {});
+			}
+		};
+
 		const taskStore = new InMemoryTaskStore();
 		const pushNotificationStore = new InMemoryPushNotificationStore();
 		const pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
@@ -584,8 +596,9 @@ export default function (pi: ExtensionAPI) {
 						const emoji = availabilityEmoji[a.availability] ?? "⚪";
 						const availLabel = a.availability.charAt(0).toUpperCase() + a.availability.slice(1);
 						const avgResp = a.avgResponseMs != null ? ` | Avg Response: ${(a.avgResponseMs / 1000).toFixed(1)}s` : "";
+						const lastSeen = a.lastSeenAt ? ` | Last seen: ${a.lastSeenAt}` : "";
 						lines.push(
-							`• **${a.name}** (id: ${a.id}) ${emoji} ${availLabel}\n  ${a.description}\n  URL: ${a.url} | Health: ${a.healthStatus}${avgResp} | Tags: ${a.tags.join(", ") || "none"}`,
+							`• **${a.name}** (id: ${a.id}) ${emoji} ${availLabel}\n  ${a.description}\n  URL: ${a.url} | Health: ${a.healthStatus}${avgResp}${lastSeen} | Tags: ${a.tags.join(", ") || "none"}`,
 						);
 						totalCount++;
 					}

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -82,6 +82,7 @@ export interface RemoteAgentSummary {
 	avgResponseMs: number | null;
 	availability: "idle" | "busy" | "saturated" | "unknown";
 	telemetryUpdatedAt: string | null;
+	lastSeenAt: string | null;
 }
 
 export interface RemoteAgentDetail {
@@ -108,6 +109,7 @@ export interface RemoteAgentDetail {
 	totalFailures: number;
 	availability: "idle" | "busy" | "saturated" | "unknown";
 	telemetryUpdatedAt: string | null;
+	lastSeenAt: string | null;
 }
 
 // ── Telemetry Snapshot ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `lastSeenAt` field to `RemoteAgentSummary` and `RemoteAgentDetail` types (new hub field)
- Display `lastSeenAt` in `a2a_discover` tool output
- Wire up `executor.onTaskFinished` callback to send telemetry and update TUI status line when an A2A task completes

## Problem

Agents were staying shown as "busy" on the hub after becoming idle. The `agent_end` hook fires before the executor clears `activeTaskId`, so `executor.isBusy()` still returns `true` at that point. The `updateStatusLine()` call in the `agent_end` handler shows the wrong state, and no subsequent update corrects it.

## Fix

Wire up `executor.onTaskFinished` — the callback that fires after the executor clears `activeTaskId` and records task stats. This is the earliest reliable point where `executor.isBusy()` returns `false`. The callback now:
1. Calls `updateStatusLine()` to refresh the TUI footer
2. Sends telemetry to the hub confirming idle state

Task: td-d728fc