### PR TITLE
fix(pi-cmux): align client with actual cmux socket API

### DIFF
--- a/extensions/pi-cmux/AGENTS.md
+++ b/extensions/pi-cmux/AGENTS.md
@@ -33,12 +33,20 @@ cmux injects these env vars into every terminal it spawns:
 
 If any are missing or the socket doesn't exist, the extension does nothing.
 
-### Socket protocol
+### Socket protocols
 
-Newline-terminated JSON-RPC over Unix domain socket:
+Two protocols over the same Unix domain socket:
+
+**JSON-RPC** — for workspace, surface, notification, browser, and system commands:
 ```
 → {"id":"uuid","method":"surface.list","params":{}}\n
 ← {"id":"uuid","ok":true,"result":{"surfaces":[...]}}\n
+```
+
+**Text-based** — for sidebar metadata (status pills, progress bars, logs):
+```
+→ set_status pi thinking... --tab=<workspace-uuid>\n
+← OK\n
 ```
 
 ## Conventions

--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -240,15 +240,30 @@ export class CmuxClient {
 	// ── Sidebar metadata (text-based protocol) ──────────────────
 
 	/**
+	 * Quote a value for the text-based sidebar protocol.
+	 * Strips CR/LF (which would split into multiple socket messages)
+	 * and wraps in single quotes if the value contains spaces or quotes.
+	 */
+	private q(s: string): string {
+		// Strip newlines — they'd split the command on the wire
+		const clean = s.replace(/[\r\n]/g, " ");
+		// If it contains spaces or single quotes, shell-quote it
+		if (/[\s']/.test(clean)) {
+			return `'${clean.replace(/'/g, "'\\''")}'`;
+		}
+		return clean;
+	}
+
+	/**
 	 * Set a sidebar status pill.
 	 * Uses a unique key so different tools can manage their own entries.
 	 */
 	async setStatus(key: string, value: string, options?: { icon?: string; color?: string }): Promise<void> {
 		const workspaceId = process.env.CMUX_WORKSPACE_ID;
 		if (!workspaceId) return;
-		let cmd = `set_status ${key} ${value}`;
-		if (options?.icon) cmd += ` --icon=${options.icon}`;
-		if (options?.color) cmd += ` --color=${options.color}`;
+		let cmd = `set_status ${this.q(key)} ${this.q(value)}`;
+		if (options?.icon) cmd += ` --icon=${this.q(options.icon)}`;
+		if (options?.color) cmd += ` --color=${this.q(options.color)}`;
 		cmd += ` --tab=${workspaceId}`;
 		await this.textCmd(cmd);
 	}
@@ -257,7 +272,7 @@ export class CmuxClient {
 	async clearStatus(key: string): Promise<void> {
 		const workspaceId = process.env.CMUX_WORKSPACE_ID;
 		if (!workspaceId) return;
-		await this.textCmd(`clear_status ${key} --tab=${workspaceId}`);
+		await this.textCmd(`clear_status ${this.q(key)} --tab=${workspaceId}`);
 	}
 
 	/** Set progress bar (0.0–1.0) in the sidebar. */
@@ -265,7 +280,7 @@ export class CmuxClient {
 		const workspaceId = process.env.CMUX_WORKSPACE_ID;
 		if (!workspaceId) return;
 		let cmd = `set_progress ${value}`;
-		if (label) cmd += ` --label=${label}`;
+		if (label) cmd += ` --label=${this.q(label)}`;
 		cmd += ` --tab=${workspaceId}`;
 		await this.textCmd(cmd);
 	}
@@ -282,10 +297,10 @@ export class CmuxClient {
 		const workspaceId = process.env.CMUX_WORKSPACE_ID;
 		if (!workspaceId) return;
 		let cmd = "log";
-		if (options?.level) cmd += ` --level=${options.level}`;
-		if (options?.source) cmd += ` --source=${options.source}`;
+		if (options?.level) cmd += ` --level=${this.q(options.level)}`;
+		if (options?.source) cmd += ` --source=${this.q(options.source)}`;
 		cmd += ` --tab=${workspaceId}`;
-		cmd += ` -- ${message}`;
+		cmd += ` -- ${this.q(message)}`;
 		await this.textCmd(cmd);
 	}
 

--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -1,12 +1,18 @@
 /**
- * pi-cmux — Unix socket JSON-RPC client for cmux.
+ * pi-cmux — Unix socket client for cmux.
  *
  * Communicates with cmux via its Unix domain socket at /tmp/cmux.sock.
- * Protocol: newline-terminated JSON-RPC over Unix socket.
  *
- * Request:  {"id":"<uuid>","method":"<method>","params":{...}}\n
- * Response: {"id":"<uuid>","ok":true,"result":{...}}\n
- *       or: {"id":"<uuid>","ok":false,"error":"message"}\n
+ * Two protocols are used:
+ *
+ * 1. JSON-RPC — for workspace, surface, notification, browser, and system commands.
+ *    Request:  {"id":"<uuid>","method":"<method>","params":{...}}\n
+ *    Response: {"id":"<uuid>","ok":true,"result":{...}}\n
+ *         or: {"id":"<uuid>","ok":false,"error":"message"}\n
+ *
+ * 2. Text-based — for sidebar metadata (status pills, progress bars, logs).
+ *    Request:  set_status <key> <value> --tab=<workspace-uuid>\n
+ *    Response: OK\n
  */
 
 import { createConnection, type Socket } from "node:net";
@@ -48,7 +54,7 @@ export class CmuxClient {
 		return existsSync(this.socketPath);
 	}
 
-	/** Send an RPC request to cmux and return the result. */
+	/** Send a JSON-RPC request to cmux and return the result. */
 	async rpc(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
 		const id = randomUUID();
 
@@ -138,42 +144,168 @@ export class CmuxClient {
 		});
 	}
 
-	// ── Convenience methods ─────────────────────────────────────
+	/**
+	 * Send a text-based command to the cmux socket.
+	 *
+	 * Sidebar metadata commands (status, progress, log) use a text-based
+	 * protocol instead of JSON-RPC. The format is:
+	 *   command [args...] --tab=<workspace-uuid>\n
+	 * Response is a plain text line (e.g. "OK\n").
+	 */
+	async textCmd(command: string): Promise<string> {
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			const settle = (fn: () => void) => {
+				if (!settled) {
+					settled = true;
+					fn();
+				}
+			};
+
+			const timeout = setTimeout(() => {
+				settle(() => {
+					conn.destroy();
+					const err = new Error(`cmux text command timeout (${RPC_TIMEOUT_MS}ms): ${command}`);
+					this.log("text_timeout", { command }, "WARN");
+					reject(err);
+				});
+			}, RPC_TIMEOUT_MS);
+
+			const conn: Socket = createConnection({ path: this.socketPath });
+
+			conn.setTimeout(CONNECT_TIMEOUT_MS);
+
+			conn.on("timeout", () => {
+				settle(() => {
+					clearTimeout(timeout);
+					conn.destroy();
+					const err = new Error(`cmux connect timeout (text): ${command}`);
+					this.log("text_connect_timeout", { command }, "WARN");
+					reject(err);
+				});
+			});
+
+			conn.on("error", (err) => {
+				settle(() => {
+					clearTimeout(timeout);
+					this.log("text_error", { command, error: err.message }, "ERROR");
+					reject(err);
+				});
+			});
+
+			let buffer = "";
+			conn.on("data", (chunk: Buffer) => {
+				buffer += chunk.toString();
+				const newlineIdx = buffer.indexOf("\n");
+				if (newlineIdx === -1) return;
+
+				const line = buffer.slice(0, newlineIdx).trim();
+				settle(() => {
+					clearTimeout(timeout);
+					conn.end();
+					this.log("text_ok", { command, response: line }, "DEBUG");
+					resolve(line);
+				});
+			});
+
+			conn.on("close", () => {
+				settle(() => {
+					clearTimeout(timeout);
+					// If we got some data before close, treat it as the response
+					if (buffer.trim()) {
+						resolve(buffer.trim());
+					} else {
+						reject(new Error(`cmux socket closed before response (text): ${command}`));
+					}
+				});
+			});
+
+			conn.on("connect", () => {
+				conn.setTimeout(0);
+				conn.write(command + "\n");
+				this.log("text_sent", { command }, "DEBUG");
+			});
+		});
+	}
+
+	// ── Notifications (JSON-RPC) ────────────────────────────────
 
 	/** Send a desktop notification. */
 	async notify(title: string, body: string, subtitle?: string): Promise<void> {
 		const params: Record<string, unknown> = { title, body };
 		if (subtitle) params.subtitle = subtitle;
-		await this.rpc("notify", params);
+		await this.rpc("notification.create", params);
 	}
 
-	/** Set sidebar status text. */
-	async setStatus(label: string): Promise<void> {
-		await this.rpc("status.set", { label });
+	// ── Sidebar metadata (text-based protocol) ──────────────────
+
+	/**
+	 * Set a sidebar status pill.
+	 * Uses a unique key so different tools can manage their own entries.
+	 */
+	async setStatus(key: string, value: string, options?: { icon?: string; color?: string }): Promise<void> {
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (!workspaceId) return;
+		let cmd = `set_status ${key} ${value}`;
+		if (options?.icon) cmd += ` --icon=${options.icon}`;
+		if (options?.color) cmd += ` --color=${options.color}`;
+		cmd += ` --tab=${workspaceId}`;
+		await this.textCmd(cmd);
 	}
 
-	/** Clear sidebar status. */
-	async clearStatus(): Promise<void> {
-		await this.rpc("status.clear", {});
+	/** Remove a sidebar status entry by key. */
+	async clearStatus(key: string): Promise<void> {
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (!workspaceId) return;
+		await this.textCmd(`clear_status ${key} --tab=${workspaceId}`);
 	}
 
-	/** Set progress bar (0.0–1.0). */
+	/** Set progress bar (0.0–1.0) in the sidebar. */
 	async setProgress(value: number, label?: string): Promise<void> {
-		const params: Record<string, unknown> = { value };
-		if (label) params.label = label;
-		await this.rpc("progress.set", params);
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (!workspaceId) return;
+		let cmd = `set_progress ${value}`;
+		if (label) cmd += ` --label=${label}`;
+		cmd += ` --tab=${workspaceId}`;
+		await this.textCmd(cmd);
 	}
 
-	/** Clear progress bar. */
+	/** Clear the sidebar progress bar. */
 	async clearProgress(): Promise<void> {
-		await this.rpc("progress.clear", {});
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (!workspaceId) return;
+		await this.textCmd(`clear_progress --tab=${workspaceId}`);
 	}
+
+	/** Append a log entry to the sidebar. */
+	async sidebarLog(message: string, options?: { level?: "info" | "progress" | "success" | "warning" | "error"; source?: string }): Promise<void> {
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (!workspaceId) return;
+		let cmd = "log";
+		if (options?.level) cmd += ` --level=${options.level}`;
+		if (options?.source) cmd += ` --source=${options.source}`;
+		cmd += ` --tab=${workspaceId}`;
+		cmd += ` -- ${message}`;
+		await this.textCmd(cmd);
+	}
+
+	/** Clear all sidebar log entries. */
+	async clearLog(): Promise<void> {
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (!workspaceId) return;
+		await this.textCmd(`clear_log --tab=${workspaceId}`);
+	}
+
+	// ── Surface management (JSON-RPC) ───────────────────────────
 
 	/** Read terminal screen output from a surface. */
-	async readScreen(surface: string, lines?: number): Promise<string> {
-		const params: Record<string, unknown> = { surface };
+	async readScreen(surfaceId: string, lines?: number): Promise<string> {
+		const params: Record<string, unknown> = { surface_id: surfaceId };
 		if (lines !== undefined) params.lines = lines;
-		const result = await this.rpc("screen.read", params);
+		const result = await this.rpc("surface.read_text", params);
+		if (result != null && typeof result === "object" && "text" in result) {
+			return (result as { text: string }).text;
+		}
 		return typeof result === "string" ? result : JSON.stringify(result);
 	}
 
@@ -189,24 +321,26 @@ export class CmuxClient {
 	}
 
 	/** Focus a surface. */
-	async focusSurface(surface: string): Promise<void> {
-		await this.rpc("surface.focus", { surface });
+	async focusSurface(surfaceId: string): Promise<void> {
+		await this.rpc("surface.focus", { surface_id: surfaceId });
 	}
 
 	/** Close a surface. */
-	async closeSurface(surface: string): Promise<void> {
-		await this.rpc("surface.close", { surface });
+	async closeSurface(surfaceId: string): Promise<void> {
+		await this.rpc("surface.close", { surface_id: surfaceId });
 	}
 
 	/** Send text input to a surface. */
-	async sendInput(surface: string, text: string): Promise<void> {
-		await this.rpc("input.send", { surface, text });
+	async sendInput(surfaceId: string, text: string): Promise<void> {
+		await this.rpc("surface.send_text", { surface_id: surfaceId, text });
 	}
 
 	/** Send a keystroke to a surface. */
-	async sendKey(surface: string, key: string): Promise<void> {
-		await this.rpc("input.send_key", { surface, key });
+	async sendKey(surfaceId: string, key: string): Promise<void> {
+		await this.rpc("surface.send_key", { surface_id: surfaceId, key });
 	}
+
+	// ── Workspace management (JSON-RPC) ─────────────────────────
 
 	/** List workspaces. */
 	async listWorkspaces(): Promise<unknown[]> {
@@ -214,48 +348,50 @@ export class CmuxClient {
 		return Array.isArray(result) ? result : (result as { workspaces?: unknown[] })?.workspaces ?? [];
 	}
 
-	/** Rename current workspace. */
-	async renameWorkspace(name: string): Promise<void> {
-		await this.rpc("workspace.rename", { name });
+	/** Rename a workspace. */
+	async renameWorkspace(title: string, workspaceId?: string): Promise<void> {
+		const wsId = workspaceId ?? process.env.CMUX_WORKSPACE_ID;
+		if (!wsId) return;
+		await this.rpc("workspace.rename", { workspace_id: wsId, title });
 	}
 
-	// ── Browser automation ──────────────────────────────────────
+	// ── Browser automation (JSON-RPC) ───────────────────────────
 
 	/** Open a URL in cmux's built-in browser. */
 	async browserOpen(url: string): Promise<unknown> {
-		return await this.rpc("browser.open", { url });
+		return await this.rpc("browser.open_split", { url });
 	}
 
 	/** Navigate an existing browser surface to a URL. */
-	async browserNavigate(surface: string, url: string): Promise<void> {
-		await this.rpc("browser.navigate", { surface, url });
+	async browserNavigate(surfaceId: string, url: string): Promise<void> {
+		await this.rpc("browser.navigate", { surface_id: surfaceId, url });
 	}
 
 	/** Get a DOM snapshot of a browser surface. */
-	async browserSnapshot(surface: string, compact?: boolean): Promise<string> {
-		const params: Record<string, unknown> = { surface };
+	async browserSnapshot(surfaceId: string, compact?: boolean): Promise<string> {
+		const params: Record<string, unknown> = { surface_id: surfaceId };
 		if (compact !== undefined) params.compact = compact;
 		const result = await this.rpc("browser.snapshot", params);
 		return typeof result === "string" ? result : JSON.stringify(result);
 	}
 
 	/** Take a screenshot of a browser surface. */
-	async browserScreenshot(surface: string): Promise<unknown> {
-		return await this.rpc("browser.screenshot", { surface });
+	async browserScreenshot(surfaceId: string): Promise<unknown> {
+		return await this.rpc("browser.screenshot", { surface_id: surfaceId });
 	}
 
 	/** Click an element in a browser surface. */
-	async browserClick(surface: string, selector: string): Promise<void> {
-		await this.rpc("browser.click", { surface, selector });
+	async browserClick(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.click", { surface_id: surfaceId, selector });
 	}
 
 	/** Fill a form field in a browser surface. */
-	async browserFill(surface: string, selector: string, value: string): Promise<void> {
-		await this.rpc("browser.fill", { surface, selector, value });
+	async browserFill(surfaceId: string, selector: string, value: string): Promise<void> {
+		await this.rpc("browser.fill", { surface_id: surfaceId, selector, value });
 	}
 
 	/** Evaluate JavaScript in a browser surface. */
-	async browserEval(surface: string, expression: string): Promise<unknown> {
-		return await this.rpc("browser.eval", { surface, expression });
+	async browserEval(surfaceId: string, expression: string): Promise<unknown> {
+		return await this.rpc("browser.eval", { surface_id: surfaceId, expression });
 	}
 }

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -62,6 +62,9 @@ export default function (pi: ExtensionAPI) {
 	// Track turn progress for multi-turn agents
 	let turnCount = 0;
 
+	/** Status pill key used for all Pi status updates. */
+	const STATUS_KEY = "pi";
+
 	pi.on("session_start", async (_event, ctx) => {
 		// Set workspace name from session
 		const name = pi.getSessionName();
@@ -70,7 +73,7 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		// Show initial idle status
-		safe(() => client.setStatus("Pi: idle"));
+		safe(() => client.setStatus(STATUS_KEY, "idle"));
 
 		// Set terminal title
 		if (ctx.hasUI) {
@@ -82,30 +85,29 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("agent_start", () => {
 		turnCount = 0;
-		safe(() => client.setStatus("Pi: thinking..."));
+		safe(() => client.setStatus(STATUS_KEY, "thinking..."));
 	});
 
 	pi.on("agent_end", () => {
 		safe(() => client.clearProgress());
-		safe(() => client.setStatus("Pi: idle"));
+		safe(() => client.setStatus(STATUS_KEY, "idle"));
 
 		// Notify user that agent is done and needs attention
 		safe(() => client.notify("Pi", "Ready for input"));
 	});
 
 	pi.on("tool_execution_start", (event) => {
-		const label = `Pi: running ${event.toolName}...`;
-		safe(() => client.setStatus(label));
+		safe(() => client.setStatus(STATUS_KEY, `running ${event.toolName}...`));
 	});
 
 	pi.on("tool_execution_end", () => {
-		safe(() => client.setStatus("Pi: thinking..."));
+		safe(() => client.setStatus(STATUS_KEY, "thinking..."));
 	});
 
 	pi.on("turn_start", () => {
 		turnCount++;
 		if (turnCount > 1) {
-			safe(() => client.setStatus(`Pi: turn ${turnCount}...`));
+			safe(() => client.setStatus(STATUS_KEY, `turn ${turnCount}...`));
 		}
 	});
 
@@ -115,7 +117,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async () => {
 		await Promise.allSettled([
-			client.clearStatus(),
+			client.clearStatus(STATUS_KEY),
 			client.clearProgress(),
 		]);
 		log("session_shutdown");

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -91,7 +91,7 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 		async execute(_toolCallId, params) {
 			const raw = await client.splitSurface(params.direction);
 			const result = (raw != null && typeof raw === "object") ? raw as Record<string, unknown> : {};
-			const surfaceId = (result.surfaceId ?? result.id ?? "unknown") as string;
+			const surfaceId = (result.surface_ref ?? result.surface_id ?? result.id ?? "unknown") as string;
 
 			if (params.command) {
 				// Ensure command ends with newline to execute


### PR DESCRIPTION
## Problem

pi-cmux client.ts used wrong RPC method names, wrong parameter names, and the wrong protocol for sidebar commands. All sidebar and several core operations were silently failing (swallowed by `safe()` in lifecycle hooks).

## What was wrong

| pi-cmux used | cmux API expects | Issue |
|---|---|---|
| `notify` | `notification.create` | Wrong method |
| `input.send` | `surface.send_text` | Wrong method |
| `input.send_key` | `surface.send_key` | Wrong method |
| `screen.read` | `surface.read_text` | Wrong method |
| `browser.open` | `browser.open_split` | Wrong method |
| `{ surface: id }` | `{ surface_id: id }` | Wrong param name |
| JSON-RPC for sidebar | Text-based protocol | Wrong protocol |
| `setStatus(label)` | `set_status key value --tab=uuid` | Wrong API shape |

## Changes

- **client.ts**: Fixed all 5 JSON-RPC method names, all parameter names (`surface` → `surface_id`), added `textCmd()` for text-based sidebar protocol, new `sidebarLog()`/`clearLog()` methods
- **index.ts**: Updated `setStatus()`/`clearStatus()` calls to use new `(key, value)` signature  
- **tools.ts**: Read `surface_ref` from split result (cmux returns refs like `surface:16`)
- **AGENTS.md**: Documented both socket protocols

All 17 JSON-RPC methods verified against `cmux capabilities --json`. Sidebar text commands verified via live socket testing.

Closes td-66daef