### PR TITLE
fix(pi-cmux): fix browser tool error handling and auto-track surface

### DIFF
--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -377,6 +377,28 @@ export class CmuxClient {
 
 	// ── Browser automation (JSON-RPC) ───────────────────────────
 
+	/**
+	 * Discover browser surfaces in the current workspace.
+	 * Queries surface.list and filters by type === "browser".
+	 * Returns the most recently added browser surface ID, or undefined.
+	 */
+	async discoverBrowserSurface(): Promise<string | undefined> {
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		const params: Record<string, unknown> = {};
+		if (workspaceId) params.workspace_id = workspaceId;
+		const result = await this.rpc("surface.list", params);
+		const surfaces = Array.isArray(result)
+			? result
+			: (result as { surfaces?: unknown[] })?.surfaces ?? [];
+		// Find browser surfaces, return the last one (most recently added)
+		const browsers = surfaces.filter(
+			(s) => s != null && typeof s === "object" && (s as Record<string, unknown>).type === "browser",
+		);
+		if (browsers.length === 0) return undefined;
+		const last = browsers[browsers.length - 1] as Record<string, unknown>;
+		return (last.id ?? last.surface_id ?? last.ref) as string | undefined;
+	}
+
 	/** Open a URL in cmux's built-in browser (in the caller's workspace). */
 	async browserOpen(url: string): Promise<unknown> {
 		const params: Record<string, unknown> = { url };

--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -116,7 +116,12 @@ export class CmuxClient {
 							this.log("rpc_ok", { method, id }, "DEBUG");
 							resolve(res.result);
 						} else {
-							const err = new Error(`cmux RPC error (${method}): ${res.error ?? "unknown"}`);
+							const errMsg = typeof res.error === "string"
+								? res.error
+								: res.error != null
+									? JSON.stringify(res.error)
+									: "unknown";
+							const err = new Error(`cmux RPC error (${method}): ${errMsg}`);
 							this.log("rpc_fail", { method, id, error: res.error }, "WARN");
 							reject(err);
 						}

--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -402,7 +402,9 @@ export class CmuxClient {
 		);
 		if (browsers.length === 0) return undefined;
 		const last = browsers[browsers.length - 1] as Record<string, unknown>;
-		return (last.id ?? last.surface_id ?? last.ref) as string | undefined;
+		// Use same field priority as extractSurfaceId: surface_ref > surface_id > id
+		const id = last.surface_ref ?? last.surface_id ?? last.id;
+		return typeof id === "string" && id.length > 0 ? id : undefined;
 	}
 
 	/** Open a URL in cmux's built-in browser (in the caller's workspace). */

--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -329,15 +329,21 @@ export class CmuxClient {
 		return typeof result === "string" ? result : JSON.stringify(result);
 	}
 
-	/** List all surfaces. */
+	/** List all surfaces (scoped to the agent's workspace). */
 	async listSurfaces(): Promise<unknown[]> {
-		const result = await this.rpc("surface.list", {});
+		const params: Record<string, unknown> = {};
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (workspaceId) params.workspace_id = workspaceId;
+		const result = await this.rpc("surface.list", params);
 		return Array.isArray(result) ? result : (result as { surfaces?: unknown[] })?.surfaces ?? [];
 	}
 
-	/** Split a surface in a direction. */
+	/** Split a surface in a direction (in the agent's workspace). */
 	async splitSurface(direction: "right" | "down"): Promise<unknown> {
-		return await this.rpc("surface.split", { direction });
+		const params: Record<string, unknown> = { direction };
+		const workspaceId = process.env.CMUX_WORKSPACE_ID;
+		if (workspaceId) params.workspace_id = workspaceId;
+		return await this.rpc("surface.split", params);
 	}
 
 	/** Focus a surface. */

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -47,7 +47,7 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Layer 2: Agent tools ──────────────────────────────────
 
-	registerTools(pi, client, log);
+	const { resetBrowserState } = registerTools(pi, client, log);
 
 	// ── Layer 1: Passive lifecycle hooks ──────────────────────
 
@@ -66,6 +66,9 @@ export default function (pi: ExtensionAPI) {
 	const STATUS_KEY = "pi";
 
 	pi.on("session_start", async (_event, ctx) => {
+		// Clear stale browser surface tracking from previous sessions
+		resetBrowserState();
+
 		// Set workspace name from session
 		const name = pi.getSessionName();
 		if (name) {

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -269,9 +269,7 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 					if (newSurfaceId) {
 						lastBrowserSurfaceId = newSurfaceId;
 					} else {
-						// Fallback: discover the browser surface that was just created
-						const discovered = await client.discoverBrowserSurface();
-						if (discovered) lastBrowserSurfaceId = discovered;
+						_log("browser_open_no_surface", { result }, "WARN");
 					}
 					const idInfo = lastBrowserSurfaceId ? ` (surface: ${lastBrowserSurfaceId})` : "";
 					return txt(`Opened browser: ${params.url}${idInfo}`, { result, surfaceId: lastBrowserSurfaceId });

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -31,7 +31,22 @@ function assertSafeUrl(url: string): void {
 	}
 }
 
+/** Extract a surface ID from a cmux RPC result object. */
+function extractSurfaceId(result: unknown): string | undefined {
+	if (result != null && typeof result === "object") {
+		const r = result as Record<string, unknown>;
+		// cmux returns surface_id (UUID) or surface_ref (surface:N)
+		const id = r.surface_id ?? r.surface_ref ?? r.id;
+		if (typeof id === "string" && id.length > 0) return id;
+	}
+	return undefined;
+}
+
 export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn): void {
+
+	// Track the most recently opened browser surface so subsequent actions
+	// (screenshot, snapshot, click, etc.) can use it without a manual cmux_list call.
+	let lastBrowserSurfaceId: string | undefined;
 
 	// ── cmux_list ───────────────────────────────────────────────
 
@@ -207,7 +222,8 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 		label: "cmux Browser",
 		description:
 			"Interact with cmux's built-in browser. Actions: open (new browser pane), " +
-			"navigate (go to URL), snapshot (get DOM), screenshot, click, fill, eval (run JS).",
+			"navigate (go to URL), snapshot (get DOM), screenshot, click, fill, eval (run JS). " +
+			"After open, the surface is remembered — subsequent actions auto-target it without needing a surface ID.",
 		parameters: Type.Object({
 			action: Type.Union([
 				Type.Literal("open"),
@@ -219,54 +235,71 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 				Type.Literal("eval"),
 			], { description: "Browser action to perform" }),
 			url: Type.Optional(Type.String({ description: "URL for open/navigate actions" })),
-			surface: Type.Optional(Type.String({ description: "Browser surface ID (for all actions except open)" })),
+			surface: Type.Optional(Type.String({ description: "Browser surface ID (optional — auto-targets the last opened browser if omitted)" })),
 			selector: Type.Optional(Type.String({ description: "CSS selector for click/fill actions" })),
 			value: Type.Optional(Type.String({ description: "Value for fill action or JS expression for eval" })),
 			compact: Type.Optional(Type.Boolean({ description: "Return compact DOM snapshot (default: true)" })),
 		}),
 		async execute(_toolCallId, params) {
+			// Resolve surface: use explicit param, fall back to last opened browser surface
+			const surface = params.surface || lastBrowserSurfaceId;
+
 			switch (params.action) {
 				case "open": {
 					if (!params.url) throw new Error("url is required for open action");
 					assertSafeUrl(params.url);
 					const result = await client.browserOpen(params.url);
-					return txt(`Opened browser: ${params.url}`, { result });
+					const newSurfaceId = extractSurfaceId(result);
+					if (newSurfaceId) lastBrowserSurfaceId = newSurfaceId;
+					const idInfo = newSurfaceId ? ` (surface: ${newSurfaceId})` : "";
+					return txt(`Opened browser: ${params.url}${idInfo}`, { result, surfaceId: newSurfaceId });
 				}
 				case "navigate": {
-					if (!params.surface) throw new Error("surface is required for navigate");
+					if (!surface) throw new Error("surface is required for navigate (open a browser first)");
 					if (!params.url) throw new Error("url is required for navigate");
 					assertSafeUrl(params.url);
-					await client.browserNavigate(params.surface, params.url);
-					return txt(`Navigated ${params.surface} to ${params.url}`);
+					await client.browserNavigate(surface, params.url);
+					return txt(`Navigated ${surface} to ${params.url}`);
 				}
 				case "snapshot": {
-					if (!params.surface) throw new Error("surface is required for snapshot");
-					const html = await client.browserSnapshot(params.surface, params.compact ?? true);
-					return txt(html, { surface: params.surface });
+					if (!surface) throw new Error("surface is required for snapshot (open a browser first)");
+					const html = await client.browserSnapshot(surface, params.compact ?? true);
+					return txt(html, { surface });
 				}
 				case "screenshot": {
-					if (!params.surface) throw new Error("surface is required for screenshot");
-					const screenshot = await client.browserScreenshot(params.surface);
-					return txt(JSON.stringify(screenshot), { surface: params.surface });
+					if (!surface) throw new Error("surface is required for screenshot (open a browser first)");
+					const screenshot = await client.browserScreenshot(surface);
+					// Extract file path from screenshot result
+					const screenshotObj = (screenshot != null && typeof screenshot === "object")
+						? screenshot as Record<string, unknown>
+						: null;
+					const filePath = screenshotObj?.path as string | undefined;
+					if (filePath) {
+						return txt(
+							`Screenshot saved to: ${filePath}\nUse the read tool on this path to view the image.`,
+							{ surface, path: filePath },
+						);
+					}
+					return txt(JSON.stringify(screenshot), { surface });
 				}
 				case "click": {
-					if (!params.surface) throw new Error("surface is required for click");
+					if (!surface) throw new Error("surface is required for click (open a browser first)");
 					if (!params.selector) throw new Error("selector is required for click");
-					await client.browserClick(params.surface, params.selector);
+					await client.browserClick(surface, params.selector);
 					return txt(`Clicked: ${params.selector}`);
 				}
 				case "fill": {
-					if (!params.surface) throw new Error("surface is required for fill");
+					if (!surface) throw new Error("surface is required for fill (open a browser first)");
 					if (!params.selector) throw new Error("selector is required for fill");
 					if (params.value === undefined) throw new Error("value is required for fill");
-					await client.browserFill(params.surface, params.selector, params.value);
-					return txt(`Filled ${params.selector}`, { surface: params.surface });
+					await client.browserFill(surface, params.selector, params.value);
+					return txt(`Filled ${params.selector}`, { surface });
 				}
 				case "eval": {
-					if (!params.surface) throw new Error("surface is required for eval");
+					if (!surface) throw new Error("surface is required for eval (open a browser first)");
 					if (params.value === undefined) throw new Error("value (JS expression) is required for eval");
-					const evalResult = await client.browserEval(params.surface, params.value);
-					return txt(JSON.stringify(evalResult, null, 2), { surface: params.surface });
+					const evalResult = await client.browserEval(surface, params.value);
+					return txt(JSON.stringify(evalResult, null, 2), { surface });
 				}
 				default:
 					throw new Error(`Unknown browser action: ${params.action}`);

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -31,21 +31,24 @@ function assertSafeUrl(url: string): void {
 	}
 }
 
-/** Extract a surface ID from a cmux RPC result object. */
+/** Extract a surface ID from a cmux RPC result object.
+ *  Prefers surface_ref (human-readable "surface:N") over UUID forms. */
 function extractSurfaceId(result: unknown): string | undefined {
 	if (result != null && typeof result === "object") {
 		const r = result as Record<string, unknown>;
-		// cmux returns surface_id (UUID) or surface_ref (surface:N)
-		const id = r.surface_id ?? r.surface_ref ?? r.id;
+		const id = r.surface_ref ?? r.surface_id ?? r.id;
 		if (typeof id === "string" && id.length > 0) return id;
 	}
 	return undefined;
 }
 
-export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn): void {
+export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn): { resetBrowserState: () => void } {
 
 	// Track the most recently opened browser surface so subsequent actions
 	// (screenshot, snapshot, click, etc.) can use it without a manual cmux_list call.
+	// NOTE: This is a single shared slot. Concurrent open calls race (last writer wins),
+	// but in practice tool calls are sequential. The surface ID is always returned in
+	// tool results, so callers can pass it explicitly for multi-browser workflows.
 	let lastBrowserSurfaceId: string | undefined;
 
 	// ── cmux_list ───────────────────────────────────────────────
@@ -192,6 +195,10 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 		}),
 		async execute(_toolCallId, params) {
 			await client.closeSurface(params.surface);
+			// Clear tracked browser surface if it was the one closed
+			if (lastBrowserSurfaceId === params.surface) {
+				lastBrowserSurfaceId = undefined;
+			}
 			return txt(`Closed surface ${params.surface}`, { surface: params.surface });
 		},
 	});
@@ -321,4 +328,10 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 			}
 		},
 	});
+
+	return {
+		resetBrowserState() {
+			lastBrowserSurfaceId = undefined;
+		},
+	};
 }

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -241,8 +241,17 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 			compact: Type.Optional(Type.Boolean({ description: "Return compact DOM snapshot (default: true)" })),
 		}),
 		async execute(_toolCallId, params) {
-			// Resolve surface: use explicit param, fall back to last opened browser surface
-			const surface = params.surface || lastBrowserSurfaceId;
+			// Resolve surface: explicit param → tracked last browser → auto-discover via surface.list
+			let surface = params.surface || lastBrowserSurfaceId;
+
+			// For non-open actions, if we don't have a surface, try to discover one
+			if (!surface && params.action !== "open") {
+				const discovered = await client.discoverBrowserSurface();
+				if (discovered) {
+					lastBrowserSurfaceId = discovered;
+					surface = discovered;
+				}
+			}
 
 			switch (params.action) {
 				case "open": {
@@ -250,9 +259,15 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 					assertSafeUrl(params.url);
 					const result = await client.browserOpen(params.url);
 					const newSurfaceId = extractSurfaceId(result);
-					if (newSurfaceId) lastBrowserSurfaceId = newSurfaceId;
-					const idInfo = newSurfaceId ? ` (surface: ${newSurfaceId})` : "";
-					return txt(`Opened browser: ${params.url}${idInfo}`, { result, surfaceId: newSurfaceId });
+					if (newSurfaceId) {
+						lastBrowserSurfaceId = newSurfaceId;
+					} else {
+						// Fallback: discover the browser surface that was just created
+						const discovered = await client.discoverBrowserSurface();
+						if (discovered) lastBrowserSurfaceId = discovered;
+					}
+					const idInfo = lastBrowserSurfaceId ? ` (surface: ${lastBrowserSurfaceId})` : "";
+					return txt(`Opened browser: ${params.url}${idInfo}`, { result, surfaceId: lastBrowserSurfaceId });
 				}
 				case "navigate": {
 					if (!surface) throw new Error("surface is required for navigate (open a browser first)");


### PR DESCRIPTION
Three fixes for the cmux_browser tool:

1. Error serialization: RPC errors that are objects now get
   JSON.stringified instead of showing [object Object].

2. Surface tracking: The 'open' action now extracts and returns
   the new surface ID, and stores it as lastBrowserSurfaceId.

3. Auto-fallback: All browser actions (screenshot, snapshot, click,
   etc.) now auto-target the last opened browser surface when no
   explicit surface param is provided. This eliminates the need
   for a cmux_list call between open and screenshot.

Before: open → cmux_list → screenshot (3 tool calls)
After:  open → screenshot (2 tool calls, no errors)
