### PR TITLE
fix(pi-cmux): pass workspace_id and surface_id in browserOpen

### DIFF
--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -372,9 +372,14 @@ export class CmuxClient {
 
 	// ── Browser automation (JSON-RPC) ───────────────────────────
 
-	/** Open a URL in cmux's built-in browser. */
+	/** Open a URL in cmux's built-in browser (in the caller's workspace). */
 	async browserOpen(url: string): Promise<unknown> {
-		return await this.rpc("browser.open_split", { url });
+		const params: Record<string, unknown> = { url };
+		const wsId = process.env.CMUX_WORKSPACE_ID;
+		if (wsId) params.workspace_id = wsId;
+		const surfaceId = process.env.CMUX_SURFACE_ID;
+		if (surfaceId) params.surface_id = surfaceId;
+		return await this.rpc("browser.open_split", params);
 	}
 
 	/** Navigate an existing browser surface to a URL. */


### PR DESCRIPTION
browserOpen() only passed { url } to browser.open_split RPC, causing
cmux to fall back to selectedTabId (the focused workspace). Browsers
would open in whatever workspace was visible instead of the caller's.

Now passes CMUX_WORKSPACE_ID and CMUX_SURFACE_ID from the environment
so browsers open in the correct workspace.
