### PR TITLE
feat(pi-cron,pi-a2a): add powerbar segments for cron and A2A status

### DIFF
--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -88,6 +88,13 @@ export default function (pi: ExtensionAPI) {
 	let executor: PiAgentExecutor | null = null;
 	/** Captured from session_start for use in async callbacks. */
 	let sessionCtx: ExtensionContext | null = null;
+
+	// ── Powerbar segment ──────────────────────────────────────
+
+	pi.events.emit("powerbar:register-segment", {
+		id: "a2a",
+		label: "A2A",
+	});
 	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
 	let staticRegistry: StaticAgentRegistry | null = null;
@@ -257,6 +264,38 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			sessionCtx.ui.setStatus("a2a", undefined);
 		}
+
+		updatePowerbar();
+	}
+
+	function updatePowerbar(): void {
+		if (!isRunning()) {
+			pi.events.emit("powerbar:update", { id: "a2a", text: undefined });
+			return;
+		}
+
+		const inbound = executor?.isBusy() ? 1 + (executor.queueDepth()) : 0;
+		const outbound = outboundPending;
+
+		const parts: string[] = ["A2A"];
+		if (inbound > 0) parts.push(`▸${inbound}`);
+		if (outbound > 0) parts.push(`◂${outbound}`);
+
+		let color: string;
+		if (inbound > 0) {
+			color = "warning";
+		} else if (outbound > 0) {
+			color = "accent";
+		} else {
+			color = "success";
+		}
+
+		pi.events.emit("powerbar:update", {
+			id: "a2a",
+			text: parts.join(" "),
+			icon: "●",
+			color,
+		});
 	}
 
 	/**
@@ -449,6 +488,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_shutdown", async () => {
 		cardEnriched = false;
 		sessionCtx?.ui.setStatus("a2a", undefined);
+		pi.events.emit("powerbar:update", { id: "a2a", text: undefined });
 		sessionCtx = null;
 		// Reject pending A2A request if any
 		if (pendingResolve) {

--- a/extensions/pi-cron/src/index.ts
+++ b/extensions/pi-cron/src/index.ts
@@ -42,6 +42,51 @@ export default function (pi: ExtensionAPI) {
 	let scheduler: CronScheduler | null = null;
 	let cwd = process.cwd();
 
+	// ── Powerbar segment ──────────────────────────────────────
+
+	pi.events.emit("powerbar:register-segment", {
+		id: "cron",
+		label: "Cron",
+	});
+
+	function updatePowerbar(): void {
+		if (!scheduler) {
+			pi.events.emit("powerbar:update", { id: "cron", text: undefined });
+			return;
+		}
+		const jobs = scheduler.list();
+		const total = jobs.filter(j => !j.disabled).length;
+		const running = jobs.filter(j => j.running).length;
+
+		if (total === 0) {
+			pi.events.emit("powerbar:update", {
+				id: "cron",
+				text: "idle",
+				icon: "⏰",
+				color: "muted",
+			});
+			return;
+		}
+
+		if (running > 0) {
+			const queued = total - running;
+			const suffix = queued > 0 ? ` +${queued}` : "";
+			pi.events.emit("powerbar:update", {
+				id: "cron",
+				text: `${running} running${suffix}`,
+				icon: "⏰",
+				color: "accent",
+			});
+		} else {
+			pi.events.emit("powerbar:update", {
+				id: "cron",
+				text: `${total} jobs`,
+				icon: "⏰",
+				color: "muted",
+			});
+		}
+	}
+
 	// ── Flag: --cron ──────────────────────────────────────────
 
 	pi.registerFlag("cron", {
@@ -60,9 +105,13 @@ export default function (pi: ExtensionAPI) {
 		}
 		const settings = resolveSettings(cwd);
 		scheduler = new CronScheduler(cwd, settings, {
-			onJobStart: (event) => pi.events.emit("cron:job_start", event),
+			onJobStart: (event) => {
+				pi.events.emit("cron:job_start", event);
+				updatePowerbar();
+			},
 			onJobComplete: (event) => {
 				pi.events.emit("cron:job_complete", event);
+				updatePowerbar();
 
 				// Send results via channel
 				const s = resolveSettings(cwd);
@@ -77,11 +126,15 @@ export default function (pi: ExtensionAPI) {
 					source: "pi-cron",
 				});
 			},
-			onReload: (jobs) => pi.events.emit("cron:reload", jobs),
+			onReload: (jobs) => {
+				pi.events.emit("cron:reload", jobs);
+				updatePowerbar();
+			},
 			log,
 		});
 		scheduler.start();
 		log("start", { pid: process.pid });
+		updatePowerbar();
 		return `✓ Cron scheduler started (PID ${process.pid})`;
 	}
 
@@ -91,6 +144,7 @@ export default function (pi: ExtensionAPI) {
 		scheduler = null;
 		releaseLock();
 		log("stop", {});
+		updatePowerbar();
 		return "✓ Cron scheduler stopped";
 	}
 
@@ -131,6 +185,9 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 
+		// Update powerbar (shows state or hides if inactive)
+		updatePowerbar();
+
 		// Mount web routes (no-op if pi-webserver isn't loaded yet)
 		mountWeb();
 	});
@@ -147,6 +204,7 @@ export default function (pi: ExtensionAPI) {
 			scheduler = null;
 			releaseLock();
 		}
+		pi.events.emit("powerbar:update", { id: "cron", text: undefined });
 	});
 
 	// ── Event API for other extensions ────────────────────────


### PR DESCRIPTION
Register powerbar segments in pi-cron and pi-a2a extensions so their
operational status shows in the powerbar alongside existing segments
like git branch, tokens, and context usage.

Cron segment (⏰):
- Hidden when scheduler is inactive
- Shows 'N jobs' (muted) when scheduler is active with no running jobs
- Shows 'N running +M' (accent) when jobs are executing
- Shows 'idle' (muted) when active but all jobs disabled

A2A segment (●):
- Hidden when A2A server is not running
- Green dot + 'A2A' when server is idle
- Yellow + 'A2A ▸N' when processing inbound requests (with queue depth)
- Accent + 'A2A ◂N' when outbound requests are pending
- Both indicators when processing inbound and waiting on outbound

Both segments use the powerbar event-driven architecture:
- powerbar:register-segment on extension init
- powerbar:update on every state change
- text: undefined to hide when inactive/shutdown
