### PR TITLE
feat(pi-cmux): expose full cmux browser automation API

### DIFF
--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -54,9 +54,12 @@ export class CmuxClient {
 		return existsSync(this.socketPath);
 	}
 
-	/** Send a JSON-RPC request to cmux and return the result. */
-	async rpc(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+	/** Send a JSON-RPC request to cmux and return the result.
+	 *  @param timeoutMs Override the default RPC timeout (for long-running ops like wait/download).
+	 */
+	async rpc(method: string, params: Record<string, unknown> = {}, timeoutMs?: number): Promise<unknown> {
 		const id = randomUUID();
+		const rpcTimeout = timeoutMs ?? RPC_TIMEOUT_MS;
 
 		return new Promise((resolve, reject) => {
 			let settled = false;
@@ -70,11 +73,11 @@ export class CmuxClient {
 			const timeout = setTimeout(() => {
 				settle(() => {
 					conn.destroy();
-					const err = new Error(`cmux RPC timeout (${RPC_TIMEOUT_MS}ms): ${method}`);
-					this.log("rpc_timeout", { method, id }, "WARN");
+					const err = new Error(`cmux RPC timeout (${rpcTimeout}ms): ${method}`);
+					this.log("rpc_timeout", { method, id, timeoutMs: rpcTimeout }, "WARN");
 					reject(err);
 				});
-			}, RPC_TIMEOUT_MS);
+			}, rpcTimeout);
 
 			const conn: Socket = createConnection({ path: this.socketPath });
 
@@ -489,7 +492,10 @@ export class CmuxClient {
 		if (opts?.load_state) params.load_state = opts.load_state;
 		if (opts?.function) params.function = opts.function;
 		if (opts?.timeout_ms !== undefined) params.timeout_ms = opts.timeout_ms;
-		await this.rpc("browser.wait", params);
+		// Use server timeout + 2s headroom as RPC deadline so the client
+		// doesn't kill the socket before the server-side wait completes.
+		const rpcTimeout = opts?.timeout_ms ? opts.timeout_ms + 2_000 : undefined;
+		await this.rpc("browser.wait", params, rpcTimeout);
 	}
 
 	/** Double-click an element. */
@@ -615,7 +621,8 @@ export class CmuxClient {
 		const params: Record<string, unknown> = { surface_id: surfaceId };
 		if (opts?.path) params.path = opts.path;
 		if (opts?.timeout_ms !== undefined) params.timeout_ms = opts.timeout_ms;
-		return await this.rpc("browser.download", params);
+		const rpcTimeout = opts?.timeout_ms ? opts.timeout_ms + 2_000 : undefined;
+		return await this.rpc("browser.download", params, rpcTimeout);
 	}
 
 	/** Manage cookies. */
@@ -628,8 +635,8 @@ export class CmuxClient {
 	/** Manage local or session storage. */
 	async browserStorage(surfaceId: string, storageType: string, action: string, key?: string, value?: string): Promise<unknown> {
 		const params: Record<string, unknown> = { surface_id: surfaceId, storage_type: storageType, action };
-		if (key) params.key = key;
-		if (value) params.value = value;
+		if (key !== undefined) params.key = key;
+		if (value !== undefined) params.value = value;
 		return await this.rpc("browser.storage", params);
 	}
 

--- a/extensions/pi-cmux/src/client.ts
+++ b/extensions/pi-cmux/src/client.ts
@@ -423,9 +423,12 @@ export class CmuxClient {
 	}
 
 	/** Get a DOM snapshot of a browser surface. */
-	async browserSnapshot(surfaceId: string, compact?: boolean): Promise<string> {
+	async browserSnapshot(surfaceId: string, compact?: boolean, options?: { selector?: string; max_depth?: number; interactive?: boolean }): Promise<string> {
 		const params: Record<string, unknown> = { surface_id: surfaceId };
 		if (compact !== undefined) params.compact = compact;
+		if (options?.selector) params.selector = options.selector;
+		if (options?.max_depth !== undefined) params.max_depth = options.max_depth;
+		if (options?.interactive !== undefined) params.interactive = options.interactive;
 		const result = await this.rpc("browser.snapshot", params);
 		return typeof result === "string" ? result : JSON.stringify(result);
 	}
@@ -448,5 +451,207 @@ export class CmuxClient {
 	/** Evaluate JavaScript in a browser surface. */
 	async browserEval(surfaceId: string, expression: string): Promise<unknown> {
 		return await this.rpc("browser.eval", { surface_id: surfaceId, expression });
+	}
+
+	// ── Additional browser automation methods ───────────────────
+
+	/** Get browser surface IDs and metadata. */
+	async browserIdentify(surfaceId: string): Promise<unknown> {
+		return await this.rpc("browser.identify", { surface_id: surfaceId });
+	}
+
+	/** Navigate back in browser history. */
+	async browserBack(surfaceId: string): Promise<void> {
+		await this.rpc("browser.back", { surface_id: surfaceId });
+	}
+
+	/** Navigate forward in browser history. */
+	async browserForward(surfaceId: string): Promise<void> {
+		await this.rpc("browser.forward", { surface_id: surfaceId });
+	}
+
+	/** Reload the current page. */
+	async browserReload(surfaceId: string): Promise<void> {
+		await this.rpc("browser.reload", { surface_id: surfaceId });
+	}
+
+	/** Get the current URL. */
+	async browserUrl(surfaceId: string): Promise<unknown> {
+		return await this.rpc("browser.url", { surface_id: surfaceId });
+	}
+
+	/** Wait for a condition. */
+	async browserWait(surfaceId: string, opts?: { selector?: string; text?: string; url_contains?: string; load_state?: string; function?: string; timeout_ms?: number }): Promise<void> {
+		const params: Record<string, unknown> = { surface_id: surfaceId };
+		if (opts?.selector) params.selector = opts.selector;
+		if (opts?.text) params.text = opts.text;
+		if (opts?.url_contains) params.url_contains = opts.url_contains;
+		if (opts?.load_state) params.load_state = opts.load_state;
+		if (opts?.function) params.function = opts.function;
+		if (opts?.timeout_ms !== undefined) params.timeout_ms = opts.timeout_ms;
+		await this.rpc("browser.wait", params);
+	}
+
+	/** Double-click an element. */
+	async browserDblclick(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.dblclick", { surface_id: surfaceId, selector });
+	}
+
+	/** Hover over an element. */
+	async browserHover(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.hover", { surface_id: surfaceId, selector });
+	}
+
+	/** Focus an element. */
+	async browserFocus(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.focus", { surface_id: surfaceId, selector });
+	}
+
+	/** Check a checkbox or radio button. */
+	async browserCheck(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.check", { surface_id: surfaceId, selector });
+	}
+
+	/** Uncheck a checkbox. */
+	async browserUncheck(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.uncheck", { surface_id: surfaceId, selector });
+	}
+
+	/** Scroll an element into view. */
+	async browserScrollIntoView(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.scroll_into_view", { surface_id: surfaceId, selector });
+	}
+
+	/** Type text into an element. */
+	async browserType(surfaceId: string, selector: string, text: string): Promise<void> {
+		await this.rpc("browser.type", { surface_id: surfaceId, selector, text });
+	}
+
+	/** Press a key. */
+	async browserPress(surfaceId: string, key: string): Promise<void> {
+		await this.rpc("browser.press", { surface_id: surfaceId, key });
+	}
+
+	/** Press a key down (without releasing). */
+	async browserKeydown(surfaceId: string, key: string): Promise<void> {
+		await this.rpc("browser.keydown", { surface_id: surfaceId, key });
+	}
+
+	/** Release a key. */
+	async browserKeyup(surfaceId: string, key: string): Promise<void> {
+		await this.rpc("browser.keyup", { surface_id: surfaceId, key });
+	}
+
+	/** Select an option in a dropdown. */
+	async browserSelect(surfaceId: string, selector: string, value: string): Promise<void> {
+		await this.rpc("browser.select", { surface_id: surfaceId, selector, value });
+	}
+
+	/** Scroll the page or an element. */
+	async browserScroll(surfaceId: string, opts?: { selector?: string; dx?: number; dy?: number }): Promise<void> {
+		const params: Record<string, unknown> = { surface_id: surfaceId };
+		if (opts?.selector) params.selector = opts.selector;
+		if (opts?.dx !== undefined) params.dx = opts.dx;
+		if (opts?.dy !== undefined) params.dy = opts.dy;
+		await this.rpc("browser.scroll", params);
+	}
+
+	/** Get page or element information. */
+	async browserGet(surfaceId: string, what: string, opts?: { selector?: string; attr?: string; property?: string }): Promise<unknown> {
+		const params: Record<string, unknown> = { surface_id: surfaceId, what };
+		if (opts?.selector) params.selector = opts.selector;
+		if (opts?.attr) params.attr = opts.attr;
+		if (opts?.property) params.property = opts.property;
+		return await this.rpc("browser.get", params);
+	}
+
+	/** Check element state. */
+	async browserIs(surfaceId: string, check: string, selector: string): Promise<unknown> {
+		return await this.rpc("browser.is", { surface_id: surfaceId, check, selector });
+	}
+
+	/** Find elements by various criteria. */
+	async browserFind(surfaceId: string, by: string, value: string, opts?: { name?: string; n?: number }): Promise<unknown> {
+		const params: Record<string, unknown> = { surface_id: surfaceId, by, value };
+		if (opts?.name) params.name = opts.name;
+		if (opts?.n !== undefined) params.n = opts.n;
+		return await this.rpc("browser.find", params);
+	}
+
+	/** Highlight an element visually. */
+	async browserHighlight(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.highlight", { surface_id: surfaceId, selector });
+	}
+
+	/** Add a script that runs on page load. */
+	async browserAddInitScript(surfaceId: string, script: string): Promise<void> {
+		await this.rpc("browser.addinitscript", { surface_id: surfaceId, script });
+	}
+
+	/** Add a script to the page. */
+	async browserAddScript(surfaceId: string, script: string): Promise<void> {
+		await this.rpc("browser.addscript", { surface_id: surfaceId, script });
+	}
+
+	/** Add a stylesheet to the page. */
+	async browserAddStyle(surfaceId: string, css: string): Promise<void> {
+		await this.rpc("browser.addstyle", { surface_id: surfaceId, css });
+	}
+
+	/** Switch to a frame or return to main content. */
+	async browserFrame(surfaceId: string, selector: string): Promise<void> {
+		await this.rpc("browser.frame", { surface_id: surfaceId, selector });
+	}
+
+	/** Handle dialog boxes. */
+	async browserDialog(surfaceId: string, action: string, promptText?: string): Promise<void> {
+		const params: Record<string, unknown> = { surface_id: surfaceId, action };
+		if (promptText) params.prompt_text = promptText;
+		await this.rpc("browser.dialog", params);
+	}
+
+	/** Trigger and handle downloads. */
+	async browserDownload(surfaceId: string, opts?: { path?: string; timeout_ms?: number }): Promise<unknown> {
+		const params: Record<string, unknown> = { surface_id: surfaceId };
+		if (opts?.path) params.path = opts.path;
+		if (opts?.timeout_ms !== undefined) params.timeout_ms = opts.timeout_ms;
+		return await this.rpc("browser.download", params);
+	}
+
+	/** Manage cookies. */
+	async browserCookies(surfaceId: string, action: string, opts?: Record<string, unknown>): Promise<unknown> {
+		const params: Record<string, unknown> = { surface_id: surfaceId, action };
+		if (opts) Object.assign(params, opts);
+		return await this.rpc("browser.cookies", params);
+	}
+
+	/** Manage local or session storage. */
+	async browserStorage(surfaceId: string, storageType: string, action: string, key?: string, value?: string): Promise<unknown> {
+		const params: Record<string, unknown> = { surface_id: surfaceId, storage_type: storageType, action };
+		if (key) params.key = key;
+		if (value) params.value = value;
+		return await this.rpc("browser.storage", params);
+	}
+
+	/** Save or load browser state. */
+	async browserState(surfaceId: string, action: string, path: string): Promise<void> {
+		await this.rpc("browser.state", { surface_id: surfaceId, action, path });
+	}
+
+	/** Manage browser tabs. */
+	async browserTab(surfaceId: string, action: string, opts?: Record<string, unknown>): Promise<unknown> {
+		const params: Record<string, unknown> = { surface_id: surfaceId, action };
+		if (opts) Object.assign(params, opts);
+		return await this.rpc("browser.tab", params);
+	}
+
+	/** Manage console logs. */
+	async browserConsole(surfaceId: string, action: string): Promise<unknown> {
+		return await this.rpc("browser.console", { surface_id: surfaceId, action });
+	}
+
+	/** Manage page errors. */
+	async browserErrors(surfaceId: string, action: string): Promise<unknown> {
+		return await this.rpc("browser.errors", { surface_id: surfaceId, action });
 	}
 }

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -451,7 +451,7 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 				case "type": {
 					if (!surface) throw new Error("surface is required for type (open a browser first)");
 					if (!params.selector) throw new Error("selector is required for type");
-					if (!params.text) throw new Error("text is required for type");
+					if (params.text === undefined) throw new Error("text is required for type");
 					await client.browserType(surface, params.selector, params.text);
 					const message = await maybeSnapshot(`Typed into ${params.selector}`);
 					return txt(message);
@@ -488,7 +488,7 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 				case "select": {
 					if (!surface) throw new Error("surface is required for select (open a browser first)");
 					if (!params.selector) throw new Error("selector is required for select");
-					if (!params.value) throw new Error("value is required for select");
+					if (params.value === undefined) throw new Error("value is required for select");
 					await client.browserSelect(surface, params.selector, params.value);
 					const message = await maybeSnapshot(`Selected ${params.value} in ${params.selector}`);
 					return txt(message);
@@ -650,7 +650,10 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 					if (!surface) throw new Error("surface is required for tab (open a browser first)");
 					if (!params.subaction) throw new Error("subaction (list/new/switch/close) is required for tab");
 					const tabOpts: Record<string, unknown> = {};
-					if (params.url) tabOpts.url = params.url;
+					if (params.url) {
+						assertSafeUrl(params.url);
+						tabOpts.url = params.url;
+					}
 					if (params.value) tabOpts.value = params.value;
 					const tabResult = await client.browserTab(surface, params.subaction, tabOpts);
 					return txt(JSON.stringify(tabResult, null, 2), { surface });

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -228,24 +228,86 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 		name: "cmux_browser",
 		label: "cmux Browser",
 		description:
-			"Interact with cmux's built-in browser. Actions: open (new browser pane), " +
-			"navigate (go to URL), snapshot (get DOM), screenshot, click, fill, eval (run JS). " +
-			"After open, the surface is remembered — subsequent actions auto-target it without needing a surface ID.",
+			"Interact with cmux's built-in browser. Actions include navigation, DOM interaction, inspection, JS injection, " +
+			"state management, and more. After open, the surface is remembered — subsequent actions auto-target it without needing a surface ID.",
 		parameters: Type.Object({
 			action: Type.Union([
+				// Navigation
 				Type.Literal("open"),
 				Type.Literal("navigate"),
+				Type.Literal("back"),
+				Type.Literal("forward"),
+				Type.Literal("reload"),
+				Type.Literal("url"),
+				Type.Literal("identify"),
+				// Waiting
+				Type.Literal("wait"),
+				// DOM interaction
+				Type.Literal("click"),
+				Type.Literal("dblclick"),
+				Type.Literal("hover"),
+				Type.Literal("focus"),
+				Type.Literal("check"),
+				Type.Literal("uncheck"),
+				Type.Literal("scroll-into-view"),
+				Type.Literal("type"),
+				Type.Literal("fill"),
+				Type.Literal("press"),
+				Type.Literal("keydown"),
+				Type.Literal("keyup"),
+				Type.Literal("select"),
+				Type.Literal("scroll"),
+				// Inspection
 				Type.Literal("snapshot"),
 				Type.Literal("screenshot"),
-				Type.Literal("click"),
-				Type.Literal("fill"),
+				Type.Literal("get"),
+				Type.Literal("is"),
+				Type.Literal("find"),
+				Type.Literal("highlight"),
+				// JS injection
 				Type.Literal("eval"),
+				Type.Literal("addinitscript"),
+				Type.Literal("addscript"),
+				Type.Literal("addstyle"),
+				// Frames/Dialogs
+				Type.Literal("frame"),
+				Type.Literal("dialog"),
+				Type.Literal("download"),
+				// State
+				Type.Literal("cookies"),
+				Type.Literal("storage"),
+				Type.Literal("state"),
+				// Tabs/Logs
+				Type.Literal("tab"),
+				Type.Literal("console"),
+				Type.Literal("errors"),
 			], { description: "Browser action to perform" }),
 			url: Type.Optional(Type.String({ description: "URL for open/navigate actions" })),
 			surface: Type.Optional(Type.String({ description: "Browser surface ID (optional — auto-targets the last opened browser if omitted)" })),
-			selector: Type.Optional(Type.String({ description: "CSS selector for click/fill actions" })),
-			value: Type.Optional(Type.String({ description: "Value for fill action or JS expression for eval" })),
+			selector: Type.Optional(Type.String({ description: "CSS selector for DOM actions" })),
+			value: Type.Optional(Type.String({ description: "Value for fill/select actions or JS expression for eval" })),
 			compact: Type.Optional(Type.Boolean({ description: "Return compact DOM snapshot (default: true)" })),
+			subaction: Type.Optional(Type.String({ description: "Sub-action for get/is/find/cookies/storage/state/tab/console/errors/dialog" })),
+			text: Type.Optional(Type.String({ description: "Text for type action, wait text condition, or dialog prompt" })),
+			key: Type.Optional(Type.String({ description: "Key name for press/keydown/keyup (e.g. 'Enter', 'Tab')" })),
+			timeout: Type.Optional(Type.Number({ description: "Timeout in milliseconds for wait action" })),
+			dx: Type.Optional(Type.Number({ description: "Horizontal scroll delta for scroll action" })),
+			dy: Type.Optional(Type.Number({ description: "Vertical scroll delta for scroll action" })),
+			attr: Type.Optional(Type.String({ description: "Attribute name for get attr" })),
+			property: Type.Optional(Type.String({ description: "Property name for get styles" })),
+			name: Type.Optional(Type.String({ description: "Name filter for find role, or key name for storage get/set" })),
+			nth: Type.Optional(Type.Number({ description: "Index for find nth" })),
+			path: Type.Optional(Type.String({ description: "File path for download or state save/load" })),
+			domain: Type.Optional(Type.String({ description: "Domain for cookies set" })),
+			storageType: Type.Optional(Type.String({ description: "Storage type: 'local' or 'session'" })),
+			waitCondition: Type.Optional(Type.String({ description: "Wait condition: 'selector'|'text'|'url'|'load-state'|'function'" })),
+			loadState: Type.Optional(Type.String({ description: "Load state for wait: 'load'|'domcontentloaded'|'networkidle'" })),
+			urlContains: Type.Optional(Type.String({ description: "URL substring for wait url condition" })),
+			function: Type.Optional(Type.String({ description: "JS function expression for wait condition" })),
+			maxDepth: Type.Optional(Type.Number({ description: "Maximum depth for snapshot DOM traversal" })),
+			interactive: Type.Optional(Type.Boolean({ description: "Include interactive elements only in snapshot" })),
+			snapshotAfter: Type.Optional(Type.Boolean({ description: "Take a snapshot after executing the action" })),
+			css: Type.Optional(Type.String({ description: "CSS string for addstyle action" })),
 		}),
 		async execute(_toolCallId, params) {
 			// Resolve surface: explicit param → tracked last browser → auto-discover via surface.list
@@ -260,7 +322,17 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 				}
 			}
 
+			// Helper to take snapshot after action if requested
+			const maybeSnapshot = async (baseResult: string): Promise<string> => {
+				if (params.snapshotAfter && surface) {
+					const snapshot = await client.browserSnapshot(surface, true);
+					return baseResult + "\n\n" + snapshot;
+				}
+				return baseResult;
+			};
+
 			switch (params.action) {
+				// ── Navigation ──────────────────────────────────────
 				case "open": {
 					if (!params.url) throw new Error("url is required for open action");
 					assertSafeUrl(params.url);
@@ -279,17 +351,172 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 					if (!params.url) throw new Error("url is required for navigate");
 					assertSafeUrl(params.url);
 					await client.browserNavigate(surface, params.url);
-					return txt(`Navigated ${surface} to ${params.url}`);
+					const message = await maybeSnapshot(`Navigated ${surface} to ${params.url}`);
+					return txt(message);
 				}
+				case "back": {
+					if (!surface) throw new Error("surface is required for back (open a browser first)");
+					await client.browserBack(surface);
+					const message = await maybeSnapshot(`Navigated back in ${surface}`);
+					return txt(message);
+				}
+				case "forward": {
+					if (!surface) throw new Error("surface is required for forward (open a browser first)");
+					await client.browserForward(surface);
+					const message = await maybeSnapshot(`Navigated forward in ${surface}`);
+					return txt(message);
+				}
+				case "reload": {
+					if (!surface) throw new Error("surface is required for reload (open a browser first)");
+					await client.browserReload(surface);
+					const message = await maybeSnapshot(`Reloaded ${surface}`);
+					return txt(message);
+				}
+				case "url": {
+					if (!surface) throw new Error("surface is required for url (open a browser first)");
+					const urlResult = await client.browserUrl(surface);
+					return txt(JSON.stringify(urlResult), { surface });
+				}
+				case "identify": {
+					if (!surface) throw new Error("surface is required for identify (open a browser first)");
+					const identifyResult = await client.browserIdentify(surface);
+					return txt(JSON.stringify(identifyResult, null, 2), { surface });
+				}
+
+				// ── Waiting ─────────────────────────────────────────
+				case "wait": {
+					if (!surface) throw new Error("surface is required for wait (open a browser first)");
+					const waitOpts: Record<string, unknown> = {};
+					if (params.selector) waitOpts.selector = params.selector;
+					if (params.text) waitOpts.text = params.text;
+					if (params.urlContains) waitOpts.url_contains = params.urlContains;
+					if (params.loadState) waitOpts.load_state = params.loadState;
+					if (params.function) waitOpts.function = params.function;
+					if (params.timeout !== undefined) waitOpts.timeout_ms = params.timeout;
+					await client.browserWait(surface, waitOpts);
+					const message = await maybeSnapshot(`Wait completed in ${surface}`);
+					return txt(message);
+				}
+
+				// ── DOM interaction ─────────────────────────────────
+				case "click": {
+					if (!surface) throw new Error("surface is required for click (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for click");
+					await client.browserClick(surface, params.selector);
+					const message = await maybeSnapshot(`Clicked: ${params.selector}`);
+					return txt(message);
+				}
+				case "dblclick": {
+					if (!surface) throw new Error("surface is required for dblclick (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for dblclick");
+					await client.browserDblclick(surface, params.selector);
+					const message = await maybeSnapshot(`Double-clicked: ${params.selector}`);
+					return txt(message);
+				}
+				case "hover": {
+					if (!surface) throw new Error("surface is required for hover (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for hover");
+					await client.browserHover(surface, params.selector);
+					const message = await maybeSnapshot(`Hovered: ${params.selector}`);
+					return txt(message);
+				}
+				case "focus": {
+					if (!surface) throw new Error("surface is required for focus (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for focus");
+					await client.browserFocus(surface, params.selector);
+					const message = await maybeSnapshot(`Focused: ${params.selector}`);
+					return txt(message);
+				}
+				case "check": {
+					if (!surface) throw new Error("surface is required for check (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for check");
+					await client.browserCheck(surface, params.selector);
+					const message = await maybeSnapshot(`Checked: ${params.selector}`);
+					return txt(message);
+				}
+				case "uncheck": {
+					if (!surface) throw new Error("surface is required for uncheck (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for uncheck");
+					await client.browserUncheck(surface, params.selector);
+					const message = await maybeSnapshot(`Unchecked: ${params.selector}`);
+					return txt(message);
+				}
+				case "scroll-into-view": {
+					if (!surface) throw new Error("surface is required for scroll-into-view (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for scroll-into-view");
+					await client.browserScrollIntoView(surface, params.selector);
+					const message = await maybeSnapshot(`Scrolled into view: ${params.selector}`);
+					return txt(message);
+				}
+				case "type": {
+					if (!surface) throw new Error("surface is required for type (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for type");
+					if (!params.text) throw new Error("text is required for type");
+					await client.browserType(surface, params.selector, params.text);
+					const message = await maybeSnapshot(`Typed into ${params.selector}`);
+					return txt(message);
+				}
+				case "fill": {
+					if (!surface) throw new Error("surface is required for fill (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for fill");
+					if (params.value === undefined) throw new Error("value is required for fill");
+					await client.browserFill(surface, params.selector, params.value);
+					const message = await maybeSnapshot(`Filled ${params.selector}`);
+					return txt(message, { surface });
+				}
+				case "press": {
+					if (!surface) throw new Error("surface is required for press (open a browser first)");
+					if (!params.key) throw new Error("key is required for press");
+					await client.browserPress(surface, params.key);
+					const message = await maybeSnapshot(`Pressed key: ${params.key}`);
+					return txt(message);
+				}
+				case "keydown": {
+					if (!surface) throw new Error("surface is required for keydown (open a browser first)");
+					if (!params.key) throw new Error("key is required for keydown");
+					await client.browserKeydown(surface, params.key);
+					const message = await maybeSnapshot(`Key down: ${params.key}`);
+					return txt(message);
+				}
+				case "keyup": {
+					if (!surface) throw new Error("surface is required for keyup (open a browser first)");
+					if (!params.key) throw new Error("key is required for keyup");
+					await client.browserKeyup(surface, params.key);
+					const message = await maybeSnapshot(`Key up: ${params.key}`);
+					return txt(message);
+				}
+				case "select": {
+					if (!surface) throw new Error("surface is required for select (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for select");
+					if (!params.value) throw new Error("value is required for select");
+					await client.browserSelect(surface, params.selector, params.value);
+					const message = await maybeSnapshot(`Selected ${params.value} in ${params.selector}`);
+					return txt(message);
+				}
+				case "scroll": {
+					if (!surface) throw new Error("surface is required for scroll (open a browser first)");
+					const scrollOpts: Record<string, unknown> = {};
+					if (params.selector) scrollOpts.selector = params.selector;
+					if (params.dx !== undefined) scrollOpts.dx = params.dx;
+					if (params.dy !== undefined) scrollOpts.dy = params.dy;
+					await client.browserScroll(surface, scrollOpts);
+					const message = await maybeSnapshot(`Scrolled in ${surface}`);
+					return txt(message);
+				}
+
+				// ── Inspection ──────────────────────────────────────
 				case "snapshot": {
 					if (!surface) throw new Error("surface is required for snapshot (open a browser first)");
-					const html = await client.browserSnapshot(surface, params.compact ?? true);
+					const snapshotOpts: Record<string, unknown> = {};
+					if (params.selector) snapshotOpts.selector = params.selector;
+					if (params.maxDepth !== undefined) snapshotOpts.max_depth = params.maxDepth;
+					if (params.interactive !== undefined) snapshotOpts.interactive = params.interactive;
+					const html = await client.browserSnapshot(surface, params.compact ?? true, snapshotOpts);
 					return txt(html, { surface });
 				}
 				case "screenshot": {
 					if (!surface) throw new Error("surface is required for screenshot (open a browser first)");
 					const screenshot = await client.browserScreenshot(surface);
-					// Extract file path from screenshot result
 					const screenshotObj = (screenshot != null && typeof screenshot === "object")
 						? screenshot as Record<string, unknown>
 						: null;
@@ -302,25 +529,145 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 					}
 					return txt(JSON.stringify(screenshot), { surface });
 				}
-				case "click": {
-					if (!surface) throw new Error("surface is required for click (open a browser first)");
-					if (!params.selector) throw new Error("selector is required for click");
-					await client.browserClick(surface, params.selector);
-					return txt(`Clicked: ${params.selector}`);
+				case "get": {
+					if (!surface) throw new Error("surface is required for get (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (what to get) is required for get");
+					const getOpts: Record<string, unknown> = {};
+					if (params.selector) getOpts.selector = params.selector;
+					if (params.attr) getOpts.attr = params.attr;
+					if (params.property) getOpts.property = params.property;
+					const getResult = await client.browserGet(surface, params.subaction, getOpts);
+					return txt(JSON.stringify(getResult, null, 2), { surface });
 				}
-				case "fill": {
-					if (!surface) throw new Error("surface is required for fill (open a browser first)");
-					if (!params.selector) throw new Error("selector is required for fill");
-					if (params.value === undefined) throw new Error("value is required for fill");
-					await client.browserFill(surface, params.selector, params.value);
-					return txt(`Filled ${params.selector}`, { surface });
+				case "is": {
+					if (!surface) throw new Error("surface is required for is (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (check type) is required for is");
+					if (!params.selector) throw new Error("selector is required for is");
+					const isResult = await client.browserIs(surface, params.subaction, params.selector);
+					return txt(JSON.stringify(isResult), { surface });
 				}
+				case "find": {
+					if (!surface) throw new Error("surface is required for find (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (find by) is required for find");
+					if (!params.value) throw new Error("value is required for find");
+					const findOpts: Record<string, unknown> = {};
+					if (params.name) findOpts.name = params.name;
+					if (params.nth !== undefined) findOpts.n = params.nth;
+					const findResult = await client.browserFind(surface, params.subaction, params.value, findOpts);
+					return txt(JSON.stringify(findResult, null, 2), { surface });
+				}
+				case "highlight": {
+					if (!surface) throw new Error("surface is required for highlight (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for highlight");
+					await client.browserHighlight(surface, params.selector);
+					return txt(`Highlighted: ${params.selector}`);
+				}
+
+				// ── JS injection ────────────────────────────────────
 				case "eval": {
 					if (!surface) throw new Error("surface is required for eval (open a browser first)");
 					if (params.value === undefined) throw new Error("value (JS expression) is required for eval");
 					const evalResult = await client.browserEval(surface, params.value);
 					return txt(JSON.stringify(evalResult, null, 2), { surface });
 				}
+				case "addinitscript": {
+					if (!surface) throw new Error("surface is required for addinitscript (open a browser first)");
+					if (!params.value) throw new Error("value (script) is required for addinitscript");
+					await client.browserAddInitScript(surface, params.value);
+					return txt(`Added init script to ${surface}`);
+				}
+				case "addscript": {
+					if (!surface) throw new Error("surface is required for addscript (open a browser first)");
+					if (!params.value) throw new Error("value (script) is required for addscript");
+					await client.browserAddScript(surface, params.value);
+					return txt(`Added script to ${surface}`);
+				}
+				case "addstyle": {
+					if (!surface) throw new Error("surface is required for addstyle (open a browser first)");
+					if (!params.css) throw new Error("css is required for addstyle");
+					await client.browserAddStyle(surface, params.css);
+					return txt(`Added stylesheet to ${surface}`);
+				}
+
+				// ── Frames/Dialogs ──────────────────────────────────
+				case "frame": {
+					if (!surface) throw new Error("surface is required for frame (open a browser first)");
+					if (!params.selector) throw new Error("selector is required for frame");
+					await client.browserFrame(surface, params.selector);
+					const message = await maybeSnapshot(`Switched to frame: ${params.selector}`);
+					return txt(message);
+				}
+				case "dialog": {
+					if (!surface) throw new Error("surface is required for dialog (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (accept/dismiss) is required for dialog");
+					await client.browserDialog(surface, params.subaction, params.text);
+					return txt(`Dialog ${params.subaction}ed`);
+				}
+				case "download": {
+					if (!surface) throw new Error("surface is required for download (open a browser first)");
+					const downloadOpts: Record<string, unknown> = {};
+					if (params.path) downloadOpts.path = params.path;
+					if (params.timeout !== undefined) downloadOpts.timeout_ms = params.timeout;
+					const downloadResult = await client.browserDownload(surface, downloadOpts);
+					return txt(JSON.stringify(downloadResult, null, 2), { surface });
+				}
+
+				// ── State ───────────────────────────────────────────
+				case "cookies": {
+					if (!surface) throw new Error("surface is required for cookies (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (get/set/clear) is required for cookies");
+					const cookieOpts: Record<string, unknown> = {};
+					if (params.name) cookieOpts.name = params.name;
+					if (params.domain) cookieOpts.domain = params.domain;
+					if (params.value) cookieOpts.value = params.value;
+					if (params.path) cookieOpts.path = params.path;
+					const cookiesResult = await client.browserCookies(surface, params.subaction, cookieOpts);
+					return txt(JSON.stringify(cookiesResult, null, 2), { surface });
+				}
+				case "storage": {
+					if (!surface) throw new Error("surface is required for storage (open a browser first)");
+					if (!params.storageType) throw new Error("storageType (local/session) is required for storage");
+					if (!params.subaction) throw new Error("subaction is required for storage");
+					const storageResult = await client.browserStorage(
+						surface,
+						params.storageType,
+						params.subaction,
+						params.name, // Storage key
+						params.value,
+					);
+					return txt(JSON.stringify(storageResult, null, 2), { surface });
+				}
+				case "state": {
+					if (!surface) throw new Error("surface is required for state (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (save/load) is required for state");
+					if (!params.path) throw new Error("path is required for state");
+					await client.browserState(surface, params.subaction, params.path);
+					return txt(`State ${params.subaction}ed: ${params.path}`);
+				}
+
+				// ── Tabs/Logs ───────────────────────────────────────
+				case "tab": {
+					if (!surface) throw new Error("surface is required for tab (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (list/new/switch/close) is required for tab");
+					const tabOpts: Record<string, unknown> = {};
+					if (params.url) tabOpts.url = params.url;
+					if (params.value) tabOpts.value = params.value;
+					const tabResult = await client.browserTab(surface, params.subaction, tabOpts);
+					return txt(JSON.stringify(tabResult, null, 2), { surface });
+				}
+				case "console": {
+					if (!surface) throw new Error("surface is required for console (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (list/clear) is required for console");
+					const consoleResult = await client.browserConsole(surface, params.subaction);
+					return txt(JSON.stringify(consoleResult, null, 2), { surface });
+				}
+				case "errors": {
+					if (!surface) throw new Error("surface is required for errors (open a browser first)");
+					if (!params.subaction) throw new Error("subaction (list/clear) is required for errors");
+					const errorsResult = await client.browserErrors(surface, params.subaction);
+					return txt(JSON.stringify(errorsResult, null, 2), { surface });
+				}
+
 				default:
 					throw new Error(`Unknown browser action: ${params.action}`);
 			}

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -322,11 +322,17 @@ export function registerTools(pi: ExtensionAPI, client: CmuxClient, _log: LogFn)
 				}
 			}
 
-			// Helper to take snapshot after action if requested
+			// Helper to take snapshot after action if requested.
+			// Failures are swallowed — the primary action already succeeded,
+			// so a snapshot error should not discard that result or trigger retries.
 			const maybeSnapshot = async (baseResult: string): Promise<string> => {
 				if (params.snapshotAfter && surface) {
-					const snapshot = await client.browserSnapshot(surface, true);
-					return baseResult + "\n\n" + snapshot;
+					try {
+						const snapshot = await client.browserSnapshot(surface, true);
+						return baseResult + "\n\n" + snapshot;
+					} catch {
+						return baseResult + "\n\n(snapshot unavailable after action)";
+					}
 				}
 				return baseResult;
 			};


### PR DESCRIPTION
## Summary

Expands the `cmux_browser` tool from 7 actions to 40+, covering the complete [cmux browser automation API](https://www.cmux.dev/docs/browser-automation).

### Before
`open`, `navigate`, `snapshot`, `screenshot`, `click`, `fill`, `eval`

### After — all categories covered

| Category | New Actions |
|----------|-------------|
| **Navigation** | `back`, `forward`, `reload`, `url`, `identify` |
| **Waiting** | `wait` (selector, text, URL, load-state, JS condition) |
| **DOM interaction** | `dblclick`, `hover`, `focus`, `check`, `uncheck`, `scroll-into-view`, `type`, `press`, `keydown`/`keyup`, `select`, `scroll` |
| **Inspection** | `get` (title/url/text/html/value/attr/count/box/styles), `is` (visible/enabled/checked), `find` (role/text/label/placeholder/alt/title/testid/first/last/nth), `highlight` |
| **JS injection** | `addinitscript`, `addscript`, `addstyle` |
| **Frames/Dialogs** | `frame`, `dialog` (accept/dismiss), `download` |
| **State** | `cookies` (get/set/clear), `storage` (local/session), `state` (save/load) |
| **Tabs/Logs** | `tab` (list/new/switch/close), `console`, `errors` |

### Also adds
- `snapshotAfter` option — take DOM snapshot after any mutating action
- Enhanced `snapshot` with `selector`, `maxDepth`, `interactive` options
- 30+ new client methods in `client.ts`

### Changes
- `extensions/pi-cmux/src/client.ts` — +207 lines (new browser RPC methods)
- `extensions/pi-cmux/src/tools.ts` — +367 lines (new tool actions, params, handlers)
- TypeScript compiles clean

Closes td-8d84ec