### PR TITLE
feat(pi-a2a): ACK immediately for long-running tasks, deliver results async

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -36,6 +36,13 @@ export interface ProcessResult {
 	durationMs: number;
 }
 
+/** Callback payload when a long-running task completes in the background. */
+export interface AsyncTaskResult {
+	taskId: string;
+	senderName: string;
+	result: ProcessResult;
+}
+
 /**
  * Callback to inject a message into the main agent conversation.
  * Returns a promise that resolves when the agent finishes processing.
@@ -63,6 +70,8 @@ export class PiAgentExecutor implements AgentExecutor {
 	private lastTaskStatus?: "completed" | "failed";
 	/** Optional callback invoked after each task completes or fails. */
 	onTaskFinished?: () => void;
+	/** Optional callback to deliver async task results (for sending responses back to callers). */
+	onAsyncResult?: (result: AsyncTaskResult) => void;
 
 	constructor(log: LogFn, processMessage: ProcessMessage) {
 		this.log = log;
@@ -144,114 +153,69 @@ export class PiAgentExecutor implements AgentExecutor {
 			| undefined;
 		const senderName = senderMeta?.name ?? "Unknown agent";
 
-		try {
-			// Extract text from all part types
-			const textSegments: string[] = [];
-			for (const part of userMessage.parts) {
-				if (part.kind === "text") {
-					textSegments.push((part as { kind: "text"; text: string }).text);
-				} else if (part.kind === "data") {
-					const dataPart = part as { kind: "data"; data: Record<string, unknown> };
-					textSegments.push(JSON.stringify(dataPart.data, null, 2));
-				} else if (part.kind === "file") {
-					const file = part.file as { uri?: string; name?: string; bytes?: string };
-					if (file?.uri) {
-						textSegments.push(`[File: ${file.name ?? file.uri}](${file.uri})`);
-					} else if (file?.name) {
-						textSegments.push(`[File: ${file.name}]`);
-					}
-					this.log("executor_file_part", { taskId, uri: file?.uri, name: file?.name });
-				} else {
-					this.log("executor_unsupported_part", { taskId, kind: (part as { kind: string }).kind }, "WARN");
+		// Extract text from all part types
+		const textSegments: string[] = [];
+		for (const part of userMessage.parts) {
+			if (part.kind === "text") {
+				textSegments.push((part as { kind: "text"; text: string }).text);
+			} else if (part.kind === "data") {
+				const dataPart = part as { kind: "data"; data: Record<string, unknown> };
+				textSegments.push(JSON.stringify(dataPart.data, null, 2));
+			} else if (part.kind === "file") {
+				const file = part.file as { uri?: string; name?: string; bytes?: string };
+				if (file?.uri) {
+					textSegments.push(`[File: ${file.name ?? file.uri}](${file.uri})`);
+				} else if (file?.name) {
+					textSegments.push(`[File: ${file.name}]`);
 				}
-			}
-
-			if (textSegments.length === 0) {
-				this.publishError(taskId, contextId, eventBus, "No processable content in message");
-				eventBus.finished();
-				return;
-			}
-
-			// ── Publish "working" status ──
-			eventBus.publish({
-				kind: "status-update",
-				taskId,
-				contextId,
-				status: { state: "working", timestamp: new Date().toISOString() },
-				final: false,
-			} as TaskStatusUpdateEvent);
-
-			const prompt = textSegments.join("\n");
-			this.activeTaskId = taskId;
-			this.log("executor_start", { taskId, sender: senderName, promptLength: prompt.length });
-
-			// ── Delegate to main agent process ──
-			const result = await this.processMessage(prompt, senderName);
-
-			// Check if canceled while processing
-			if (this.activeTaskId !== taskId) {
-				this.log("executor_canceled_during_run", { taskId });
-				eventBus.finished();
-				return;
-			}
-
-			this.activeTaskId = null;
-
-			if (result.ok) {
-				// Publish artifact with response
-				eventBus.publish({
-					kind: "artifact-update",
-					taskId,
-					contextId,
-					artifact: {
-						artifactId: randomUUID(),
-						name: "response",
-						parts: [{ kind: "text", text: result.response } as Part],
-					},
-				} as TaskArtifactUpdateEvent);
-
-				// Publish "completed"
-				eventBus.publish({
-					kind: "status-update",
-					taskId,
-					contextId,
-					status: { state: "completed", timestamp: new Date().toISOString() },
-					final: true,
-				} as TaskStatusUpdateEvent);
-				this.log("executor_completed", { taskId, responseLength: result.response.length, durationMs: result.durationMs });
-
-				// Record telemetry for hub reporting
-				this.lastTaskDurationMs = result.durationMs;
-				this.lastTaskStatus = "completed";
-				this.onTaskFinished?.();
+				this.log("executor_file_part", { taskId, uri: file?.uri, name: file?.name });
 			} else {
-				this.publishError(taskId, contextId, eventBus, result.error ?? "Unknown error");
-				this.log("executor_failed", { taskId, error: result.error ?? "Unknown", durationMs: result.durationMs }, "ERROR");
-
-				// Record telemetry for hub reporting
-				this.lastTaskDurationMs = result.durationMs;
-				this.lastTaskStatus = "failed";
-				this.onTaskFinished?.();
+				this.log("executor_unsupported_part", { taskId, kind: (part as { kind: string }).kind }, "WARN");
 			}
-
-			eventBus.finished();
-		} catch (err: unknown) {
-			this.activeTaskId = null;
-			const msg = err instanceof Error ? err.message : String(err);
-			this.publishError(taskId, contextId, eventBus, msg);
-			this.log("executor_error", { taskId, error: msg }, "ERROR");
-
-			// Record telemetry for hub reporting — clear stale duration
-			// to avoid pairing a previous task's timing with this failure
-			this.lastTaskDurationMs = undefined;
-			this.lastTaskStatus = "failed";
-			this.onTaskFinished?.();
-
-			eventBus.finished();
-		} finally {
-			// Release the queue so the next task can proceed
-			releaseQueue!();
 		}
+
+		if (textSegments.length === 0) {
+			this.publishError(taskId, contextId, eventBus, "No processable content in message");
+			eventBus.finished();
+			releaseQueue!();
+			return;
+		}
+
+		const prompt = textSegments.join("\n");
+		this.activeTaskId = taskId;
+		this.log("executor_start", { taskId, sender: senderName, promptLength: prompt.length });
+
+		// ── ACK immediately: publish "working" and finish the event bus ──
+		// This unblocks the HTTP response so the sender gets a Task with
+		// state: "working" right away instead of waiting for the agent to
+		// finish (which can take minutes and causes timeout).
+		eventBus.publish({
+			kind: "status-update",
+			taskId,
+			contextId,
+			status: {
+				state: "working",
+				message: {
+					kind: "message",
+					messageId: randomUUID(),
+					role: "agent",
+					parts: [{ kind: "text", text: "Message received, working on it…" } as Part],
+				},
+				timestamp: new Date().toISOString(),
+			},
+			final: true,
+		} as TaskStatusUpdateEvent);
+		eventBus.finished();
+
+		// ── Process in the background ──────────────────────────────
+		// The HTTP response has already been sent. The agent works on the
+		// task, and when done, the result is delivered via onAsyncResult
+		// which sends it back to the caller as a new A2A message.
+		this.processInBackground(taskId, prompt, senderName, releaseQueue!).catch((err) => {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.log("executor_bg_error", { taskId, error: msg }, "ERROR");
+			releaseQueue!();
+		});
 	}
 
 	async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
@@ -301,6 +265,60 @@ export class PiAgentExecutor implements AgentExecutor {
 	/** Number of tasks waiting in the queue (not including the active one). */
 	queueDepth(): number {
 		return this._queueDepth;
+	}
+
+	/**
+	 * Process a task in the background after the ACK has been sent.
+	 * When the agent finishes, delivers the result via onAsyncResult callback.
+	 */
+	private async processInBackground(
+		taskId: string,
+		prompt: string,
+		senderName: string,
+		releaseQueue: () => void,
+	): Promise<void> {
+		try {
+			const result = await this.processMessage(prompt, senderName);
+
+			// Check if canceled while processing
+			if (this.activeTaskId !== taskId) {
+				this.log("executor_canceled_during_run", { taskId });
+				return;
+			}
+
+			this.activeTaskId = null;
+
+			// Record telemetry
+			this.lastTaskDurationMs = result.durationMs;
+			this.lastTaskStatus = result.ok ? "completed" : "failed";
+			this.onTaskFinished?.();
+
+			if (result.ok) {
+				this.log("executor_completed", { taskId, responseLength: result.response.length, durationMs: result.durationMs });
+			} else {
+				this.log("executor_failed", { taskId, error: result.error ?? "Unknown", durationMs: result.durationMs }, "ERROR");
+			}
+
+			// Deliver the result to be sent back to the caller
+			this.onAsyncResult?.({ taskId, senderName, result });
+		} catch (err: unknown) {
+			this.activeTaskId = null;
+			const msg = err instanceof Error ? err.message : String(err);
+			this.log("executor_error", { taskId, error: msg }, "ERROR");
+
+			this.lastTaskDurationMs = undefined;
+			this.lastTaskStatus = "failed";
+			this.onTaskFinished?.();
+
+			// Deliver error result
+			this.onAsyncResult?.({
+				taskId,
+				senderName,
+				result: { ok: false, response: "", error: msg, durationMs: 0 },
+			});
+		} finally {
+			releaseQueue();
+		}
 	}
 
 	private publishError(taskId: string, contextId: string, eventBus: ExecutionEventBus, error: string): void {

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -40,6 +40,8 @@ export interface ProcessResult {
 export interface AsyncTaskResult {
 	taskId: string;
 	senderName: string;
+	/** Sender's A2A endpoint URL, captured from the original request context. */
+	senderUrl?: string;
 	result: ProcessResult;
 }
 
@@ -147,11 +149,12 @@ export class PiAgentExecutor implements AgentExecutor {
 			return;
 		}
 
-		// Extract sender identity
+		// Extract sender identity (name + URL for reply routing)
 		const senderMeta = (userMessage.metadata as Record<string, unknown> | undefined)?.["pi:sender"] as
-			| { name?: string; description?: string }
+			| { name?: string; description?: string; url?: string }
 			| undefined;
 		const senderName = senderMeta?.name ?? "Unknown agent";
+		const senderUrl = senderMeta?.url;
 
 		// Extract text from all part types
 		const textSegments: string[] = [];
@@ -211,10 +214,9 @@ export class PiAgentExecutor implements AgentExecutor {
 		// The HTTP response has already been sent. The agent works on the
 		// task, and when done, the result is delivered via onAsyncResult
 		// which sends it back to the caller as a new A2A message.
-		this.processInBackground(taskId, prompt, senderName, releaseQueue!).catch((err) => {
+		this.processInBackground(taskId, prompt, senderName, senderUrl, releaseQueue!).catch((err) => {
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_bg_error", { taskId, error: msg }, "ERROR");
-			releaseQueue!();
 		});
 	}
 
@@ -275,6 +277,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		taskId: string,
 		prompt: string,
 		senderName: string,
+		senderUrl: string | undefined,
 		releaseQueue: () => void,
 	): Promise<void> {
 		try {
@@ -300,7 +303,7 @@ export class PiAgentExecutor implements AgentExecutor {
 			}
 
 			// Deliver the result to be sent back to the caller
-			this.onAsyncResult?.({ taskId, senderName, result });
+			this.onAsyncResult?.({ taskId, senderName, senderUrl, result });
 		} catch (err: unknown) {
 			this.activeTaskId = null;
 			const msg = err instanceof Error ? err.message : String(err);
@@ -314,6 +317,7 @@ export class PiAgentExecutor implements AgentExecutor {
 			this.onAsyncResult?.({
 				taskId,
 				senderName,
+				senderUrl,
 				result: { ok: false, response: "", error: msg, durationMs: 0 },
 			});
 		} finally {

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -14,6 +14,8 @@ export interface SenderIdentity {
 	name: string;
 	/** Agent description (optional). */
 	description?: string;
+	/** Agent's own A2A endpoint URL — allows the receiver to reply directly. */
+	url?: string;
 }
 
 export interface SendMessageOptions {
@@ -67,6 +69,7 @@ export async function sendA2AMessage(
 			"pi:sender": {
 				name: sender.name,
 				...(sender.description ? { description: sender.description } : {}),
+				...(sender.url ? { url: sender.url } : {}),
 			},
 		};
 	}

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -39,6 +39,8 @@ export interface SendMessageResult {
 	error?: string;
 	/** True when the remote agent returned HTTP 401 — credential may be stale. */
 	unauthorized?: boolean;
+	/** True when the remote agent ACKed with "working" — the real result will arrive later as a separate message. */
+	working?: boolean;
 }
 
 /**
@@ -118,6 +120,14 @@ export async function sendA2AMessage(
 
 		if (!data.result) {
 			return { ok: false, error: "Empty result from remote agent", raw: data };
+		}
+
+		// Detect "working" ACK — the remote agent accepted the task but hasn't finished yet.
+		// The actual result will arrive later as a separate A2A message.
+		const status = (data.result as { status?: { state?: string } }).status;
+		if (status?.state === "working") {
+			log("a2a_send_working", { url });
+			return { ok: true, response: "", raw: data.result, working: true };
 		}
 
 		// Extract response text from the A2A task result

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -44,7 +44,7 @@ import {
 } from "@a2a-js/sdk/server";
 import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
-import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
+import { PiAgentExecutor, type ProcessResult, type AsyncTaskResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
 import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification } from "./hub.ts";
 import { sendA2AMessage, type SenderIdentity } from "./client.ts";
@@ -401,6 +401,51 @@ export default function (pi: ExtensionAPI) {
 			if (hubAgentId) {
 				sendTelemetry(config).catch(() => {});
 			}
+		};
+
+		// When a long-running task completes, send the result back to the sender
+		// as a new A2A message. The initial HTTP response already returned a
+		// "working" ACK — this delivers the actual content.
+		executor.onAsyncResult = (asyncResult: AsyncTaskResult) => {
+			const { taskId, senderName, result } = asyncResult;
+			if (!result.ok) {
+				log("async_result_failed", { taskId, sender: senderName, error: result.error }, "WARN");
+				return;
+			}
+
+			// Find the sender in discovered agents (by name, case-insensitive)
+			const senderLower = senderName.toLowerCase();
+			const senderAgent = discoveredAgents.find((a) => a.name.toLowerCase() === senderLower);
+			if (!senderAgent) {
+				log("async_result_no_sender", { taskId, sender: senderName }, "WARN");
+				return;
+			}
+
+			// Send the response back as a new A2A message
+			const sendOpts = {
+				url: senderAgent.url,
+				message: result.response,
+				credential: null as string | null,
+				timeoutMs: config.sendTimeoutMs,
+				sender: { name: config.name ?? "Pi Agent", description: config.description } as SenderIdentity,
+			};
+
+			// Get credential for the sender agent and send
+			const senderAgentId = senderAgent.id;
+			(async () => {
+				if (config.hub?.apiKey && senderAgentId) {
+					sendOpts.credential = await getCachedCredential(senderAgentId, config.hub);
+				}
+				const sendResult = await sendA2AMessage(sendOpts, log);
+				if (sendResult.ok) {
+					log("async_result_sent", { taskId, sender: senderName, responseLength: result.response.length });
+				} else {
+					log("async_result_send_failed", { taskId, sender: senderName, error: sendResult.error }, "ERROR");
+				}
+			})().catch((err: unknown) => {
+				const msg = err instanceof Error ? err.message : String(err);
+				log("async_result_send_error", { taskId, sender: senderName, error: msg }, "ERROR");
+			});
 		};
 
 		const taskStore = new InMemoryTaskStore();
@@ -782,7 +827,19 @@ export default function (pi: ExtensionAPI) {
 
 				const dur = fmtDuration(Date.now() - sendStart);
 
-				if (result.ok) {
+				if (result.ok && result.working) {
+					// ACK received — the remote agent is working on it.
+					// The actual result will arrive later as a separate inbound A2A message.
+					pi.sendMessage(
+						{
+							customType: "a2a-response-ack",
+							content:
+								`⏳ **${resolvedName}** acknowledged the request (${dur}) — working on it. Response will arrive when ready.`,
+							display: true,
+						},
+						{ triggerTurn: false },
+					);
+				} else if (result.ok) {
 					pi.sendMessage(
 						{
 							customType: "a2a-response-received",

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -66,6 +66,43 @@ function fmtDuration(ms: number): string {
 	return `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
+/**
+ * Validate a reply URL for SSRF safety.
+ *
+ * Accepts https:// URLs unconditionally.
+ * Accepts http:// only for localhost (127.0.0.1, [::1], localhost).
+ * Rejects everything else: private/link-local IPs, non-http(s) schemes, invalid URLs.
+ *
+ * Returns the validated URL string, or null if rejected.
+ */
+function validateReplyUrl(url: string): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+
+	// Only allow http(s) schemes
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+		return null;
+	}
+
+	// https is always allowed
+	if (parsed.protocol === "https:") {
+		return url;
+	}
+
+	// http: only allowed for localhost
+	const hostname = parsed.hostname;
+	if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]") {
+		return url;
+	}
+
+	// Reject http to anything else (private IPs, link-local, public hosts)
+	return null;
+}
+
 /** Extract text content from the last assistant message. */
 function extractAssistantText(messages: AgentMessage[]): string {
 	for (let i = messages.length - 1; i >= 0; i--) {
@@ -408,9 +445,6 @@ export default function (pi: ExtensionAPI) {
 
 		// When a long-running task completes, send the result back to the sender
 		// as a new A2A message. The initial HTTP response already returned a
-		// "working" ACK — this delivers the actual content.
-		// When a long-running task completes, send the result back to the sender
-		// as a new A2A message. The initial HTTP response already returned a
 		// "working" ACK — this delivers the actual content (or error).
 		executor.onAsyncResult = (asyncResult: AsyncTaskResult) => {
 			const { taskId, senderName, senderUrl, result } = asyncResult;
@@ -420,19 +454,40 @@ export default function (pi: ExtensionAPI) {
 				? result.response
 				: `❌ Task failed: ${result.error ?? "Unknown error"}`;
 
-			// Resolve sender's URL and credential using the same priority order as a2a_send:
-			// 1. senderUrl from pi:sender metadata (most reliable — set by the actual caller)
-			// 2. staticRegistry (locally configured agents)
-			// 3. discoveredAgents (cached from hub discovery)
-			// 4. Hub lookup by name (last resort)
+			// Resolve sender's URL and credential. Priority:
+			// 1. Match senderUrl against known agents (static registry + discovered hub agents)
+			// 2. Match senderName against known agents (static registry + discovered hub agents)
+			// 3. Fall back to validated senderUrl (SSRF-safe: https required, no private IPs)
 			(async () => {
-				let replyUrl: string | null = senderUrl ?? null;
+				let replyUrl: string | null = null;
 				let credential: string | null = null;
 				let agentId: string | null = null;
+				const senderLower = senderName.toLowerCase();
 
+				// If senderUrl is provided, try to match it against known agents first.
+				// This validates the URL is legitimate without trusting it blindly.
+				if (senderUrl) {
+					if (staticRegistry) {
+						const staticMatch = staticRegistry.findByUrl(senderUrl);
+						if (staticMatch) {
+							replyUrl = staticMatch.config.url;
+							credential = staticMatch.config.apiKey ?? null;
+						}
+					}
+					if (!replyUrl) {
+						const normalizedSender = senderUrl.replace(/\/+$/, "");
+						const hubMatch = discoveredAgents.find(
+							(a) => a.url.replace(/\/+$/, "") === normalizedSender,
+						);
+						if (hubMatch) {
+							replyUrl = hubMatch.url;
+							agentId = hubMatch.id;
+						}
+					}
+				}
+
+				// Fall back to name-based lookup in known agents
 				if (!replyUrl) {
-					// Try static agents
-					const senderLower = senderName.toLowerCase();
 					if (staticRegistry) {
 						const staticMatch = staticRegistry.findByName(senderName);
 						if (staticMatch) {
@@ -440,8 +495,6 @@ export default function (pi: ExtensionAPI) {
 							credential = staticMatch.config.apiKey ?? null;
 						}
 					}
-
-					// Try discovered hub agents
 					if (!replyUrl) {
 						const hubMatch = discoveredAgents.find((a) => a.name.toLowerCase() === senderLower);
 						if (hubMatch) {
@@ -449,14 +502,16 @@ export default function (pi: ExtensionAPI) {
 							agentId = hubMatch.id;
 						}
 					}
+				}
 
-					// Try hub lookup by name
-					if (!replyUrl && config.hub) {
-						const detail = await getAgentFromHub(senderName, config.hub, log);
-						if (detail) {
-							replyUrl = (detail.agentCard as { url?: string }).url ?? null;
-							agentId = detail.id;
-						}
+				// Last resort: use senderUrl directly, but only after SSRF validation.
+				// Require https in production; allow http only for localhost/127.0.0.1.
+				if (!replyUrl && senderUrl) {
+					const validated = validateReplyUrl(senderUrl);
+					if (validated) {
+						replyUrl = validated;
+					} else {
+						log("async_result_url_rejected", { taskId, sender: senderName, senderUrl }, "WARN");
 					}
 				}
 

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -98,6 +98,8 @@ export default function (pi: ExtensionAPI) {
 	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
 	let staticRegistry: StaticAgentRegistry | null = null;
+	/** This agent's own public A2A URL — included in pi:sender for reply routing. */
+	let selfUrl: string | null = null;
 
 	// ── Main-process message handling ─────────────────────────
 	//
@@ -387,6 +389,7 @@ export default function (pi: ExtensionAPI) {
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
 		const port = config.port ?? DEFAULT_PORT;
 		const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
+		selfUrl = publicUrl;
 		const agentCard = buildAgentCard(config, publicUrl);
 
 		// Set up executor with main-process callback
@@ -406,39 +409,77 @@ export default function (pi: ExtensionAPI) {
 		// When a long-running task completes, send the result back to the sender
 		// as a new A2A message. The initial HTTP response already returned a
 		// "working" ACK — this delivers the actual content.
+		// When a long-running task completes, send the result back to the sender
+		// as a new A2A message. The initial HTTP response already returned a
+		// "working" ACK — this delivers the actual content (or error).
 		executor.onAsyncResult = (asyncResult: AsyncTaskResult) => {
-			const { taskId, senderName, result } = asyncResult;
-			if (!result.ok) {
-				log("async_result_failed", { taskId, sender: senderName, error: result.error }, "WARN");
-				return;
-			}
+			const { taskId, senderName, senderUrl, result } = asyncResult;
 
-			// Find the sender in discovered agents (by name, case-insensitive)
-			const senderLower = senderName.toLowerCase();
-			const senderAgent = discoveredAgents.find((a) => a.name.toLowerCase() === senderLower);
-			if (!senderAgent) {
-				log("async_result_no_sender", { taskId, sender: senderName }, "WARN");
-				return;
-			}
+			// Build the message — include error info so the caller knows what happened
+			const messageText = result.ok
+				? result.response
+				: `❌ Task failed: ${result.error ?? "Unknown error"}`;
 
-			// Send the response back as a new A2A message
-			const sendOpts = {
-				url: senderAgent.url,
-				message: result.response,
-				credential: null as string | null,
-				timeoutMs: config.sendTimeoutMs,
-				sender: { name: config.name ?? "Pi Agent", description: config.description } as SenderIdentity,
-			};
-
-			// Get credential for the sender agent and send
-			const senderAgentId = senderAgent.id;
+			// Resolve sender's URL and credential using the same priority order as a2a_send:
+			// 1. senderUrl from pi:sender metadata (most reliable — set by the actual caller)
+			// 2. staticRegistry (locally configured agents)
+			// 3. discoveredAgents (cached from hub discovery)
+			// 4. Hub lookup by name (last resort)
 			(async () => {
-				if (config.hub?.apiKey && senderAgentId) {
-					sendOpts.credential = await getCachedCredential(senderAgentId, config.hub);
+				let replyUrl: string | null = senderUrl ?? null;
+				let credential: string | null = null;
+				let agentId: string | null = null;
+
+				if (!replyUrl) {
+					// Try static agents
+					const senderLower = senderName.toLowerCase();
+					if (staticRegistry) {
+						const staticMatch = staticRegistry.findByName(senderName);
+						if (staticMatch) {
+							replyUrl = staticMatch.config.url;
+							credential = staticMatch.config.apiKey ?? null;
+						}
+					}
+
+					// Try discovered hub agents
+					if (!replyUrl) {
+						const hubMatch = discoveredAgents.find((a) => a.name.toLowerCase() === senderLower);
+						if (hubMatch) {
+							replyUrl = hubMatch.url;
+							agentId = hubMatch.id;
+						}
+					}
+
+					// Try hub lookup by name
+					if (!replyUrl && config.hub) {
+						const detail = await getAgentFromHub(senderName, config.hub, log);
+						if (detail) {
+							replyUrl = (detail.agentCard as { url?: string }).url ?? null;
+							agentId = detail.id;
+						}
+					}
 				}
-				const sendResult = await sendA2AMessage(sendOpts, log);
+
+				if (!replyUrl) {
+					log("async_result_no_sender", { taskId, sender: senderName }, "WARN");
+					return;
+				}
+
+				// Get credential for hub agents
+				if (!credential && agentId && config.hub?.apiKey) {
+					credential = await getCachedCredential(agentId, config.hub);
+				}
+
+				const sendResult = await sendA2AMessage({
+					url: replyUrl,
+					message: messageText,
+					credential,
+					timeoutMs: config.sendTimeoutMs,
+					sender: { name: config.name ?? "Pi Agent", description: config.description, url: selfUrl ?? undefined } as SenderIdentity,
+				}, log);
+
 				if (sendResult.ok) {
-					log("async_result_sent", { taskId, sender: senderName, responseLength: result.response.length });
+					log("async_result_sent", { taskId, sender: senderName, ok: result.ok, responseLength: messageText.length });
 				} else {
 					log("async_result_send_failed", { taskId, sender: senderName, error: sendResult.error }, "ERROR");
 				}
@@ -802,7 +843,7 @@ export default function (pi: ExtensionAPI) {
 				message: params.message,
 				credential,
 				timeoutMs: config.sendTimeoutMs,
-				sender: { name: config.name ?? "Pi Agent", description: config.description } as SenderIdentity,
+				sender: { name: config.name ?? "Pi Agent", description: config.description, url: selfUrl ?? undefined } as SenderIdentity,
 			};
 
 			(async () => {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -95,7 +95,7 @@ function validateReplyUrl(url: string): string | null {
 
 	// http: only allowed for localhost
 	const hostname = parsed.hostname;
-	if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]") {
+	if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") {
 		return url;
 	}
 


### PR DESCRIPTION
## Problem

Cross-agent A2A task dispatches time out because the receiving agent blocks the HTTP response until the agent finishes processing. Agent work can take minutes, exceeding the sender's 5-minute timeout. The sender gives up, and the response is lost.

## Solution: Immediate ACK + Async Result Delivery

### Receiver side (agent-executor.ts)

**Before:** Executor processes the task to completion, publishes artifacts + completed status, then calls `eventBus.finished()`. HTTP response blocks for the entire duration.

**After:** Executor immediately publishes `working` status with `final: true` and calls `eventBus.finished()` — HTTP response returns within seconds with a Task showing `state: "working"`. The agent then processes in the background via `processInBackground()`. When done, the new `onAsyncResult` callback fires, which sends the actual result back to the sender as a new outbound A2A message.

### Sender side (client.ts + index.ts)

- `SendMessageResult` gains a `working` flag to distinguish ACK from real response
- ACK shows `⏳ acknowledged, working on it` (no triggerTurn — don't interrupt the agent)
- The actual result arrives later as a normal inbound A2A message

### Flow diagram

```
Sender                          Receiver
  |--- message/send ------------>|
  |                              | publish submitted + working
  |                              | eventBus.finished()
  |<-- Task{state:working} ------|
  |  (⏳ ACK, ~1-2s)            |
  |                              | ...agent processes for 3min...
  |                              | onAsyncResult fires
  |<-- NEW message/send ---------|  (sends result back)
  | (📨 response from agent)    |
```

### Changes
- `agent-executor.ts` — ACK pattern + `processInBackground()` + `AsyncTaskResult` type
- `client.ts` — `working` flag on `SendMessageResult`, detect `state: working` in response
- `index.ts` — `onAsyncResult` callback wired up, sender handles `working` ACK

Closes td-3096d5