### PR TITLE
feat(pi-proxy): route LLM API calls through configurable proxy

### DIFF
--- a/extensions/pi-proxy/AGENTS.md
+++ b/extensions/pi-proxy/AGENTS.md
@@ -1,0 +1,35 @@
+---
+name: pi-proxy
+description: Route LLM API calls through a configurable proxy server
+---
+
+## Overview
+
+Lightweight extension that overrides provider `baseUrl` for all known LLM providers when `pi-proxy.baseUrl` is set in settings.json. No-op when not configured.
+
+## Architecture
+
+- **`src/index.ts`** — Entry point. Reads settings, calls `pi.registerProvider()` for each known provider with the proxy URL. Runs at extension load time (not on session_start) since `registerProvider` is queued and applied during runner init.
+- **`src/settings.ts`** — Settings loader. Reads `pi-proxy` key from global + project settings.json, merges them (project overrides global per-key).
+
+## Key Design Decisions
+
+- Providers are overridden at load time via `pi.registerProvider()`, not per-request
+- Only `baseUrl` (and optionally `headers`) are overridden — all models, API keys, and API types are preserved
+- Each provider maps to `{baseUrl}/{provider}` by default, customizable via `providers` config
+- A provider can be excluded from proxying by setting it to `false`
+- If `baseUrl` is empty/missing, the extension is completely inert
+
+## Settings Schema
+
+```json
+{
+  "pi-proxy": {
+    "baseUrl": "string",
+    "headers": { "key": "value-or-env-var-name" },
+    "providers": {
+      "provider-name": "string (custom path) | false (skip)"
+    }
+  }
+}
+```

--- a/extensions/pi-proxy/AGENTS.md
+++ b/extensions/pi-proxy/AGENTS.md
@@ -5,12 +5,12 @@ description: Route LLM API calls through a configurable proxy server
 
 ## Overview
 
-Lightweight extension that overrides provider `baseUrl` for all known LLM providers when `pi-proxy.baseUrl` is set in settings.json. No-op when not configured.
+Lightweight extension that overrides provider `baseUrl` for all known LLM providers when `pi-proxy.baseUrl` is set in global settings.json. No-op when not configured.
 
 ## Architecture
 
-- **`src/index.ts`** — Entry point. Reads settings, calls `pi.registerProvider()` for each known provider with the proxy URL. Runs at extension load time (not on session_start) since `registerProvider` is queued and applied during runner init.
-- **`src/settings.ts`** — Settings loader. Reads `pi-proxy` key from global + project settings.json, merges them (project overrides global per-key).
+- **`src/index.ts`** — Entry point. Reads settings, validates URL scheme, calls `pi.registerProvider()` for each known provider with the proxy URL. Runs at extension load time (not on session_start) since `registerProvider` is queued and applied during runner init.
+- **`src/settings.ts`** — Settings loader. Reads `pi-proxy` key from global + project settings.json. Returns `{ settings, error? }` so callers can distinguish config errors from intentional non-configuration.
 
 ## Key Design Decisions
 
@@ -20,13 +20,20 @@ Lightweight extension that overrides provider `baseUrl` for all known LLM provid
 - A provider can be excluded from proxying by setting it to `false`
 - If `baseUrl` is empty/missing, the extension is completely inert
 
+## Security Model
+
+- `baseUrl` and `headers` are **global-only** — project settings cannot override them (prevents malicious repos from hijacking LLM traffic)
+- `baseUrl` must use `https://` — `http://` is only allowed for localhost/127.0.0.1 (local dev)
+- Project settings can only configure `providers` (per-provider path overrides or exclusions)
+- `registerProvider()` calls are wrapped in try/catch to prevent partial proxy state
+
 ## Settings Schema
 
 ```json
 {
   "pi-proxy": {
-    "baseUrl": "string",
-    "headers": { "key": "value-or-env-var-name" },
+    "baseUrl": "string (global only, https required)",
+    "headers": { "key": "value-or-env-var-name (global only)" },
     "providers": {
       "provider-name": "string (custom path) | false (skip)"
     }

--- a/extensions/pi-proxy/README.md
+++ b/extensions/pi-proxy/README.md
@@ -1,0 +1,79 @@
+# pi-proxy
+
+Route all LLM API calls through a configurable proxy server.
+
+When enabled, requests to Anthropic, OpenAI, Google, xAI, OpenRouter, Groq, and Mistral are redirected through your proxy instead of going directly to provider APIs.
+
+## Setup
+
+Add to your global `~/.pi/agent/settings.json`:
+
+```json
+{
+  "pi-proxy": {
+    "baseUrl": "https://proxy.example.com"
+  }
+}
+```
+
+That's it. All provider requests will now route through `https://proxy.example.com/{provider}`:
+
+| Provider | Proxied URL |
+|----------|-------------|
+| Anthropic | `https://proxy.example.com/anthropic` |
+| OpenAI | `https://proxy.example.com/openai` |
+| Google | `https://proxy.example.com/google` |
+| xAI | `https://proxy.example.com/xai` |
+| OpenRouter | `https://proxy.example.com/openrouter` |
+| Groq | `https://proxy.example.com/groq` |
+| Mistral | `https://proxy.example.com/mistral` |
+
+If `baseUrl` is not set or empty, the extension does nothing — requests go directly to providers as usual.
+
+## Custom Headers
+
+Add headers to all proxied requests:
+
+```json
+{
+  "pi-proxy": {
+    "baseUrl": "https://proxy.example.com",
+    "headers": {
+      "X-Proxy-Auth": "MY_PROXY_TOKEN"
+    }
+  }
+}
+```
+
+Header values can be environment variable names (resolved at request time by pi) or literal strings.
+
+## Per-Provider Overrides
+
+Customize the path for specific providers, or disable proxying for a provider:
+
+```json
+{
+  "pi-proxy": {
+    "baseUrl": "https://proxy.example.com",
+    "providers": {
+      "anthropic": "/v1/anthropic",
+      "google": false
+    }
+  }
+}
+```
+
+- **String** — custom path suffix (e.g. `"/v1/anthropic"` → `https://proxy.example.com/v1/anthropic`)
+- **`false`** — skip proxying for that provider (requests go directly to the provider API)
+
+## Project Overrides
+
+Project-level settings (`.pi/settings.json`) override global settings per-key:
+
+```json
+{
+  "pi-proxy": {
+    "baseUrl": "https://different-proxy.example.com"
+  }
+}
+```

--- a/extensions/pi-proxy/README.md
+++ b/extensions/pi-proxy/README.md
@@ -6,7 +6,7 @@ When enabled, requests to Anthropic, OpenAI, Google, xAI, OpenRouter, Groq, and 
 
 ## Setup
 
-Add to your global `~/.pi/agent/settings.json`:
+Add to your **global** `~/.pi/agent/settings.json`:
 
 ```json
 {
@@ -32,7 +32,7 @@ If `baseUrl` is not set or empty, the extension does nothing — requests go dir
 
 ## Custom Headers
 
-Add headers to all proxied requests:
+Add headers to all proxied requests (global settings only):
 
 ```json
 {
@@ -49,12 +49,11 @@ Header values can be environment variable names (resolved at request time by pi)
 
 ## Per-Provider Overrides
 
-Customize the path for specific providers, or disable proxying for a provider:
+Customize the path for specific providers, or disable proxying for a provider. This works in both global and project settings:
 
 ```json
 {
   "pi-proxy": {
-    "baseUrl": "https://proxy.example.com",
     "providers": {
       "anthropic": "/v1/anthropic",
       "google": false
@@ -66,14 +65,8 @@ Customize the path for specific providers, or disable proxying for a provider:
 - **String** — custom path suffix (e.g. `"/v1/anthropic"` → `https://proxy.example.com/v1/anthropic`)
 - **`false`** — skip proxying for that provider (requests go directly to the provider API)
 
-## Project Overrides
+## Security
 
-Project-level settings (`.pi/settings.json`) override global settings per-key:
-
-```json
-{
-  "pi-proxy": {
-    "baseUrl": "https://different-proxy.example.com"
-  }
-}
-```
+- **`baseUrl` and `headers` are global-only** — project-level `.pi/settings.json` cannot override them, preventing a malicious repo from redirecting LLM traffic
+- **HTTPS required** — `baseUrl` must use `https://`. `http://` is only allowed for `localhost` / `127.0.0.1` (local dev proxies)
+- Project settings can only configure `providers` (path overrides and exclusions)

--- a/extensions/pi-proxy/package-lock.json
+++ b/extensions/pi-proxy/package-lock.json
@@ -1,0 +1,4214 @@
+{
+	"name": "@e9n/pi-proxy",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@e9n/pi-proxy",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@types/node": "^22.0.0",
+				"typescript": "^5.0.0"
+			},
+			"peerDependencies": {
+				"@mariozechner/pi-coding-agent": "*"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1009.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1009.0.tgz",
+			"integrity": "sha512-0k9d0oO6nw3Y6jtgs1cmMPNuwAVPQahIoshKK3NDfhVQR1wNC90/gSpdfa9GKswe8XRq/ZZlq7ny0qM1rd/Hkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/credential-provider-node": "^3.972.21",
+				"@aws-sdk/eventstream-handler-node": "^3.972.11",
+				"@aws-sdk/middleware-eventstream": "^3.972.8",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.8",
+				"@aws-sdk/middleware-user-agent": "^3.972.21",
+				"@aws-sdk/middleware-websocket": "^3.972.13",
+				"@aws-sdk/region-config-resolver": "^3.972.8",
+				"@aws-sdk/token-providers": "3.1009.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.7",
+				"@smithy/config-resolver": "^4.4.11",
+				"@smithy/core": "^3.23.11",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.12",
+				"@smithy/eventstream-serde-node": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.25",
+				"@smithy/middleware-retry": "^4.4.42",
+				"@smithy/middleware-serde": "^4.2.14",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.4.16",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.41",
+				"@smithy/util-defaults-mode-node": "^4.2.44",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/util-stream": "^4.5.19",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.973.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
+			"integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/xml-builder": "^3.972.11",
+				"@smithy/core": "^3.23.11",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
+			"integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
+			"integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.4.16",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.19",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
+			"integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/credential-provider-env": "^3.972.18",
+				"@aws-sdk/credential-provider-http": "^3.972.20",
+				"@aws-sdk/credential-provider-login": "^3.972.20",
+				"@aws-sdk/credential-provider-process": "^3.972.18",
+				"@aws-sdk/credential-provider-sso": "^3.972.20",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.20",
+				"@aws-sdk/nested-clients": "^3.996.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
+			"integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/nested-clients": "^3.996.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.21",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
+			"integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.18",
+				"@aws-sdk/credential-provider-http": "^3.972.20",
+				"@aws-sdk/credential-provider-ini": "^3.972.20",
+				"@aws-sdk/credential-provider-process": "^3.972.18",
+				"@aws-sdk/credential-provider-sso": "^3.972.20",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.20",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
+			"integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
+			"integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/nested-clients": "^3.996.10",
+				"@aws-sdk/token-providers": "3.1009.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
+			"integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/nested-clients": "^3.996.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.11.tgz",
+			"integrity": "sha512-2IrLrOruRr1NhTK0vguBL1gCWv1pu4bf4KaqpsA+/vCJpFEbvXFawn71GvCzk1wyjnDUsemtKypqoKGv4cSGbA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+			"integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+			"integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+			"integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+			"integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.21",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.21.tgz",
+			"integrity": "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@smithy/core": "^3.23.11",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-retry": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.13.tgz",
+			"integrity": "sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-format-url": "^3.972.8",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.996.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
+			"integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.8",
+				"@aws-sdk/middleware-user-agent": "^3.972.21",
+				"@aws-sdk/region-config-resolver": "^3.972.8",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.7",
+				"@smithy/config-resolver": "^4.4.11",
+				"@smithy/core": "^3.23.11",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.25",
+				"@smithy/middleware-retry": "^4.4.42",
+				"@smithy/middleware-serde": "^4.2.14",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.4.16",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.41",
+				"@smithy/util-defaults-mode-node": "^4.2.44",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+			"integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/config-resolver": "^4.4.11",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1009.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
+			"integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.20",
+				"@aws-sdk/nested-clients": "^3.996.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+			"integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-endpoints": "^3.3.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+			"integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+			"integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.7",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.7.tgz",
+			"integrity": "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.21",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
+			"integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"fast-xml-parser": "5.4.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.45.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.45.0.tgz",
+			"integrity": "sha512-+sNRWhKiRibVgc4OKi7aBJJ0A7RcoVD8tGG+eFkqxAWRjASDW+ktS9lLwTDnAxZICzCVoeAdu8dYLJVTX60N9w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+			"integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+				"@mariozechner/clipboard-darwin-universal": "0.3.2",
+				"@mariozechner/clipboard-darwin-x64": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+			"integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+			"integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+			"integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+			"integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+			"integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+			"integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+			"integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/jiti": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"std-env": "^3.10.0",
+				"yoctocolors": "^2.1.2"
+			},
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.58.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.58.1.tgz",
+			"integrity": "sha512-7bnkMRgdbfH1A397K7OOQ8XGpZQtJ+kqT1WClj7W00eHTvTUxgJBMCAJXmsho4PqmUxHwIoOTr1mhPW14yH3Zw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.58.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.58.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.58.1.tgz",
+			"integrity": "sha512-ZZ9+SiWVm55JlafOlv3InAUBrSzAji1n8otvSjS7VLHHpfEUeG5s+L1w8S76t8gn9+lqVLK4/UgkxQUdFWIyDw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.73.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "1.14.1",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.58.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.58.1.tgz",
+			"integrity": "sha512-eEsCe/EpZgcwqqwuNIR53bo4Q/HJFr3s3sCyo2GgI3cUYiiA+0BIlwI8ojQ9MoNNMyxXhhxb/TVsFee9WDq13g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.58.1",
+				"@mariozechner/pi-ai": "^0.58.1",
+				"@mariozechner/pi-tui": "^0.58.1",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.58.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.58.1.tgz",
+			"integrity": "sha512-4cO6E4/zN3FFzfwvdBpBYaZagrEyuOzZV2PYiS+FFl8u4pC1TsrV2GYqjhVVpylgxoOTKNyiargZvthp0kc4xQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+			"integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+			"peer": true,
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.24.1"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@smithy/abort-controller": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+			"integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "4.4.11",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.11.tgz",
+			"integrity": "sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.23.11",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
+			"integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-stream": "^4.5.19",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+			"integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+			"integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+			"integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+			"integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+			"integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+			"integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.15",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+			"integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+			"integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+			"integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+			"integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.25",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.25.tgz",
+			"integrity": "sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.11",
+				"@smithy/middleware-serde": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.4.42",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.42.tgz",
+			"integrity": "sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.14.tgz",
+			"integrity": "sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.11",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+			"integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+			"integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
+			"integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/abort-controller": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+			"integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+			"integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+			"integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+			"integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+			"integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+			"integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+			"integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.12.5",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
+			"integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.11",
+				"@smithy/middleware-endpoint": "^4.4.25",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.19",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+			"integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/querystring-parser": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.41",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.41.tgz",
+			"integrity": "sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.44",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.44.tgz",
+			"integrity": "sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.11",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.5",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+			"integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+			"integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+			"integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "4.5.19",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.19.tgz",
+			"integrity": "sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.4.16",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/node": {
+			"version": "22.19.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+			"integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
+			"integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-xml-builder": "^1.0.0",
+				"strnum": "^2.1.2"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.2",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+			"integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+			"integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2",
+				"rimraf": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.6.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+			"integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "7.1.3",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/koffi": {
+			"version": "2.15.2",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
+			"integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"url": "https://liberapay.com/Koromix"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/lru-cache": {
+			"version": "11.2.7",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+			"integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+			"integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
+			}
+		}
+	}
+}

--- a/extensions/pi-proxy/package.json
+++ b/extensions/pi-proxy/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@e9n/pi-proxy",
+	"version": "0.1.0",
+	"description": "Route LLM API calls through a configurable proxy server",
+	"type": "module",
+	"keywords": [
+		"pi-package"
+	],
+	"license": "MIT",
+	"author": "Espen Nilsen <hi@e9n.dev>",
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit"
+	},
+	"peerDependencies": {
+		"@mariozechner/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.0.0"
+	},
+	"files": [
+		"CHANGELOG.md",
+		"README.md",
+		"package.json",
+		"src"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/espennilsen/pi.git",
+		"directory": "extensions/pi-proxy"
+	},
+	"private": true
+}

--- a/extensions/pi-proxy/src/index.ts
+++ b/extensions/pi-proxy/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * pi-proxy — Route LLM API calls through a configurable proxy.
  *
- * Reads `pi-proxy.baseUrl` from settings.json (global or project).
+ * Reads `pi-proxy.baseUrl` from global settings.json.
  * When set, overrides the baseUrl for all known providers so requests
  * go through the proxy instead of directly to provider APIs.
  *
@@ -12,10 +12,14 @@
  * When `pi-proxy.baseUrl` is not set (or empty), the extension is
  * a no-op — requests go directly to provider APIs as usual.
  *
+ * Security:
+ *   - baseUrl and headers are global-only (project settings cannot override)
+ *   - baseUrl must use https:// (except localhost for local dev)
+ *   - Project settings can only configure per-provider path overrides
+ *
  * Optional per-provider path overrides via `pi-proxy.providers`:
  *   {
  *     "pi-proxy": {
- *       "baseUrl": "https://proxy.example.com",
  *       "providers": {
  *         "anthropic": "/v1/anthropic",
  *         "openai": false
@@ -43,11 +47,28 @@ const KNOWN_PROVIDERS = [
 	"mistral",
 ] as const;
 
+/** Check if a URL is a local address (localhost / 127.0.0.1 / [::1]). */
+function isLocalUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		return parsed.hostname === "localhost"
+			|| parsed.hostname === "127.0.0.1"
+			|| parsed.hostname === "[::1]";
+	} catch {
+		return false;
+	}
+}
+
 export default function (pi: ExtensionAPI) {
 	const log = (event: string, data: unknown, level: string = "INFO") =>
 		pi.events.emit("log", { channel: CH, event, data, level });
 
-	const settings = resolveSettings();
+	const { settings, error } = resolveSettings();
+
+	if (error) {
+		log("error", { reason: "settings error", error }, "WARN");
+		return;
+	}
 
 	if (!settings.baseUrl) {
 		log("skip", { reason: "no baseUrl configured" });
@@ -55,6 +76,17 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	const baseUrl = settings.baseUrl.replace(/\/+$/, ""); // strip trailing slashes
+
+	// Validate URL scheme — require https:// unless it's a local dev proxy
+	if (!baseUrl.startsWith("https://") && !isLocalUrl(baseUrl)) {
+		log("error", {
+			reason: "baseUrl must use https:// (http:// allowed only for localhost)",
+			baseUrl,
+		}, "WARN");
+		return;
+	}
+
+	const hasHeaders = Object.keys(settings.headers).length > 0;
 	let proxiedCount = 0;
 
 	for (const provider of KNOWN_PROVIDERS) {
@@ -70,13 +102,21 @@ export default function (pi: ExtensionAPI) {
 		const path = typeof override === "string" ? override : `/${provider}`;
 		const providerUrl = `${baseUrl}${path}`;
 
-		pi.registerProvider(provider, {
-			baseUrl: providerUrl,
-			...(settings.headers ? { headers: settings.headers } : {}),
-		});
+		try {
+			pi.registerProvider(provider, {
+				baseUrl: providerUrl,
+				...(hasHeaders ? { headers: settings.headers } : {}),
+			});
 
-		log("proxied", { provider, url: providerUrl });
-		proxiedCount++;
+			log("proxied", { provider, url: providerUrl });
+			proxiedCount++;
+		} catch (err) {
+			log("register-error", {
+				provider,
+				url: providerUrl,
+				error: err instanceof Error ? err.message : String(err),
+			}, "WARN");
+		}
 	}
 
 	log("init", {

--- a/extensions/pi-proxy/src/index.ts
+++ b/extensions/pi-proxy/src/index.ts
@@ -88,6 +88,8 @@ export default function (pi: ExtensionAPI) {
 
 	const hasHeaders = Object.keys(settings.headers).length > 0;
 	let proxiedCount = 0;
+	let disabledCount = 0;
+	let errorCount = 0;
 
 	for (const provider of KNOWN_PROVIDERS) {
 		const override = settings.providers[provider];
@@ -95,11 +97,13 @@ export default function (pi: ExtensionAPI) {
 		// Explicitly disabled
 		if (override === false) {
 			log("skip-provider", { provider, reason: "disabled" });
+			disabledCount++;
 			continue;
 		}
 
-		// Build the provider URL
-		const path = typeof override === "string" ? override : `/${provider}`;
+		// Build the provider URL — normalize leading slash on custom paths
+		const rawPath = typeof override === "string" ? override : `/${provider}`;
+		const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
 		const providerUrl = `${baseUrl}${path}`;
 
 		try {
@@ -116,12 +120,14 @@ export default function (pi: ExtensionAPI) {
 				url: providerUrl,
 				error: err instanceof Error ? err.message : String(err),
 			}, "WARN");
+			errorCount++;
 		}
 	}
 
 	log("init", {
 		baseUrl,
 		proxied: proxiedCount,
-		skipped: KNOWN_PROVIDERS.length - proxiedCount,
+		disabled: disabledCount,
+		errors: errorCount,
 	});
 }

--- a/extensions/pi-proxy/src/index.ts
+++ b/extensions/pi-proxy/src/index.ts
@@ -1,0 +1,87 @@
+/**
+ * pi-proxy — Route LLM API calls through a configurable proxy.
+ *
+ * Reads `pi-proxy.baseUrl` from settings.json (global or project).
+ * When set, overrides the baseUrl for all known providers so requests
+ * go through the proxy instead of directly to provider APIs.
+ *
+ * Each provider is mounted at `{baseUrl}/{provider}`, e.g.:
+ *   https://proxy.example.com/anthropic
+ *   https://proxy.example.com/openai
+ *
+ * When `pi-proxy.baseUrl` is not set (or empty), the extension is
+ * a no-op — requests go directly to provider APIs as usual.
+ *
+ * Optional per-provider path overrides via `pi-proxy.providers`:
+ *   {
+ *     "pi-proxy": {
+ *       "baseUrl": "https://proxy.example.com",
+ *       "providers": {
+ *         "anthropic": "/v1/anthropic",
+ *         "openai": false
+ *       }
+ *     }
+ *   }
+ *
+ * Set a provider to `false` to skip proxying for that provider.
+ * Set a provider to a string to use a custom path suffix.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { resolveSettings } from "./settings.ts";
+
+const CH = "pi-proxy";
+
+/** Known providers that can be proxied. */
+const KNOWN_PROVIDERS = [
+	"anthropic",
+	"openai",
+	"google",
+	"xai",
+	"openrouter",
+	"groq",
+	"mistral",
+] as const;
+
+export default function (pi: ExtensionAPI) {
+	const log = (event: string, data: unknown, level: string = "INFO") =>
+		pi.events.emit("log", { channel: CH, event, data, level });
+
+	const settings = resolveSettings();
+
+	if (!settings.baseUrl) {
+		log("skip", { reason: "no baseUrl configured" });
+		return;
+	}
+
+	const baseUrl = settings.baseUrl.replace(/\/+$/, ""); // strip trailing slashes
+	let proxiedCount = 0;
+
+	for (const provider of KNOWN_PROVIDERS) {
+		const override = settings.providers[provider];
+
+		// Explicitly disabled
+		if (override === false) {
+			log("skip-provider", { provider, reason: "disabled" });
+			continue;
+		}
+
+		// Build the provider URL
+		const path = typeof override === "string" ? override : `/${provider}`;
+		const providerUrl = `${baseUrl}${path}`;
+
+		pi.registerProvider(provider, {
+			baseUrl: providerUrl,
+			...(settings.headers ? { headers: settings.headers } : {}),
+		});
+
+		log("proxied", { provider, url: providerUrl });
+		proxiedCount++;
+	}
+
+	log("init", {
+		baseUrl,
+		proxied: proxiedCount,
+		skipped: KNOWN_PROVIDERS.length - proxiedCount,
+	});
+}

--- a/extensions/pi-proxy/src/index.ts
+++ b/extensions/pi-proxy/src/index.ts
@@ -103,7 +103,7 @@ export default function (pi: ExtensionAPI) {
 
 		// Build the provider URL — normalize leading slash on custom paths
 		const rawPath = typeof override === "string" ? override : `/${provider}`;
-		const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+		const path = `/${rawPath.replace(/^\/+/, "")}`;
 		const providerUrl = `${baseUrl}${path}`;
 
 		try {

--- a/extensions/pi-proxy/src/settings.ts
+++ b/extensions/pi-proxy/src/settings.ts
@@ -1,0 +1,89 @@
+/**
+ * pi-proxy — Settings loader.
+ *
+ * Reads from `pi-proxy` key in settings.json (global + project merge).
+ *
+ * Example settings.json:
+ *   {
+ *     "pi-proxy": {
+ *       "baseUrl": "https://proxy.example.com",
+ *       "headers": {
+ *         "X-Proxy-Auth": "MY_PROXY_TOKEN"
+ *       },
+ *       "providers": {
+ *         "openai": "/custom/openai/path",
+ *         "google": false
+ *       }
+ *     }
+ *   }
+ */
+
+import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+
+export interface ProxySettings {
+	/** Base URL of the proxy server. Empty/undefined = no proxying. */
+	baseUrl: string;
+
+	/** Optional headers to add to all proxied requests. Values can be env var names. */
+	headers: Record<string, string>;
+
+	/**
+	 * Per-provider overrides.
+	 * - string: custom path suffix (e.g. "/v1/anthropic")
+	 * - false: skip proxying for this provider
+	 * - undefined/missing: use default `/{provider}` path
+	 */
+	providers: Record<string, string | false>;
+}
+
+export function resolveSettings(): ProxySettings {
+	const defaults: ProxySettings = {
+		baseUrl: "",
+		headers: {},
+		providers: {},
+	};
+
+	try {
+		const agentDir = getAgentDir();
+		const sm = SettingsManager.create(process.cwd(), agentDir);
+		const global = (sm.getGlobalSettings() as Record<string, any>) ?? {};
+		const project = (sm.getProjectSettings() as Record<string, any>) ?? {};
+
+		const g = global["pi-proxy"] ?? {};
+		const p = project["pi-proxy"] ?? {};
+
+		// Project settings override global
+		const baseUrl = typeof p.baseUrl === "string" ? p.baseUrl
+			: typeof g.baseUrl === "string" ? g.baseUrl
+			: "";
+
+		// Merge headers (project overrides global per-key)
+		const headers: Record<string, string> = {};
+		if (g.headers && typeof g.headers === "object") {
+			for (const [k, v] of Object.entries(g.headers)) {
+				if (typeof v === "string") headers[k] = v;
+			}
+		}
+		if (p.headers && typeof p.headers === "object") {
+			for (const [k, v] of Object.entries(p.headers)) {
+				if (typeof v === "string") headers[k] = v;
+			}
+		}
+
+		// Merge provider overrides (project overrides global per-provider)
+		const providers: Record<string, string | false> = {};
+		for (const src of [g.providers, p.providers]) {
+			if (src && typeof src === "object") {
+				for (const [k, v] of Object.entries(src)) {
+					if (typeof v === "string" || v === false) {
+						providers[k] = v;
+					}
+				}
+			}
+		}
+
+		return { baseUrl, headers, providers };
+	} catch {
+		return defaults;
+	}
+}

--- a/extensions/pi-proxy/src/settings.ts
+++ b/extensions/pi-proxy/src/settings.ts
@@ -3,13 +3,23 @@
  *
  * Reads from `pi-proxy` key in settings.json (global + project merge).
  *
- * Example settings.json:
+ * Security: `baseUrl` and `headers` are global-only settings. Project-level
+ * settings can only configure `providers` (path overrides / exclusions) to
+ * prevent a malicious repo from redirecting LLM traffic to an attacker server.
+ *
+ * Example global settings.json (~/.pi/agent/settings.json):
  *   {
  *     "pi-proxy": {
  *       "baseUrl": "https://proxy.example.com",
  *       "headers": {
  *         "X-Proxy-Auth": "MY_PROXY_TOKEN"
- *       },
+ *       }
+ *     }
+ *   }
+ *
+ * Example project settings.json (.pi/settings.json):
+ *   {
+ *     "pi-proxy": {
  *       "providers": {
  *         "openai": "/custom/openai/path",
  *         "google": false
@@ -21,14 +31,14 @@
 import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
 
 export interface ProxySettings {
-	/** Base URL of the proxy server. Empty/undefined = no proxying. */
+	/** Base URL of the proxy server. Empty/undefined = no proxying. Global-only. */
 	baseUrl: string;
 
-	/** Optional headers to add to all proxied requests. Values can be env var names. */
+	/** Optional headers to add to all proxied requests. Values can be env var names. Global-only. */
 	headers: Record<string, string>;
 
 	/**
-	 * Per-provider overrides.
+	 * Per-provider overrides (global + project merged).
 	 * - string: custom path suffix (e.g. "/v1/anthropic")
 	 * - false: skip proxying for this provider
 	 * - undefined/missing: use default `/{provider}` path
@@ -36,7 +46,12 @@ export interface ProxySettings {
 	providers: Record<string, string | false>;
 }
 
-export function resolveSettings(): ProxySettings {
+export interface ResolveResult {
+	settings: ProxySettings;
+	error?: string;
+}
+
+export function resolveSettings(): ResolveResult {
 	const defaults: ProxySettings = {
 		baseUrl: "",
 		headers: {},
@@ -52,25 +67,18 @@ export function resolveSettings(): ProxySettings {
 		const g = global["pi-proxy"] ?? {};
 		const p = project["pi-proxy"] ?? {};
 
-		// Project settings override global
-		const baseUrl = typeof p.baseUrl === "string" ? p.baseUrl
-			: typeof g.baseUrl === "string" ? g.baseUrl
-			: "";
+		// baseUrl is global-only — project settings cannot override it
+		const baseUrl = typeof g.baseUrl === "string" ? g.baseUrl : "";
 
-		// Merge headers (project overrides global per-key)
+		// headers are global-only — project settings cannot override them
 		const headers: Record<string, string> = {};
 		if (g.headers && typeof g.headers === "object") {
 			for (const [k, v] of Object.entries(g.headers)) {
 				if (typeof v === "string") headers[k] = v;
 			}
 		}
-		if (p.headers && typeof p.headers === "object") {
-			for (const [k, v] of Object.entries(p.headers)) {
-				if (typeof v === "string") headers[k] = v;
-			}
-		}
 
-		// Merge provider overrides (project overrides global per-provider)
+		// Provider path overrides are merged (project overrides global per-provider)
 		const providers: Record<string, string | false> = {};
 		for (const src of [g.providers, p.providers]) {
 			if (src && typeof src === "object") {
@@ -82,8 +90,11 @@ export function resolveSettings(): ProxySettings {
 			}
 		}
 
-		return { baseUrl, headers, providers };
-	} catch {
-		return defaults;
+		return { settings: { baseUrl, headers, providers } };
+	} catch (err) {
+		return {
+			settings: defaults,
+			error: err instanceof Error ? err.message : String(err),
+		};
 	}
 }

--- a/extensions/pi-proxy/tsconfig.json
+++ b/extensions/pi-proxy/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds `pi-proxy` extension that redirects all LLM provider requests through a configurable proxy server.

## Configuration

Add to `settings.json`:
```json
{
  "pi-proxy": {
    "baseUrl": "https://proxy.example.com"
  }
}
```

When set, all requests route through `{baseUrl}/{provider}` (e.g. `https://proxy.example.com/anthropic`).

When not set, the extension is a no-op.

## Features

- Proxies 7 built-in providers: Anthropic, OpenAI, Google, xAI, OpenRouter, Groq, Mistral
- Custom headers for proxy auth (`headers` config)
- Per-provider path overrides or exclusions (`providers` config)
- Project-level settings override global
- Preserves all models, API keys, and API types — only `baseUrl` is changed

## Files
- `extensions/pi-proxy/src/index.ts` — Entry point, registers provider overrides
- `extensions/pi-proxy/src/settings.ts` — Settings loader (global + project merge)

Closes td-b94bac