### PR TITLE
feat(pi-subagent): non-blocking pool spawn/send with wait/poll

### DIFF
--- a/extensions/pi-subagent/package-lock.json
+++ b/extensions/pi-subagent/package-lock.json
@@ -1,19 +1,21 @@
 {
-  "name": "pi-subagent",
+  "name": "@e9n/pi-subagent",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pi-subagent",
+      "name": "@e9n/pi-subagent",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
+        "@mariozechner/pi-agent-core": "*",
         "@mariozechner/pi-ai": "*",
         "@mariozechner/pi-coding-agent": "*",
+        "@mariozechner/pi-tui": "*",
         "@sinclair/typebox": "*"
       }
     },

--- a/extensions/pi-subagent/src/pool.ts
+++ b/extensions/pi-subagent/src/pool.ts
@@ -294,6 +294,7 @@ export class AgentPool {
 			.catch(err => {
 				op.settled = true;
 				op.error = err instanceof Error ? err : new Error(String(err));
+				entry.node.state = "idle";
 			})
 			.finally(() => {
 				if (fromId) this.router.clearWaiting(fromId);
@@ -337,9 +338,10 @@ export class AgentPool {
 		const racePromises: Promise<void>[] = ops.map(op => op.promise);
 
 		if (timeout && timeout > 0) {
-			const timeoutPromise = new Promise<void>((_, reject) =>
-				setTimeout(() => reject(new Error(`Wait timed out after ${timeout}ms`)), timeout),
-			);
+			let timer: ReturnType<typeof setTimeout>;
+			const timeoutPromise = new Promise<void>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(`Wait timed out after ${timeout}ms`)), timeout);
+			});
 			try {
 				await Promise.race([...racePromises, timeoutPromise]);
 			} catch (err: any) {
@@ -350,6 +352,8 @@ export class AgentPool {
 					throw err;
 				}
 				// Op failure — that's fine, it settled with an error
+			} finally {
+				clearTimeout(timer!);
 			}
 		} else {
 			try {

--- a/extensions/pi-subagent/src/pool.ts
+++ b/extensions/pi-subagent/src/pool.ts
@@ -16,6 +16,7 @@ import { PoolServer, type PoolRequestHandler } from "./pool-server.ts";
 import { MessageRouter } from "./router.ts";
 import type {
 	AgentConfig,
+	PendingOpResult,
 	PoolAgentNode,
 	PoolEntry,
 	PoolIpcRequest,
@@ -60,6 +61,18 @@ function isBlocked(ext: string, blocklist: Set<string>): boolean {
 	return ALWAYS_BLOCKED.has(name) || blocklist.has(name);
 }
 
+/** Internal tracking for async (background) operations */
+interface InternalPendingOp {
+	opId: number;
+	agentId: string;
+	type: "spawn" | "send";
+	startedAt: number;
+	settled: boolean;
+	result?: RpcPromptResult;
+	error?: Error;
+	promise: Promise<void>;
+}
+
 export class AgentPool {
 	private agents = new Map<string, { rpc: RpcAgent; node: PoolAgentNode }>();
 	private server: PoolServer | null = null;
@@ -70,6 +83,8 @@ export class AgentPool {
 	private log: PoolLogger;
 	private shimPath: string;
 	private disposed = false;
+	private pendingOps = new Map<number, InternalPendingOp>();
+	private nextOpId = 1;
 
 	constructor(settings: SubagentSettings, allAgentConfigs: AgentConfig[], cwd: string, log: PoolLogger) {
 		this.settings = settings;
@@ -90,8 +105,11 @@ export class AgentPool {
 		this.log("pool-server-started", { port: this.server.port });
 	}
 
-	/** Spawn a new agent in the pool. */
-	async spawn(opts: PoolSpawnOpts): Promise<RpcPromptResult> {
+	/**
+	 * Internal: validate, create RpcAgent, add to pool, and start subprocess.
+	 * Does NOT send the initial prompt — caller decides sync vs async.
+	 */
+	private async setupAgent(opts: PoolSpawnOpts): Promise<{ rpc: RpcAgent; node: PoolAgentNode }> {
 		if (this.disposed) throw new Error("Pool is disposed");
 		if (this.agents.has(opts.id)) throw new Error(`Agent "${opts.id}" already exists in pool`);
 		if (this.agents.size >= this.settings.maxPoolSize) {
@@ -163,11 +181,16 @@ export class AgentPool {
 
 		this.log("pool-spawn", { id: opts.id, agent: opts.agent.name, depth, parentId: opts.parentId ?? null });
 
-		try {
-			await rpc.start();
-			node.state = "idle";
+		await rpc.start();
+		node.state = "idle";
 
-			// Send initial task
+		return { rpc, node };
+	}
+
+	/** Spawn a new agent in the pool (blocking — waits for initial task to complete). */
+	async spawn(opts: PoolSpawnOpts): Promise<RpcPromptResult> {
+		const { rpc, node } = await this.setupAgent(opts);
+		try {
 			const result = await rpc.prompt(`Task: ${opts.task}`);
 			this.syncUsage(opts.id);
 			return result;
@@ -175,6 +198,38 @@ export class AgentPool {
 			node.state = "dead";
 			throw err;
 		}
+	}
+
+	/** Spawn a new agent in the background (non-blocking — returns immediately). */
+	async spawnAsync(opts: PoolSpawnOpts): Promise<number> {
+		const { rpc, node } = await this.setupAgent(opts);
+		node.state = "streaming";
+
+		const opId = this.nextOpId++;
+		const op: InternalPendingOp = {
+			opId,
+			agentId: opts.id,
+			type: "spawn",
+			startedAt: Date.now(),
+			settled: false,
+			promise: null!,
+		};
+
+		op.promise = rpc.prompt(`Task: ${opts.task}`)
+			.then(result => {
+				this.syncUsage(opts.id);
+				op.settled = true;
+				op.result = result;
+			})
+			.catch(err => {
+				op.settled = true;
+				op.error = err instanceof Error ? err : new Error(String(err));
+				node.state = "dead";
+			});
+
+		this.pendingOps.set(opId, op);
+		this.log("pool-spawn-async", { id: opts.id, opId });
+		return opId;
 	}
 
 	/** Send a message to an existing agent. Returns the agent's response. */
@@ -203,6 +258,118 @@ export class AgentPool {
 				this.router.clearWaiting(fromId);
 			}
 		}
+	}
+
+	/** Send a message to an agent in the background (non-blocking — returns immediately). */
+	async sendAsync(targetId: string, message: string, fromId?: string): Promise<number> {
+		const entry = this.agents.get(targetId);
+		if (!entry) throw new Error(`Agent "${targetId}" not found in pool`);
+		if (entry.node.state === "dead") throw new Error(`Agent "${targetId}" is dead`);
+		if (entry.node.state === "streaming") throw new Error(`Agent "${targetId}" is busy processing another prompt`);
+
+		if (fromId && this.router.wouldCycle(fromId, targetId)) {
+			throw new Error(`Deadlock detected: ${fromId} → ${targetId} would create a cycle.`);
+		}
+		if (fromId) this.router.markWaiting(fromId, targetId);
+
+		entry.node.state = "streaming";
+		const prefix = fromId ? `Message from ${fromId}: ` : "";
+
+		const opId = this.nextOpId++;
+		const op: InternalPendingOp = {
+			opId,
+			agentId: targetId,
+			type: "send",
+			startedAt: Date.now(),
+			settled: false,
+			promise: null!,
+		};
+
+		op.promise = entry.rpc.prompt(`${prefix}${message}`)
+			.then(result => {
+				this.syncUsage(targetId);
+				op.settled = true;
+				op.result = result;
+			})
+			.catch(err => {
+				op.settled = true;
+				op.error = err instanceof Error ? err : new Error(String(err));
+			})
+			.finally(() => {
+				if (fromId) this.router.clearWaiting(fromId);
+			});
+
+		this.pendingOps.set(opId, op);
+		this.log("pool-send-async", { targetId, opId });
+		return opId;
+	}
+
+	/** Return all completed async operations and remove them from the pending queue. */
+	poll(): PendingOpResult[] {
+		const settled: PendingOpResult[] = [];
+		for (const [id, op] of this.pendingOps) {
+			if (op.settled) {
+				settled.push({
+					opId: op.opId,
+					agentId: op.agentId,
+					type: op.type,
+					startedAt: op.startedAt,
+					response: op.result?.response,
+					error: op.error?.message,
+				});
+				this.pendingOps.delete(id);
+			}
+		}
+		return settled;
+	}
+
+	/** Wait until at least one async operation completes, then return all completed. */
+	async waitAny(timeout?: number): Promise<PendingOpResult[]> {
+		// Check already settled first
+		const alreadySettled = this.poll();
+		if (alreadySettled.length > 0) return alreadySettled;
+
+		// Nothing pending at all?
+		if (this.pendingOps.size === 0) return [];
+
+		// Wait for any one to settle
+		const ops = [...this.pendingOps.values()];
+		const racePromises: Promise<void>[] = ops.map(op => op.promise);
+
+		if (timeout && timeout > 0) {
+			const timeoutPromise = new Promise<void>((_, reject) =>
+				setTimeout(() => reject(new Error(`Wait timed out after ${timeout}ms`)), timeout),
+			);
+			try {
+				await Promise.race([...racePromises, timeoutPromise]);
+			} catch (err: any) {
+				if (err?.message?.startsWith("Wait timed out")) {
+					// Return whatever settled during the wait
+					const partial = this.poll();
+					if (partial.length > 0) return partial;
+					throw err;
+				}
+				// Op failure — that's fine, it settled with an error
+			}
+		} else {
+			try {
+				await Promise.race(racePromises);
+			} catch {
+				// Op failure — that's fine, it settled with an error
+			}
+		}
+
+		// Collect everything that settled
+		return this.poll();
+	}
+
+	/** Number of async operations still in progress. */
+	get pendingCount(): number {
+		let count = 0;
+		for (const op of this.pendingOps.values()) {
+			if (!op.settled) count++;
+		}
+		return count;
 	}
 
 	/** List all agents in the pool. */

--- a/extensions/pi-subagent/src/tool.ts
+++ b/extensions/pi-subagent/src/tool.ts
@@ -1008,10 +1008,9 @@ async function handlePoolAction(
 
 		case "wait": {
 			if (!activePool) return text("No active pool.");
-			const pending = activePool.pendingCount;
-			if (pending === 0) return text("No pending background operations.");
 			try {
 				const results = await activePool.waitAny();
+				if (results.length === 0) return text("No pending background operations.");
 				const remaining = activePool.pendingCount;
 				const lines = results.map(r => {
 					if (r.error) return `### ${r.agentId} (${r.type}) ✗\nError: ${r.error}`;

--- a/extensions/pi-subagent/src/tool.ts
+++ b/extensions/pi-subagent/src/tool.ts
@@ -405,11 +405,14 @@ const SubagentParams = Type.Object({
 	orchestrator: Type.Optional(OrchestratorItem),
 	// ── New: pool management actions ─────────────────
 	action: Type.Optional(StringEnum(
-		["spawn", "send", "list", "kill", "kill-all"] as const,
+		["spawn", "send", "list", "kill", "kill-all", "wait", "poll"] as const,
 		{ description: "Pool management action. Use with id/message params." },
 	)),
 	id: Type.Optional(Type.String({ description: "Agent ID (for spawn/send/kill pool actions)" })),
 	message: Type.Optional(Type.String({ description: "Message to send (for 'send' pool action)" })),
+	background: Type.Optional(Type.Boolean({
+		description: "Run spawn/send in background (non-blocking). Returns immediately — use wait/poll to collect results later. Enables parallel dispatch to multiple pool agents.",
+	})),
 	// ── Shared options ───────────────────────────────
 	agentScope: Type.Optional(StringEnum(["user", "project", "both"] as const, {
 		description: 'Agent discovery scope. Default: "user" (~/.pi/agent/agents). "both" includes project .pi/agents.',
@@ -466,6 +469,10 @@ export function registerSubagentTool(
 			"• Pool actions: Manual pool management for long-lived agents:",
 			'  - { action: "spawn", id: "worker-1", agent: "worker", task: "..." } — spawn a persistent agent',
 			'  - { action: "send", id: "worker-1", message: "..." } — send follow-up (agent keeps context)',
+			'  - { action: "spawn", ..., background: true } — spawn without waiting (non-blocking)',
+			'  - { action: "send", ..., background: true } — send without waiting (non-blocking)',
+			'  - { action: "wait" } — block until background ops complete, return results',
+			'  - { action: "poll" } — check for completed background ops (non-blocking)',
 			'  - { action: "list" } — show all pool agents',
 			'  - { action: "kill", id: "worker-1" } — kill agent and its children',
 			'  - { action: "kill-all" } — tear down entire pool',
@@ -725,8 +732,10 @@ export function registerSubagentTool(
 
 			// ── Pool action rendering ─────────────────────
 			if (args.action) {
+				const bgLabel = args.background ? " (background)" : "";
 				let t = theme.fg("toolTitle", theme.bold("subagent ")) +
-					theme.fg("accent", `pool:${args.action}`);
+					theme.fg("accent", `pool:${args.action}`) +
+					(bgLabel ? theme.fg("warning", bgLabel) : "");
 				if (args.id) t += theme.fg("muted", ` ${args.id}`);
 				if (args.message) {
 					const preview = args.message.length > 50 ? `${args.message.slice(0, 50)}...` : args.message;
@@ -944,19 +953,27 @@ async function handlePoolAction(
 				return text(`Unknown agent: ${params.agent}. Available: ${agents.map(a => a.name).join(", ")}`);
 			}
 			const pool = await ensurePool();
+			const spawnOpts = {
+				id: params.id,
+				agent: agentConfig,
+				task: params.task,
+				cwd,
+				model: params.model,
+				thinking: params.thinking,
+				extensions: params.extensions,
+				skills: params.skills,
+				noTools: params.noTools,
+				noSkills: params.noSkills,
+			};
 			try {
-				const result = await pool.spawn({
-					id: params.id,
-					agent: agentConfig,
-					task: params.task,
-					cwd,
-					model: params.model,
-					thinking: params.thinking,
-					extensions: params.extensions,
-					skills: params.skills,
-					noTools: params.noTools,
-					noSkills: params.noSkills,
-				});
+				if (params.background) {
+					const opId = await pool.spawnAsync(spawnOpts);
+					return {
+						content: [{ type: "text" as const, text: `✓ Spawned "${params.id}" (${params.agent}) in background [op:${opId}]. Use { action: "wait" } or { action: "poll" } to collect results.` }],
+						details: makePoolDetails(pool),
+					};
+				}
+				const result = await pool.spawn(spawnOpts);
 				return {
 					content: [{ type: "text" as const, text: `✓ Spawned "${params.id}" (${params.agent}). Response:\n\n${result.response}` }],
 					details: makePoolDetails(pool),
@@ -972,6 +989,13 @@ async function handlePoolAction(
 			}
 			if (!activePool) return text("No active pool. Spawn an agent first.");
 			try {
+				if (params.background) {
+					const opId = await activePool.sendAsync(params.id, params.message);
+					return {
+						content: [{ type: "text" as const, text: `✓ Message dispatched to "${params.id}" in background [op:${opId}]. Use { action: "wait" } or { action: "poll" } to collect results.` }],
+						details: makePoolDetails(activePool),
+					};
+				}
 				const result = await activePool.send(params.id, params.message);
 				return {
 					content: [{ type: "text" as const, text: `Response from ${params.id}:\n\n${result.response}` }],
@@ -980,6 +1004,47 @@ async function handlePoolAction(
 			} catch (err: any) {
 				return { content: [{ type: "text" as const, text: `✗ Send failed: ${err.message}` }], details: makePoolDetails(activePool), isError: true };
 			}
+		}
+
+		case "wait": {
+			if (!activePool) return text("No active pool.");
+			const pending = activePool.pendingCount;
+			if (pending === 0) return text("No pending background operations.");
+			try {
+				const results = await activePool.waitAny();
+				const remaining = activePool.pendingCount;
+				const lines = results.map(r => {
+					if (r.error) return `### ${r.agentId} (${r.type}) ✗\nError: ${r.error}`;
+					return `### ${r.agentId} (${r.type}) ✓\n${r.response || "(no output)"}`;
+				});
+				const suffix = remaining > 0 ? `\n\n_${remaining} operation(s) still pending._` : "";
+				return {
+					content: [{ type: "text" as const, text: `## ${results.length} operation(s) completed\n\n${lines.join("\n\n")}${suffix}` }],
+					details: makePoolDetails(activePool),
+				};
+			} catch (err: any) {
+				return { content: [{ type: "text" as const, text: `✗ Wait failed: ${err.message}` }], details: makePoolDetails(activePool), isError: true };
+			}
+		}
+
+		case "poll": {
+			if (!activePool) return text("No active pool.");
+			const results = activePool.poll();
+			const remaining = activePool.pendingCount;
+			if (results.length === 0) {
+				return text(remaining > 0
+					? `No completed operations yet. ${remaining} still pending.`
+					: "No pending background operations.");
+			}
+			const lines = results.map(r => {
+				if (r.error) return `### ${r.agentId} (${r.type}) ✗\nError: ${r.error}`;
+				return `### ${r.agentId} (${r.type}) ✓\n${r.response || "(no output)"}`;
+			});
+			const suffix = remaining > 0 ? `\n\n_${remaining} operation(s) still pending._` : "";
+			return {
+				content: [{ type: "text" as const, text: `## ${results.length} completed\n\n${lines.join("\n\n")}${suffix}` }],
+				details: makePoolDetails(activePool),
+			};
 		}
 
 		case "list": {

--- a/extensions/pi-subagent/src/types.ts
+++ b/extensions/pi-subagent/src/types.ts
@@ -203,6 +203,22 @@ export interface PoolDetails {
 	totalUsage: UsageStats;
 }
 
+/** Result of a completed async pool operation (spawn or send) */
+export interface PendingOpResult {
+	/** Sequential operation ID */
+	opId: number;
+	/** Agent ID this operation was for */
+	agentId: string;
+	/** Whether this was a spawn or send */
+	type: "spawn" | "send";
+	/** When the operation was dispatched */
+	startedAt: number;
+	/** Agent response text (if successful) */
+	response?: string;
+	/** Error message (if failed) */
+	error?: string;
+}
+
 // ── Settings ────────────────────────────────────────────────────
 
 export interface SubagentSettings {


### PR DESCRIPTION
Pool spawn and send previously blocked until the agent finished its task,
making parallel workflows serial. Add background mode:

- spawn with background: true — starts agent, returns immediately
- send with background: true — dispatches message, returns immediately
- action: 'wait' — blocks until at least one background op completes
- action: 'poll' — non-blocking check for completed ops

Implementation:
- Extract setupAgent() from spawn() for shared validation/setup
- Add spawnAsync()/sendAsync() that fire-and-forget the prompt
- Add poll()/waitAny() with internal pending ops queue
- Add PendingOpResult type for completed op results
- Update tool schema, handler, and TUI rendering

Enables parallel agent dispatch:
  spawn bg pr-97 → spawn bg pr-95 → spawn bg pr-93 → wait
  instead of: spawn pr-97 (block) → spawn pr-95 (block) → ...
