### PR TITLE
feat: add google-workspace skill for gws CLI

### DIFF
--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -99,7 +99,7 @@ Core Google Workspace API skills. Read the reference file for full resource/meth
 | Admin Reports | Audit logs and usage reports | [references/gws-admin-reports.md](references/gws-admin-reports.md) |
 | Events | Subscribe to Workspace events | [references/gws-events.md](references/gws-events.md) |
 | Keep | Manage Google Keep notes | [references/gws-keep.md](references/gws-keep.md) |
-| Classroom | Manage courses, students, and invitations | [references/recipe-create-classroom-course.md](references/recipe-create-classroom-course.md) |
+| Classroom | Manage courses, students, and invitations | [references/gws-classroom.md](references/gws-classroom.md) |
 | Model Armor | Filter content for safety | [references/gws-modelarmor.md](references/gws-modelarmor.md) |
 | Workflow | Cross-service productivity workflows | [references/gws-workflow.md](references/gws-workflow.md) |
 

--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: google-workspace
+description: >
+  Manage Google Workspace via the gws CLI — Drive, Gmail, Sheets, Docs, Slides,
+  People, Chat, Meet, Forms, and cross-service workflows. Use when asked to
+  send email, read/write spreadsheets, upload files to Drive, manage contacts,
+  create presentations, send Chat messages, create docs, or any Google Workspace
+  operation. Also triggers on "gws", "Google Drive", "Google Sheets", "Gmail",
+  "Google Docs", "Google Slides", "Google Chat", "Google Meet", "Google Forms",
+  "check my inbox", "upload to Drive", "read spreadsheet", "send an email",
+  "create a doc", "send a chat message", "create a presentation".
+---
+
+# Google Workspace CLI (`gws`)
+
+Interact with Google Workspace services via the `gws` CLI. This skill covers
+all supported services, helper shortcuts, cross-service workflows, role-based
+personas, and multi-step recipes.
+
+## Installation & Auth
+
+The `gws` binary must be on `$PATH`. Version: 0.16.0+.
+
+```bash
+# Browser-based OAuth (interactive)
+gws auth login
+
+# Service Account
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+
+# Check status
+gws auth status
+```
+
+### Auth Flags
+
+| Flag | Description |
+|------|-------------|
+| `--readonly` | Request read-only scopes |
+| `--full` | Request all scopes incl. pubsub + cloud-platform |
+| `--scopes` | Comma-separated custom scopes |
+| `-s, --services` | Limit scope picker to specific services (e.g. `-s drive,gmail`) |
+
+## CLI Syntax
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format <FMT>` | Output format: `json` (default), `table`, `yaml`, `csv` |
+| `--dry-run` | Validate locally without calling the API |
+| `--sanitize <TEMPLATE>` | Screen responses through Model Armor |
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request body |
+| `-o, --output <PATH>` | Save binary responses to file |
+| `--upload <PATH>` | Upload file content (multipart) |
+| `--page-all` | Auto-paginate (NDJSON output) |
+| `--page-limit <N>` | Max pages with --page-all (default: 10) |
+| `--page-delay <MS>` | Delay between pages in ms (default: 100) |
+
+### Discovering Commands
+
+```bash
+gws <service> --help                    # Browse resources and methods
+gws schema <service.resource.method>    # Inspect params, types, defaults
+```
+
+## Shell Tips
+
+- **zsh `!` expansion:** Use double quotes for sheet ranges: `--range "Sheet1!A1:D10"`
+- **JSON with double quotes:** Wrap `--params`/`--json` in single quotes: `--params '{"pageSize": 5}'`
+
+## Security Rules
+
+- **Never** output secrets (API keys, tokens) directly
+- **Always** confirm with user before executing write/delete commands
+- Prefer `--dry-run` for destructive operations
+- Use `--sanitize` for PII/content safety screening
+
+## Services
+
+Core Google Workspace API skills. Read the reference file for full resource/method details.
+
+| Service | Description | Reference |
+|---------|-------------|-----------|
+| Drive | Manage files, folders, shared drives | [references/gws-drive.md](references/gws-drive.md) |
+| Sheets | Read and write spreadsheets | [references/gws-sheets.md](references/gws-sheets.md) |
+| Gmail | Send, read, and manage email | [references/gws-gmail.md](references/gws-gmail.md) |
+| Docs | Read and write Google Docs | [references/gws-docs.md](references/gws-docs.md) |
+| Slides | Read and write presentations | [references/gws-slides.md](references/gws-slides.md) |
+| People | Manage contacts and profiles | [references/gws-people.md](references/gws-people.md) |
+| Chat | Manage Chat spaces and messages | [references/gws-chat.md](references/gws-chat.md) |
+| Meet | Manage Google Meet conferences | [references/gws-meet.md](references/gws-meet.md) |
+| Forms | Read and write Google Forms | [references/gws-forms.md](references/gws-forms.md) |
+| Admin Reports | Audit logs and usage reports | [references/gws-admin-reports.md](references/gws-admin-reports.md) |
+| Events | Subscribe to Workspace events | [references/gws-events.md](references/gws-events.md) |
+| Keep | Manage Google Keep notes | [references/gws-keep.md](references/gws-keep.md) |
+| Model Armor | Filter content for safety | [references/gws-modelarmor.md](references/gws-modelarmor.md) |
+| Workflow | Cross-service productivity workflows | [references/gws-workflow.md](references/gws-workflow.md) |
+
+## Helper Shortcuts
+
+Quick commands for common operations. Read the reference file for flags and examples.
+
+### Drive
+| Command | Reference |
+|---------|-----------|
+| `gws drive +upload <file>` | [references/gws-drive-upload.md](references/gws-drive-upload.md) |
+
+### Sheets
+| Command | Reference |
+|---------|-----------|
+| `gws sheets +read --spreadsheet ID --range RANGE` | [references/gws-sheets-read.md](references/gws-sheets-read.md) |
+| `gws sheets +append --spreadsheet ID --values '...'` | [references/gws-sheets-append.md](references/gws-sheets-append.md) |
+
+### Gmail
+| Command | Reference |
+|---------|-----------|
+| `gws gmail +send --to EMAIL --subject S --body B` | [references/gws-gmail-send.md](references/gws-gmail-send.md) |
+| `gws gmail +triage` | [references/gws-gmail-triage.md](references/gws-gmail-triage.md) |
+| `gws gmail +reply --message-id ID --body TEXT` | [references/gws-gmail-reply.md](references/gws-gmail-reply.md) |
+| `gws gmail +reply-all --message-id ID --body TEXT` | [references/gws-gmail-reply-all.md](references/gws-gmail-reply-all.md) |
+| `gws gmail +forward --message-id ID --to EMAIL` | [references/gws-gmail-forward.md](references/gws-gmail-forward.md) |
+| `gws gmail +watch` | [references/gws-gmail-watch.md](references/gws-gmail-watch.md) |
+
+### Docs
+| Command | Reference |
+|---------|-----------|
+| `gws docs +write --document ID --text TEXT` | [references/gws-docs-write.md](references/gws-docs-write.md) |
+
+### Chat
+| Command | Reference |
+|---------|-----------|
+| `gws chat +send --space NAME --text TEXT` | [references/gws-chat-send.md](references/gws-chat-send.md) |
+
+### Events
+| Command | Reference |
+|---------|-----------|
+| `gws events +subscribe` | [references/gws-events-subscribe.md](references/gws-events-subscribe.md) |
+| `gws events +renew` | [references/gws-events-renew.md](references/gws-events-renew.md) |
+
+### Model Armor
+| Command | Reference |
+|---------|-----------|
+| `gws modelarmor +sanitize-prompt --template NAME` | [references/gws-modelarmor-sanitize-prompt.md](references/gws-modelarmor-sanitize-prompt.md) |
+| `gws modelarmor +sanitize-response --template NAME` | [references/gws-modelarmor-sanitize-response.md](references/gws-modelarmor-sanitize-response.md) |
+| `gws modelarmor +create-template --project P --location L --template-id ID` | [references/gws-modelarmor-create-template.md](references/gws-modelarmor-create-template.md) |
+
+### Workflow
+| Command | Reference |
+|---------|-----------|
+| `gws workflow +standup-report` | [references/gws-workflow-standup-report.md](references/gws-workflow-standup-report.md) |
+| `gws workflow +meeting-prep` | [references/gws-workflow-meeting-prep.md](references/gws-workflow-meeting-prep.md) |
+| `gws workflow +email-to-task --message-id ID` | [references/gws-workflow-email-to-task.md](references/gws-workflow-email-to-task.md) |
+| `gws workflow +weekly-digest` | [references/gws-workflow-weekly-digest.md](references/gws-workflow-weekly-digest.md) |
+| `gws workflow +file-announce --file-id ID --space SPACE` | [references/gws-workflow-file-announce.md](references/gws-workflow-file-announce.md) |
+
+## Personas
+
+Role-based skill bundles for common workflows. Read the reference for instructions.
+
+| Persona | Description | Reference |
+|---------|-------------|-----------|
+| Executive Assistant | Schedule, inbox, and communications | [references/persona-exec-assistant.md](references/persona-exec-assistant.md) |
+| Project Manager | Tasks, meetings, and doc sharing | [references/persona-project-manager.md](references/persona-project-manager.md) |
+| Team Lead | Standups, coordination, and comms | [references/persona-team-lead.md](references/persona-team-lead.md) |
+| Sales Operations | Deal tracking, calls, client comms | [references/persona-sales-ops.md](references/persona-sales-ops.md) |
+| Content Creator | Create, organize, distribute content | [references/persona-content-creator.md](references/persona-content-creator.md) |
+| Event Coordinator | Scheduling, invitations, logistics | [references/persona-event-coordinator.md](references/persona-event-coordinator.md) |
+| Customer Support | Tickets, responses, escalation | [references/persona-customer-support.md](references/persona-customer-support.md) |
+| HR Coordinator | Onboarding, announcements, comms | [references/persona-hr-coordinator.md](references/persona-hr-coordinator.md) |
+| IT Administrator | Security monitoring, configuration | [references/persona-it-admin.md](references/persona-it-admin.md) |
+| Researcher | References, notes, collaboration | [references/persona-researcher.md](references/persona-researcher.md) |
+
+## Recipes
+
+Multi-step task sequences with real commands. Read the reference for step-by-step instructions.
+
+### Gmail Recipes
+| Recipe | Reference |
+|--------|-----------|
+| Label and archive emails | [references/recipe-label-and-archive-emails.md](references/recipe-label-and-archive-emails.md) |
+| Create Gmail filter | [references/recipe-create-gmail-filter.md](references/recipe-create-gmail-filter.md) |
+| Forward labeled emails | [references/recipe-forward-labeled-emails.md](references/recipe-forward-labeled-emails.md) |
+| Set vacation responder | [references/recipe-create-vacation-responder.md](references/recipe-create-vacation-responder.md) |
+| Save email attachments to Drive | [references/recipe-save-email-attachments.md](references/recipe-save-email-attachments.md) |
+| Save email to Google Doc | [references/recipe-save-email-to-doc.md](references/recipe-save-email-to-doc.md) |
+| Draft email from Doc | [references/recipe-draft-email-from-doc.md](references/recipe-draft-email-from-doc.md) |
+
+### Drive Recipes
+| Recipe | Reference |
+|--------|-----------|
+| Organize Drive folder | [references/recipe-organize-drive-folder.md](references/recipe-organize-drive-folder.md) |
+| Share folder with team | [references/recipe-share-folder-with-team.md](references/recipe-share-folder-with-team.md) |
+| Email a Drive link | [references/recipe-email-drive-link.md](references/recipe-email-drive-link.md) |
+| Bulk download folder | [references/recipe-bulk-download-folder.md](references/recipe-bulk-download-folder.md) |
+| Find large files | [references/recipe-find-large-files.md](references/recipe-find-large-files.md) |
+| Create shared drive | [references/recipe-create-shared-drive.md](references/recipe-create-shared-drive.md) |
+| Watch Drive changes | [references/recipe-watch-drive-changes.md](references/recipe-watch-drive-changes.md) |
+
+### Sheets Recipes
+| Recipe | Reference |
+|--------|-----------|
+| Create expense tracker | [references/recipe-create-expense-tracker.md](references/recipe-create-expense-tracker.md) |
+| Copy sheet for new month | [references/recipe-copy-sheet-for-new-month.md](references/recipe-copy-sheet-for-new-month.md) |
+| Log deal update | [references/recipe-log-deal-update.md](references/recipe-log-deal-update.md) |
+| Compare sheet tabs | [references/recipe-compare-sheet-tabs.md](references/recipe-compare-sheet-tabs.md) |
+| Backup sheet as CSV | [references/recipe-backup-sheet-as-csv.md](references/recipe-backup-sheet-as-csv.md) |
+| Sync contacts to sheet | [references/recipe-sync-contacts-to-sheet.md](references/recipe-sync-contacts-to-sheet.md) |
+| Generate report from sheet | [references/recipe-generate-report-from-sheet.md](references/recipe-generate-report-from-sheet.md) |
+
+### Cross-Service Recipes
+| Recipe | Reference |
+|--------|-----------|
+| Create doc from template | [references/recipe-create-doc-from-template.md](references/recipe-create-doc-from-template.md) |
+| Share doc and notify | [references/recipe-share-doc-and-notify.md](references/recipe-share-doc-and-notify.md) |
+| Send team announcement | [references/recipe-send-team-announcement.md](references/recipe-send-team-announcement.md) |
+| Create feedback form | [references/recipe-create-feedback-form.md](references/recipe-create-feedback-form.md) |
+| Create Meet space | [references/recipe-create-meet-space.md](references/recipe-create-meet-space.md) |
+| Review Meet participants | [references/recipe-review-meet-participants.md](references/recipe-review-meet-participants.md) |
+| Create presentation | [references/recipe-create-presentation.md](references/recipe-create-presentation.md) |
+| Collect form responses | [references/recipe-collect-form-responses.md](references/recipe-collect-form-responses.md) |
+| Create classroom course | [references/recipe-create-classroom-course.md](references/recipe-create-classroom-course.md) |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | API error — Google returned an error response |
+| 2 | Auth error — credentials missing or invalid |
+| 3 | Validation — bad arguments or input |
+| 4 | Discovery — could not fetch API schema |
+| 5 | Internal — unexpected failure |
+
+## Community & Feedback
+
+- Star the repo: https://github.com/googleworkspace/cli
+- Bugs / feature requests: https://github.com/googleworkspace/cli/issues
+- Always search existing issues before creating new ones

--- a/skills/google-workspace/SKILL.md
+++ b/skills/google-workspace/SKILL.md
@@ -99,6 +99,7 @@ Core Google Workspace API skills. Read the reference file for full resource/meth
 | Admin Reports | Audit logs and usage reports | [references/gws-admin-reports.md](references/gws-admin-reports.md) |
 | Events | Subscribe to Workspace events | [references/gws-events.md](references/gws-events.md) |
 | Keep | Manage Google Keep notes | [references/gws-keep.md](references/gws-keep.md) |
+| Classroom | Manage courses, students, and invitations | [references/recipe-create-classroom-course.md](references/recipe-create-classroom-course.md) |
 | Model Armor | Filter content for safety | [references/gws-modelarmor.md](references/gws-modelarmor.md) |
 | Workflow | Cross-service productivity workflows | [references/gws-workflow.md](references/gws-workflow.md) |
 

--- a/skills/google-workspace/references/gws-admin-reports.md
+++ b/skills/google-workspace/references/gws-admin-reports.md
@@ -1,0 +1,32 @@
+# admin-reports (reports_v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws admin-reports <resource> <method> [flags]
+```
+
+## API Resources
+
+### activities
+- `list` — Retrieves a list of activities for a customer's account and application.
+- `watch` — Start receiving notifications for account activities.
+
+### channels
+- `stop` — Stop watching resources through this channel.
+
+### customerUsageReports
+- `get` — Retrieves a customer usage report.
+
+### entityUsageReports
+- `get` — Retrieves an entity usage report.
+
+### userUsageReport
+- `get` — Retrieves a user usage report.
+
+## Discovering Commands
+
+```bash
+gws admin-reports --help
+gws schema admin-reports.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-chat-send.md
+++ b/skills/google-workspace/references/gws-chat-send.md
@@ -1,0 +1,30 @@
+# chat +send
+
+Send a message to a space.
+
+## Usage
+
+```bash
+gws chat +send --space <NAME> --text <TEXT>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--space` | ✓ | — | Space name (e.g. spaces/AAAA...) |
+| `--text` | ✓ | — | Message text (plain text) |
+
+## Examples
+
+```bash
+gws chat +send --space spaces/AAAAxxxx --text 'Hello team!'
+```
+
+## Tips
+
+- Use `gws chat spaces list` to find space names.
+- For cards or threaded replies, use the raw API.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-chat.md
+++ b/skills/google-workspace/references/gws-chat.md
@@ -1,0 +1,38 @@
+# chat (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws chat <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+send` | Send a message to a space — see [gws-chat-send.md](gws-chat-send.md) |
+
+## API Resources
+
+### customEmojis
+- `create`, `delete`, `get`, `list` — Custom emoji management.
+
+### media
+- `download` — Downloads media.
+- `upload` — Uploads an attachment.
+
+### spaces
+- `completeImport`, `create`, `delete`, `findDirectMessage`, `get`, `list`, `patch`, `search`, `setup` — Space management.
+- `members` — Space member operations.
+- `messages` — Space message operations.
+- `spaceEvents` — Space event operations.
+
+### users
+- `spaces` — User space operations.
+
+## Discovering Commands
+
+```bash
+gws chat --help
+gws schema chat.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-classroom.md
+++ b/skills/google-workspace/references/gws-classroom.md
@@ -1,0 +1,53 @@
+# classroom (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+>
+> Classroom is not enabled by default. Enable the Google Classroom API in your GCP project and authenticate with `gws auth login --full` to include the required scopes.
+
+```bash
+gws classroom <resource> <method> [flags]
+```
+
+## API Resources
+
+### courses
+- `create` — Creates a course. The user in `ownerId` becomes owner and teacher.
+- `delete` — Deletes a course.
+- `get` — Returns a course by ID.
+- `getGradingPeriodSettings` — Returns grading period settings for a course.
+- `list` — Lists courses the requesting user can view.
+- `patch` — Updates one or more fields in a course.
+- `update` — Replaces all fields in a course.
+- `updateGradingPeriodSettings` — Updates grading period settings.
+- `aliases` — Course alias operations.
+- `announcements` — Course announcement operations.
+- `courseWork` — Coursework (assignments, questions) operations.
+- `courseWorkMaterials` — Course work material operations.
+- `posts` — Course post operations.
+- `studentGroups` — Student group operations.
+- `students` — Student roster operations.
+- `teachers` — Teacher roster operations.
+- `topics` — Course topic operations.
+
+### invitations
+- `accept` — Accepts an invitation, adding the user to the course.
+- `create` — Creates an invitation. One per user/course at a time.
+- `delete` — Deletes an invitation.
+- `get` — Returns an invitation by ID.
+- `list` — Lists invitations. Requires `user_id` or `course_id`.
+
+### registrations
+- `create` — Creates a registration for Pub/Sub notifications.
+- `delete` — Deletes a registration, stopping notifications.
+
+### userProfiles
+- `get` — Returns a user profile.
+- `guardianInvitations` — Guardian invitation operations.
+- `guardians` — Guardian operations.
+
+## Discovering Commands
+
+```bash
+gws classroom --help
+gws schema classroom.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-docs-write.md
+++ b/skills/google-workspace/references/gws-docs-write.md
@@ -1,0 +1,30 @@
+# docs +write
+
+Append text to a document.
+
+## Usage
+
+```bash
+gws docs +write --document <ID> --text <TEXT>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--document` | ✓ | — | Document ID |
+| `--text` | ✓ | — | Text to append (plain text) |
+
+## Examples
+
+```bash
+gws docs +write --document DOC_ID --text 'Hello, world!'
+```
+
+## Tips
+
+- Text is inserted at the end of the document body.
+- For rich formatting, use the raw batchUpdate API.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-docs.md
+++ b/skills/google-workspace/references/gws-docs.md
@@ -1,0 +1,27 @@
+# docs (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws docs <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+write` | Append text to a document — see [gws-docs-write.md](gws-docs-write.md) |
+
+## API Resources
+
+### documents
+- `batchUpdate` — Applies one or more updates to the document.
+- `create` — Creates a blank document using the title given.
+- `get` — Gets the latest version of the specified document.
+
+## Discovering Commands
+
+```bash
+gws docs --help
+gws schema docs.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-drive-upload.md
+++ b/skills/google-workspace/references/gws-drive-upload.md
@@ -1,0 +1,33 @@
+# drive +upload
+
+Upload a file with automatic metadata.
+
+## Usage
+
+```bash
+gws drive +upload <file>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `<file>` | ✓ | — | Path to file to upload |
+| `--parent` | — | — | Parent folder ID |
+| `--name` | — | — | Target filename (defaults to source filename) |
+
+## Examples
+
+```bash
+gws drive +upload ./report.pdf
+gws drive +upload ./report.pdf --parent FOLDER_ID
+gws drive +upload ./data.csv --name 'Sales Data.csv'
+```
+
+## Tips
+
+- MIME type is detected automatically.
+- Filename is inferred from the local path unless --name is given.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-drive.md
+++ b/skills/google-workspace/references/gws-drive.md
@@ -1,0 +1,93 @@
+# drive (v3)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws drive <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+upload` | Upload a file with automatic metadata — see [gws-drive-upload.md](gws-drive-upload.md) |
+
+## API Resources
+
+### about
+- `get` — Gets information about the user, the user's Drive, and system capabilities. Required: The `fields` parameter must be set.
+
+### accessproposals
+- `get` — Retrieves an access proposal by ID.
+- `list` — List the access proposals on a file. Only approvers can list.
+- `resolve` — Approves or denies an access proposal.
+
+### apps
+- `get` — Gets a specific app.
+- `list` — Lists a user's installed apps.
+
+### changes
+- `getStartPageToken` — Gets the starting pageToken for listing future changes.
+- `list` — Lists the changes for a user or shared drive.
+- `watch` — Subscribes to changes for a user.
+
+### channels
+- `stop` — Stops watching resources through this channel.
+
+### comments
+- `create` — Creates a comment on a file. Required: `fields` parameter.
+- `delete` — Deletes a comment.
+- `get` — Gets a comment by ID. Required: `fields` parameter.
+- `list` — Lists a file's comments. Required: `fields` parameter.
+- `update` — Updates a comment with patch semantics. Required: `fields` parameter.
+
+### drives
+- `create` — Creates a shared drive.
+- `get` — Gets a shared drive's metadata by ID.
+- `hide` — Hides a shared drive from the default view.
+- `list` — Lists the user's shared drives. Accepts `q` search parameter.
+- `unhide` — Restores a shared drive to the default view.
+- `update` — Updates the metadata for a shared drive.
+
+### files
+- `copy` — Creates a copy of a file with patch semantics.
+- `create` — Creates a file. Max size: 5,120 GB.
+- `download` — Downloads the content of a file. Valid for 24 hours.
+- `export` — Exports a Google Workspace document to requested MIME type. Max 10 MB.
+- `generateIds` — Generates a set of file IDs for create/copy requests.
+- `get` — Gets a file's metadata or content by ID. Use `alt=media` for content.
+- `list` — Lists the user's files. Accepts `q` search. Returns all files including trashed by default.
+- `listLabels` — Lists the labels on a file.
+- `modifyLabels` — Modifies the set of labels applied to a file.
+- `update` — Updates a file's metadata, content, or both. Supports patch semantics.
+- `watch` — Subscribes to changes to a file.
+
+### operations
+- `get` — Gets the latest state of a long-running operation.
+
+### permissions
+- `create` — Creates a permission for a file or shared drive.
+- `delete` — Deletes a permission.
+- `get` — Gets a permission by ID.
+- `list` — Lists a file's or shared drive's permissions.
+- `update` — Updates a permission with patch semantics.
+
+### replies
+- `create` — Creates a reply to a comment.
+- `delete` — Deletes a reply.
+- `get` — Gets a reply by ID.
+- `list` — Lists a comment's replies.
+- `update` — Updates a reply with patch semantics.
+
+### revisions
+- `delete` — Permanently deletes a file version. Only for binary content.
+- `get` — Gets a revision's metadata or content by ID.
+- `list` — Lists a file's revisions.
+- `update` — Updates a revision with patch semantics.
+
+## Discovering Commands
+
+```bash
+gws drive --help
+gws schema drive.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-events-renew.md
+++ b/skills/google-workspace/references/gws-events-renew.md
@@ -1,0 +1,29 @@
+# events +renew
+
+Renew/reactivate Workspace Events subscriptions.
+
+## Usage
+
+```bash
+gws events +renew
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--name` | — | — | Subscription name to reactivate |
+| `--all` | — | — | Renew all subscriptions expiring within --within window |
+| `--within` | — | 1h | Time window for --all (e.g., 1h, 30m, 2d) |
+
+## Examples
+
+```bash
+gws events +renew --name subscriptions/SUB_ID
+gws events +renew --all --within 2d
+```
+
+## Tips
+
+- Subscriptions expire if not renewed periodically.
+- Use --all with a cron job to keep subscriptions alive.

--- a/skills/google-workspace/references/gws-events-renew.md
+++ b/skills/google-workspace/references/gws-events-renew.md
@@ -27,3 +27,6 @@ gws events +renew --all --within 2d
 
 - Subscriptions expire if not renewed periodically.
 - Use --all with a cron job to keep subscriptions alive.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-events-subscribe.md
+++ b/skills/google-workspace/references/gws-events-subscribe.md
@@ -33,6 +33,7 @@ gws events +subscribe --subscription projects/p/subscriptions/my-sub --once
 ## Tips
 
 - Without --cleanup, Pub/Sub resources persist for reconnection.
+- `--cleanup` only runs on graceful exit (Ctrl-C). Resources may persist after a crash or SIGKILL — use `gws events subscriptions delete` to recover orphaned resources.
 - Press Ctrl-C to stop gracefully.
 
 > [!CAUTION]

--- a/skills/google-workspace/references/gws-events-subscribe.md
+++ b/skills/google-workspace/references/gws-events-subscribe.md
@@ -1,0 +1,39 @@
+# events +subscribe
+
+Subscribe to Workspace events and stream them as NDJSON.
+
+## Usage
+
+```bash
+gws events +subscribe
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--target` | — | — | Workspace resource URI |
+| `--event-types` | — | — | Comma-separated CloudEvents types |
+| `--project` | — | — | GCP project ID for Pub/Sub resources |
+| `--subscription` | — | — | Existing Pub/Sub subscription name |
+| `--max-messages` | — | 10 | Max messages per pull batch |
+| `--poll-interval` | — | 5 | Seconds between pulls |
+| `--once` | — | — | Pull once and exit |
+| `--cleanup` | — | — | Delete created Pub/Sub resources on exit |
+| `--no-ack` | — | — | Don't auto-acknowledge messages |
+| `--output-dir` | — | — | Write each event to a separate JSON file |
+
+## Examples
+
+```bash
+gws events +subscribe --target '//chat.googleapis.com/spaces/SPACE' --event-types 'google.workspace.chat.message.v1.created' --project my-project
+gws events +subscribe --subscription projects/p/subscriptions/my-sub --once
+```
+
+## Tips
+
+- Without --cleanup, Pub/Sub resources persist for reconnection.
+- Press Ctrl-C to stop gracefully.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-events.md
+++ b/skills/google-workspace/references/gws-events.md
@@ -1,0 +1,31 @@
+# events (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws events <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+subscribe` | Subscribe to events — see [gws-events-subscribe.md](gws-events-subscribe.md) |
+| `+renew` | Renew subscriptions — see [gws-events-renew.md](gws-events-renew.md) |
+
+## API Resources
+
+### subscriptions
+- `create` — Creates a Google Workspace subscription.
+- `delete` — Deletes a subscription.
+- `get` — Gets subscription details.
+- `list` — Lists subscriptions.
+- `patch` — Updates or renews a subscription.
+- `reactivate` — Reactivates a suspended subscription.
+
+## Discovering Commands
+
+```bash
+gws events --help
+gws schema events.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-forms.md
+++ b/skills/google-workspace/references/gws-forms.md
@@ -1,0 +1,24 @@
+# forms (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws forms <resource> <method> [flags]
+```
+
+## API Resources
+
+### forms
+- `batchUpdate` — Change the form with a batch of updates.
+- `create` — Create a new form. Only title/document_title copied; add items via batchUpdate.
+- `get` — Get a form.
+- `setPublishSettings` — Updates publish settings (not for legacy forms).
+- `responses` — Form response operations.
+- `watches` — Form watch operations.
+
+## Discovering Commands
+
+```bash
+gws forms --help
+gws schema forms.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-gmail-forward.md
+++ b/skills/google-workspace/references/gws-gmail-forward.md
@@ -31,3 +31,6 @@ gws gmail +forward --message-id 18f1a2b3c4d --to dave@example.com --body 'FYI se
 ## Tips
 
 - Includes original message with sender, date, subject, and recipients.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-gmail-forward.md
+++ b/skills/google-workspace/references/gws-gmail-forward.md
@@ -1,0 +1,33 @@
+# gmail +forward
+
+Forward a message to new recipients.
+
+## Usage
+
+```bash
+gws gmail +forward --message-id <ID> --to <EMAILS>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--message-id` | ✓ | — | Gmail message ID to forward |
+| `--to` | ✓ | — | Recipient email address(es), comma-separated |
+| `--from` | — | — | Sender address (for send-as/alias) |
+| `--cc` | — | — | CC email address(es) |
+| `--bcc` | — | — | BCC email address(es) |
+| `--body` | — | — | Optional note above the forwarded message |
+| `--html` | — | — | Send as HTML |
+| `--dry-run` | — | — | Show request without executing |
+
+## Examples
+
+```bash
+gws gmail +forward --message-id 18f1a2b3c4d --to dave@example.com
+gws gmail +forward --message-id 18f1a2b3c4d --to dave@example.com --body 'FYI see below'
+```
+
+## Tips
+
+- Includes original message with sender, date, subject, and recipients.

--- a/skills/google-workspace/references/gws-gmail-reply-all.md
+++ b/skills/google-workspace/references/gws-gmail-reply-all.md
@@ -1,0 +1,37 @@
+# gmail +reply-all
+
+Reply-all to a message (handles threading automatically).
+
+## Usage
+
+```bash
+gws gmail +reply-all --message-id <ID> --body <TEXT>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--message-id` | ✓ | — | Gmail message ID to reply to |
+| `--body` | ✓ | — | Reply body (plain text, or HTML with --html) |
+| `--from` | — | — | Sender address (for send-as/alias) |
+| `--to` | — | — | Additional To email address(es) |
+| `--cc` | — | — | Additional CC email address(es) |
+| `--bcc` | — | — | BCC email address(es) |
+| `--remove` | — | — | Exclude recipients (comma-separated emails) |
+| `--html` | — | — | Send as HTML |
+| `--dry-run` | — | — | Show request without executing |
+
+## Examples
+
+```bash
+gws gmail +reply-all --message-id 18f1a2b3c4d --body 'Sounds good to me!'
+gws gmail +reply-all --message-id 18f1a2b3c4d --body 'Updated' --remove bob@example.com
+gws gmail +reply-all --message-id 18f1a2b3c4d --body '<i>Noted</i>' --html
+```
+
+## Tips
+
+- Replies to sender and all original To/CC recipients.
+- Use --remove to exclude recipients from the reply.
+- Fails if no To recipient remains after exclusions.

--- a/skills/google-workspace/references/gws-gmail-reply-all.md
+++ b/skills/google-workspace/references/gws-gmail-reply-all.md
@@ -35,3 +35,6 @@ gws gmail +reply-all --message-id 18f1a2b3c4d --body '<i>Noted</i>' --html
 - Replies to sender and all original To/CC recipients.
 - Use --remove to exclude recipients from the reply.
 - Fails if no To recipient remains after exclusions.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-gmail-reply.md
+++ b/skills/google-workspace/references/gws-gmail-reply.md
@@ -1,0 +1,36 @@
+# gmail +reply
+
+Reply to a message (handles threading automatically).
+
+## Usage
+
+```bash
+gws gmail +reply --message-id <ID> --body <TEXT>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--message-id` | ✓ | — | Gmail message ID to reply to |
+| `--body` | ✓ | — | Reply body (plain text, or HTML with --html) |
+| `--from` | — | — | Sender address (for send-as/alias) |
+| `--to` | — | — | Additional To email address(es) |
+| `--cc` | — | — | Additional CC email address(es) |
+| `--bcc` | — | — | BCC email address(es) |
+| `--html` | — | — | Send as HTML |
+| `--dry-run` | — | — | Show request without executing |
+
+## Examples
+
+```bash
+gws gmail +reply --message-id 18f1a2b3c4d --body 'Thanks, got it!'
+gws gmail +reply --message-id 18f1a2b3c4d --body 'Looping in Carol' --cc carol@example.com
+gws gmail +reply --message-id 18f1a2b3c4d --body '<b>Bold reply</b>' --html
+```
+
+## Tips
+
+- Automatically sets In-Reply-To, References, and threadId headers.
+- Quotes the original message in the reply body.
+- For reply-all, use +reply-all instead.

--- a/skills/google-workspace/references/gws-gmail-reply.md
+++ b/skills/google-workspace/references/gws-gmail-reply.md
@@ -34,3 +34,6 @@ gws gmail +reply --message-id 18f1a2b3c4d --body '<b>Bold reply</b>' --html
 - Automatically sets In-Reply-To, References, and threadId headers.
 - Quotes the original message in the reply body.
 - For reply-all, use +reply-all instead.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-gmail-send.md
+++ b/skills/google-workspace/references/gws-gmail-send.md
@@ -1,0 +1,37 @@
+# gmail +send
+
+Send an email.
+
+## Usage
+
+```bash
+gws gmail +send --to <EMAILS> --subject <SUBJECT> --body <TEXT>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--to` | ✓ | — | Recipient email address(es), comma-separated |
+| `--subject` | ✓ | — | Email subject |
+| `--body` | ✓ | — | Email body (plain text, or HTML with --html) |
+| `--cc` | — | — | CC email address(es), comma-separated |
+| `--bcc` | — | — | BCC email address(es), comma-separated |
+| `--html` | — | — | Treat --body as HTML content |
+| `--dry-run` | — | — | Show request without executing |
+
+## Examples
+
+```bash
+gws gmail +send --to alice@example.com --subject 'Hello' --body 'Hi Alice!'
+gws gmail +send --to alice@example.com --subject 'Hello' --body 'Hi!' --cc bob@example.com
+gws gmail +send --to alice@example.com --subject 'Hello' --body '<b>Bold</b> text' --html
+```
+
+## Tips
+
+- Handles RFC 2822 formatting and base64 encoding automatically.
+- For attachments, use the raw API: `gws gmail users messages send --json '...'`
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-gmail-triage.md
+++ b/skills/google-workspace/references/gws-gmail-triage.md
@@ -1,0 +1,31 @@
+# gmail +triage
+
+Show unread inbox summary (sender, subject, date).
+
+## Usage
+
+```bash
+gws gmail +triage
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--max` | — | 20 | Maximum messages to show |
+| `--query` | — | — | Gmail search query (default: is:unread) |
+| `--labels` | — | — | Include label names in output |
+
+## Examples
+
+```bash
+gws gmail +triage
+gws gmail +triage --max 5 --query 'from:boss'
+gws gmail +triage --format json | jq '.[].subject'
+gws gmail +triage --labels
+```
+
+## Tips
+
+- Read-only — never modifies your mailbox.
+- Defaults to table output format.

--- a/skills/google-workspace/references/gws-gmail-watch.md
+++ b/skills/google-workspace/references/gws-gmail-watch.md
@@ -35,6 +35,7 @@ gws gmail +watch --subscription projects/p/subscriptions/my-sub
 
 - Gmail watch expires after 7 days — re-run to renew.
 - Without --cleanup, Pub/Sub resources persist for reconnection.
+- `--cleanup` only runs on graceful exit (Ctrl-C). Resources may persist after a crash or SIGKILL — use `gws events subscriptions delete` to recover orphaned resources.
 - Press Ctrl-C to stop gracefully.
 
 > [!CAUTION]

--- a/skills/google-workspace/references/gws-gmail-watch.md
+++ b/skills/google-workspace/references/gws-gmail-watch.md
@@ -35,7 +35,7 @@ gws gmail +watch --subscription projects/p/subscriptions/my-sub
 
 - Gmail watch expires after 7 days — re-run to renew.
 - Without --cleanup, Pub/Sub resources persist for reconnection.
-- `--cleanup` only runs on graceful exit (Ctrl-C). Resources may persist after a crash or SIGKILL — use `gws events subscriptions delete` to recover orphaned resources.
+- `--cleanup` only runs on graceful exit (Ctrl-C). Resources may persist after a crash or SIGKILL — use `gcloud pubsub subscriptions delete` and `gcloud pubsub topics delete` (or the Cloud Console) to recover orphaned Pub/Sub resources.
 - Press Ctrl-C to stop gracefully.
 
 > [!CAUTION]

--- a/skills/google-workspace/references/gws-gmail-watch.md
+++ b/skills/google-workspace/references/gws-gmail-watch.md
@@ -1,0 +1,38 @@
+# gmail +watch
+
+Watch for new emails and stream them as NDJSON.
+
+## Usage
+
+```bash
+gws gmail +watch
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--project` | — | — | GCP project ID for Pub/Sub resources |
+| `--subscription` | — | — | Existing Pub/Sub subscription name |
+| `--topic` | — | — | Existing Pub/Sub topic with Gmail push permission |
+| `--label-ids` | — | — | Comma-separated Gmail label IDs to filter |
+| `--max-messages` | — | 10 | Max messages per pull batch |
+| `--poll-interval` | — | 5 | Seconds between pulls |
+| `--msg-format` | — | full | Gmail message format: full, metadata, minimal, raw |
+| `--once` | — | — | Pull once and exit |
+| `--cleanup` | — | — | Delete created Pub/Sub resources on exit |
+| `--output-dir` | — | — | Write each message to a separate JSON file |
+
+## Examples
+
+```bash
+gws gmail +watch --project my-gcp-project
+gws gmail +watch --project my-project --label-ids INBOX --once
+gws gmail +watch --subscription projects/p/subscriptions/my-sub
+```
+
+## Tips
+
+- Gmail watch expires after 7 days — re-run to renew.
+- Without --cleanup, Pub/Sub resources persist for reconnection.
+- Press Ctrl-C to stop gracefully.

--- a/skills/google-workspace/references/gws-gmail-watch.md
+++ b/skills/google-workspace/references/gws-gmail-watch.md
@@ -36,3 +36,6 @@ gws gmail +watch --subscription projects/p/subscriptions/my-sub
 - Gmail watch expires after 7 days — re-run to renew.
 - Without --cleanup, Pub/Sub resources persist for reconnection.
 - Press Ctrl-C to stop gracefully.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-gmail.md
+++ b/skills/google-workspace/references/gws-gmail.md
@@ -1,0 +1,38 @@
+# gmail (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws gmail <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+send` | Send an email — see [gws-gmail-send.md](gws-gmail-send.md) |
+| `+triage` | Unread inbox summary — see [gws-gmail-triage.md](gws-gmail-triage.md) |
+| `+reply` | Reply to a message — see [gws-gmail-reply.md](gws-gmail-reply.md) |
+| `+reply-all` | Reply-all — see [gws-gmail-reply-all.md](gws-gmail-reply-all.md) |
+| `+forward` | Forward a message — see [gws-gmail-forward.md](gws-gmail-forward.md) |
+| `+watch` | Watch for new emails — see [gws-gmail-watch.md](gws-gmail-watch.md) |
+
+## API Resources
+
+### users
+- `getProfile` — Gets the current user's Gmail profile.
+- `stop` — Stop receiving push notifications.
+- `watch` — Set up or update push notification watch.
+- `drafts` — Operations on drafts.
+- `history` — Operations on history.
+- `labels` — Operations on labels.
+- `messages` — Operations on messages.
+- `settings` — Operations on settings.
+- `threads` — Operations on threads.
+
+## Discovering Commands
+
+```bash
+gws gmail --help
+gws schema gmail.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-keep.md
+++ b/skills/google-workspace/references/gws-keep.md
@@ -1,0 +1,26 @@
+# keep (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws keep <resource> <method> [flags]
+```
+
+## API Resources
+
+### media
+- `download` — Gets an attachment. Use `alt=media` query parameter.
+
+### notes
+- `create` — Creates a new note.
+- `delete` — Deletes a note. Caller must have OWNER role.
+- `get` — Gets a note.
+- `list` — Lists notes with pagination.
+- `permissions` — Note permission operations.
+
+## Discovering Commands
+
+```bash
+gws keep --help
+gws schema keep.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-meet.md
+++ b/skills/google-workspace/references/gws-meet.md
@@ -1,0 +1,29 @@
+# meet (v2)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws meet <resource> <method> [flags]
+```
+
+## API Resources
+
+### conferenceRecords
+- `get` — Gets a conference record by ID.
+- `list` — Lists conference records, ordered by start time descending.
+- `participants` — Participant operations.
+- `recordings` — Recording operations.
+- `transcripts` — Transcript operations.
+
+### spaces
+- `create` — Creates a meeting space.
+- `endActiveConference` — Ends an active conference.
+- `get` — Gets meeting space details.
+- `patch` — Updates meeting space details.
+
+## Discovering Commands
+
+```bash
+gws meet --help
+gws schema meet.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-modelarmor-create-template.md
+++ b/skills/google-workspace/references/gws-modelarmor-create-template.md
@@ -1,0 +1,33 @@
+# modelarmor +create-template
+
+Create a new Model Armor template.
+
+## Usage
+
+```bash
+gws modelarmor +create-template --project <PROJECT> --location <LOCATION> --template-id <ID>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--project` | ✓ | — | GCP project ID |
+| `--location` | ✓ | — | GCP location (e.g. us-central1) |
+| `--template-id` | ✓ | — | Template ID to create |
+| `--preset` | — | — | Use a preset template: jailbreak |
+| `--json` | — | — | JSON body for template configuration |
+
+## Examples
+
+```bash
+gws modelarmor +create-template --project P --location us-central1 --template-id my-tmpl --preset jailbreak
+```
+
+## Tips
+
+- Defaults to jailbreak preset if neither --preset nor --json is given.
+- Use resulting template name with +sanitize-prompt and +sanitize-response.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-modelarmor-sanitize-prompt.md
+++ b/skills/google-workspace/references/gws-modelarmor-sanitize-prompt.md
@@ -1,0 +1,29 @@
+# modelarmor +sanitize-prompt
+
+Sanitize a user prompt through a Model Armor template.
+
+## Usage
+
+```bash
+gws modelarmor +sanitize-prompt --template <NAME>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--template` | ✓ | — | Full template resource name |
+| `--text` | — | — | Text content to sanitize |
+| `--json` | — | — | Full JSON request body (overrides --text) |
+
+## Examples
+
+```bash
+gws modelarmor +sanitize-prompt --template projects/P/locations/L/templates/T --text 'user input'
+echo 'prompt' | gws modelarmor +sanitize-prompt --template ...
+```
+
+## Tips
+
+- If neither --text nor --json is given, reads from stdin.
+- For outbound safety, use +sanitize-response instead.

--- a/skills/google-workspace/references/gws-modelarmor-sanitize-response.md
+++ b/skills/google-workspace/references/gws-modelarmor-sanitize-response.md
@@ -1,0 +1,28 @@
+# modelarmor +sanitize-response
+
+Sanitize a model response through a Model Armor template.
+
+## Usage
+
+```bash
+gws modelarmor +sanitize-response --template <NAME>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--template` | ✓ | — | Full template resource name |
+| `--text` | — | — | Text content to sanitize |
+| `--json` | — | — | Full JSON request body (overrides --text) |
+
+## Examples
+
+```bash
+gws modelarmor +sanitize-response --template projects/P/locations/L/templates/T --text 'model output'
+```
+
+## Tips
+
+- Use for outbound safety (model -> user).
+- For inbound safety (user -> model), use +sanitize-prompt.

--- a/skills/google-workspace/references/gws-modelarmor.md
+++ b/skills/google-workspace/references/gws-modelarmor.md
@@ -1,0 +1,22 @@
+# modelarmor (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws modelarmor <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+sanitize-prompt` | Sanitize user prompt — see [gws-modelarmor-sanitize-prompt.md](gws-modelarmor-sanitize-prompt.md) |
+| `+sanitize-response` | Sanitize model response — see [gws-modelarmor-sanitize-response.md](gws-modelarmor-sanitize-response.md) |
+| `+create-template` | Create a template — see [gws-modelarmor-create-template.md](gws-modelarmor-create-template.md) |
+
+## Discovering Commands
+
+```bash
+gws modelarmor --help
+gws schema modelarmor.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-people.md
+++ b/skills/google-workspace/references/gws-people.md
@@ -1,0 +1,37 @@
+# people (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws people <resource> <method> [flags]
+```
+
+## API Resources
+
+### contactGroups
+- `batchGet`, `create`, `delete`, `get`, `list`, `update` — Contact group management.
+- `members` — Contact group member operations.
+
+### otherContacts
+- `copyOtherContactToMyContactsGroup` — Copies an "Other contact" to myContacts.
+- `list` — List all other contacts.
+- `search` — Search other contacts.
+
+### people
+- `batchCreateContacts`, `batchUpdateContacts` — Batch operations.
+- `createContact` — Create a new contact.
+- `deleteContactPhoto`, `updateContactPhoto` — Photo management.
+- `get` — Get person info. Use `people/me` for authenticated user.
+- `getBatchGet` — Get multiple people.
+- `listDirectoryPeople` — List domain directory profiles.
+- `searchContacts` — Search contacts.
+- `searchDirectoryPeople` — Search domain directory.
+- `updateContact` — Update a contact.
+- `connections` — Operations on connections.
+
+## Discovering Commands
+
+```bash
+gws people --help
+gws schema people.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-shared.md
+++ b/skills/google-workspace/references/gws-shared.md
@@ -1,0 +1,65 @@
+# gws — Shared Reference
+
+## Installation
+
+The `gws` binary must be on `$PATH`. See the project README for install options.
+
+## Authentication
+
+```bash
+# Browser-based OAuth (interactive)
+gws auth login
+
+# Service Account
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+```
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format <FORMAT>` | Output format: `json` (default), `table`, `yaml`, `csv` |
+| `--dry-run` | Validate locally without calling the API |
+| `--sanitize <TEMPLATE>` | Screen responses through Model Armor |
+
+## CLI Syntax
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Method Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request body |
+| `-o, --output <PATH>` | Save binary responses to file |
+| `--upload <PATH>` | Upload file content (multipart) |
+| `--page-all` | Auto-paginate (NDJSON output) |
+| `--page-limit <N>` | Max pages when using --page-all (default: 10) |
+| `--page-delay <MS>` | Delay between pages in ms (default: 100) |
+
+## Security Rules
+
+- **Never** output secrets (API keys, tokens) directly
+- **Always** confirm with user before executing write/delete commands
+- Prefer `--dry-run` for destructive operations
+- Use `--sanitize` for PII/content safety screening
+
+## Shell Tips
+
+- **zsh `!` expansion:** Use double quotes for sheet ranges:
+  ```bash
+  gws sheets +read --spreadsheet ID --range "Sheet1!A1:D10"
+  ```
+- **JSON with double quotes:** Wrap `--params` and `--json` values in single quotes:
+  ```bash
+  gws drive files list --params '{"pageSize": 5}'
+  ```
+
+## Community & Feedback
+
+- Star the repo: https://github.com/googleworkspace/cli
+- Bugs/features: https://github.com/googleworkspace/cli/issues
+- Search existing issues before creating new ones

--- a/skills/google-workspace/references/gws-sheets-append.md
+++ b/skills/google-workspace/references/gws-sheets-append.md
@@ -1,0 +1,32 @@
+# sheets +append
+
+Append a row to a spreadsheet.
+
+## Usage
+
+```bash
+gws sheets +append --spreadsheet <ID>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--spreadsheet` | ✓ | — | Spreadsheet ID |
+| `--values` | — | — | Comma-separated values (simple strings) |
+| `--json-values` | — | — | JSON array of rows, e.g. '[["a","b"],["c","d"]]' |
+
+## Examples
+
+```bash
+gws sheets +append --spreadsheet ID --values 'Alice,100,true'
+gws sheets +append --spreadsheet ID --json-values '[["a","b"],["c","d"]]'
+```
+
+## Tips
+
+- Use --values for simple single-row appends.
+- Use --json-values for bulk multi-row inserts.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-sheets-read.md
+++ b/skills/google-workspace/references/gws-sheets-read.md
@@ -1,0 +1,28 @@
+# sheets +read
+
+Read values from a spreadsheet.
+
+## Usage
+
+```bash
+gws sheets +read --spreadsheet <ID> --range <RANGE>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--spreadsheet` | ✓ | — | Spreadsheet ID |
+| `--range` | ✓ | — | Range to read (e.g. 'Sheet1!A1:B2') |
+
+## Examples
+
+```bash
+gws sheets +read --spreadsheet ID --range "Sheet1!A1:D10"
+gws sheets +read --spreadsheet ID --range Sheet1
+```
+
+## Tips
+
+- Read-only — never modifies the spreadsheet.
+- For advanced options, use the raw values.get API.

--- a/skills/google-workspace/references/gws-sheets.md
+++ b/skills/google-workspace/references/gws-sheets.md
@@ -1,0 +1,32 @@
+# sheets (v4)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws sheets <resource> <method> [flags]
+```
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+append` | Append a row — see [gws-sheets-append.md](gws-sheets-append.md) |
+| `+read` | Read values — see [gws-sheets-read.md](gws-sheets-read.md) |
+
+## API Resources
+
+### spreadsheets
+- `batchUpdate` — Applies one or more updates to the spreadsheet.
+- `create` — Creates a spreadsheet, returning the newly created spreadsheet.
+- `get` — Returns the spreadsheet at the given ID.
+- `getByDataFilter` — Returns the spreadsheet using data filters.
+- `developerMetadata` — Operations on developer metadata.
+- `sheets` — Operations on sheets.
+- `values` — Operations on values.
+
+## Discovering Commands
+
+```bash
+gws sheets --help
+gws schema sheets.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-slides.md
+++ b/skills/google-workspace/references/gws-slides.md
@@ -1,0 +1,22 @@
+# slides (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws slides <resource> <method> [flags]
+```
+
+## API Resources
+
+### presentations
+- `batchUpdate` — Applies one or more updates to the presentation.
+- `create` — Creates a blank presentation.
+- `get` — Gets the latest version of the specified presentation.
+- `pages` — Operations on pages.
+
+## Discovering Commands
+
+```bash
+gws slides --help
+gws schema slides.<resource>.<method>
+```

--- a/skills/google-workspace/references/gws-workflow-email-to-task.md
+++ b/skills/google-workspace/references/gws-workflow-email-to-task.md
@@ -25,4 +25,7 @@ gws workflow +email-to-task --message-id MSG_ID --tasklist LIST_ID
 ## Tips
 
 - Reads the email subject as the task title and snippet as notes.
-- Creates a new task — confirm with the user before executing.
+- Creates a new task.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-workflow-email-to-task.md
+++ b/skills/google-workspace/references/gws-workflow-email-to-task.md
@@ -1,0 +1,28 @@
+# workflow +email-to-task
+
+Convert a Gmail message into a Google Tasks entry.
+
+## Usage
+
+```bash
+gws workflow +email-to-task --message-id <ID>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--message-id` | ✓ | — | Gmail message ID to convert |
+| `--tasklist` | — | @default | Task list ID |
+
+## Examples
+
+```bash
+gws workflow +email-to-task --message-id MSG_ID
+gws workflow +email-to-task --message-id MSG_ID --tasklist LIST_ID
+```
+
+## Tips
+
+- Reads the email subject as the task title and snippet as notes.
+- Creates a new task — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-workflow-file-announce.md
+++ b/skills/google-workspace/references/gws-workflow-file-announce.md
@@ -1,0 +1,31 @@
+# workflow +file-announce
+
+Announce a Drive file in a Chat space.
+
+## Usage
+
+```bash
+gws workflow +file-announce --file-id <ID> --space <SPACE>
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--file-id` | ✓ | — | Drive file ID to announce |
+| `--space` | ✓ | — | Chat space name (e.g. spaces/SPACE_ID) |
+| `--message` | — | — | Custom announcement message |
+| `--format` | — | — | Output format: json (default), table, yaml, csv |
+
+## Examples
+
+```bash
+gws workflow +file-announce --file-id FILE_ID --space spaces/ABC123
+gws workflow +file-announce --file-id FILE_ID --space spaces/ABC123 --message 'Check this out!'
+```
+
+## Tips
+
+- This is a write command — sends a Chat message.
+- Use `gws drive +upload` first to upload the file, then announce it here.
+- Fetches the file name from Drive to build the announcement.

--- a/skills/google-workspace/references/gws-workflow-file-announce.md
+++ b/skills/google-workspace/references/gws-workflow-file-announce.md
@@ -29,3 +29,6 @@ gws workflow +file-announce --file-id FILE_ID --space spaces/ABC123 --message 'C
 - This is a write command — sends a Chat message.
 - Use `gws drive +upload` first to upload the file, then announce it here.
 - Fetches the file name from Drive to build the announcement.
+
+> [!CAUTION]
+> This is a **write** command — confirm with the user before executing.

--- a/skills/google-workspace/references/gws-workflow-meeting-prep.md
+++ b/skills/google-workspace/references/gws-workflow-meeting-prep.md
@@ -1,0 +1,28 @@
+# workflow +meeting-prep
+
+Prepare for your next meeting: agenda, attendees, and linked docs.
+
+## Usage
+
+```bash
+gws workflow +meeting-prep
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--calendar` | — | primary | Calendar ID |
+| `--format` | — | — | Output format: json (default), table, yaml, csv |
+
+## Examples
+
+```bash
+gws workflow +meeting-prep
+gws workflow +meeting-prep --calendar Work
+```
+
+## Tips
+
+- Read-only — never modifies data.
+- Shows the next upcoming event with attendees and description.

--- a/skills/google-workspace/references/gws-workflow-standup-report.md
+++ b/skills/google-workspace/references/gws-workflow-standup-report.md
@@ -1,0 +1,27 @@
+# workflow +standup-report
+
+Today's meetings + open tasks as a standup summary.
+
+## Usage
+
+```bash
+gws workflow +standup-report
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--format` | — | — | Output format: json (default), table, yaml, csv |
+
+## Examples
+
+```bash
+gws workflow +standup-report
+gws workflow +standup-report --format table
+```
+
+## Tips
+
+- Read-only — never modifies data.
+- Combines calendar agenda (today) with tasks list.

--- a/skills/google-workspace/references/gws-workflow-weekly-digest.md
+++ b/skills/google-workspace/references/gws-workflow-weekly-digest.md
@@ -1,0 +1,27 @@
+# workflow +weekly-digest
+
+Weekly summary: this week's meetings + unread email count.
+
+## Usage
+
+```bash
+gws workflow +weekly-digest
+```
+
+## Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--format` | — | — | Output format: json (default), table, yaml, csv |
+
+## Examples
+
+```bash
+gws workflow +weekly-digest
+gws workflow +weekly-digest --format table
+```
+
+## Tips
+
+- Read-only — never modifies data.
+- Combines calendar agenda (week) with gmail triage summary.

--- a/skills/google-workspace/references/gws-workflow.md
+++ b/skills/google-workspace/references/gws-workflow.md
@@ -1,0 +1,26 @@
+# workflow (v1)
+
+> **PREREQUISITE:** See [gws-shared.md](gws-shared.md) for auth, global flags, and security rules.
+
+```bash
+gws workflow <resource> <method> [flags]
+```
+
+Alias: `gws wf`
+
+## Helper Commands
+
+| Command | Description |
+|---------|-------------|
+| `+standup-report` | Today's meetings + open tasks — see [gws-workflow-standup-report.md](gws-workflow-standup-report.md) |
+| `+meeting-prep` | Next meeting prep — see [gws-workflow-meeting-prep.md](gws-workflow-meeting-prep.md) |
+| `+email-to-task` | Convert email to task — see [gws-workflow-email-to-task.md](gws-workflow-email-to-task.md) |
+| `+weekly-digest` | Weekly summary — see [gws-workflow-weekly-digest.md](gws-workflow-weekly-digest.md) |
+| `+file-announce` | Announce Drive file in Chat — see [gws-workflow-file-announce.md](gws-workflow-file-announce.md) |
+
+## Discovering Commands
+
+```bash
+gws workflow --help
+gws schema workflow.<resource>.<method>
+```

--- a/skills/google-workspace/references/persona-content-creator.md
+++ b/skills/google-workspace/references/persona-content-creator.md
@@ -1,0 +1,18 @@
+# Content Creator
+
+Create, organize, and distribute content across Workspace.
+
+## Relevant Workflows
+- `gws workflow +file-announce`
+
+## Instructions
+- Draft content in Google Docs with `gws docs +write`.
+- Organize content assets in Drive folders — use `gws drive files list` to browse.
+- Upload media assets to Drive with `gws drive +upload`.
+- Share finished content by announcing in Chat with `gws workflow +file-announce`.
+- Send content review requests via email with `gws gmail +send`.
+- Create presentations with `gws slides presentations create`.
+
+## Tips
+- Keep a content calendar in a shared Sheet for tracking publication schedules.
+- Use `--format yaml` for human-readable output when debugging API responses.

--- a/skills/google-workspace/references/persona-customer-support.md
+++ b/skills/google-workspace/references/persona-customer-support.md
@@ -1,0 +1,20 @@
+# Customer Support Agent
+
+Manage customer support — triage tickets, respond to customers, and escalate issues.
+
+## Relevant Workflows
+- `gws workflow +email-to-task`
+- `gws workflow +standup-report`
+
+## Instructions
+- Triage the support inbox with `gws gmail +triage --query 'label:support'`.
+- Convert customer emails into tracked tasks with `gws workflow +email-to-task`.
+- Log ticket status updates in a tracking sheet with `gws sheets +append`.
+- Escalate urgent issues to the team Chat space with `gws chat +send`.
+- Reply to customers with `gws gmail +reply` — keep responses clear and helpful.
+- Start the day with `gws workflow +standup-report` for a daily overview.
+
+## Tips
+- Use `gws gmail +triage --labels` to see email categories at a glance.
+- Set up Gmail filters for auto-labeling support requests.
+- Use `--format table` for quick status dashboard views.

--- a/skills/google-workspace/references/persona-event-coordinator.md
+++ b/skills/google-workspace/references/persona-event-coordinator.md
@@ -1,0 +1,21 @@
+# Event Coordinator
+
+Plan and manage events — invitations, materials, and logistics tracking.
+
+## Relevant Workflows
+- `gws workflow +meeting-prep`
+- `gws workflow +file-announce`
+- `gws workflow +weekly-digest`
+
+## Instructions
+- Prepare event materials and upload to Drive with `gws drive +upload`.
+- Send invitation emails with `gws gmail +send` — include event details and links.
+- Announce updates in Chat spaces with `gws workflow +file-announce`.
+- Track RSVPs and logistics in Sheets with `gws sheets +append`.
+- Use `gws workflow +weekly-digest` to review your calendar for event planning.
+- Create Google Meet spaces for virtual events with `gws meet spaces create`.
+- Share event docs with attendees using `gws drive permissions create`.
+
+## Tips
+- Use `gws sheets +read` to review RSVP status before events.
+- Create a shared Drive folder per event for all materials.

--- a/skills/google-workspace/references/persona-exec-assistant.md
+++ b/skills/google-workspace/references/persona-exec-assistant.md
@@ -1,0 +1,21 @@
+# Executive Assistant
+
+Manage an executive's schedule, inbox, and communications.
+
+## Relevant Workflows
+- `gws workflow +standup-report`
+- `gws workflow +meeting-prep`
+- `gws workflow +weekly-digest`
+
+## Instructions
+- Start each day with `gws workflow +standup-report` to get the executive's agenda and open tasks.
+- Before each meeting, run `gws workflow +meeting-prep` to see attendees, description, and linked docs.
+- Triage the inbox with `gws gmail +triage --max 10` — prioritize emails from direct reports and leadership.
+- Draft replies with `gws gmail +send` — keep tone professional and concise.
+- Use `gws gmail +reply` and `gws gmail +forward` to handle threads efficiently.
+- Share documents by uploading to Drive with `gws drive +upload` and emailing links.
+
+## Tips
+- Always confirm before sending emails on the executive's behalf.
+- Use `--format table` for quick visual scans of agenda and triage output.
+- Check `gws workflow +weekly-digest` on Monday mornings for weekly planning.

--- a/skills/google-workspace/references/persona-hr-coordinator.md
+++ b/skills/google-workspace/references/persona-hr-coordinator.md
@@ -1,0 +1,19 @@
+# HR Coordinator
+
+Handle HR workflows — onboarding, announcements, and employee communications.
+
+## Relevant Workflows
+- `gws workflow +email-to-task`
+- `gws workflow +file-announce`
+
+## Instructions
+- Upload onboarding docs to a shared Drive folder with `gws drive +upload`.
+- Announce new hires in Chat spaces with `gws workflow +file-announce` to share their profile doc.
+- Convert email requests into tracked tasks with `gws workflow +email-to-task`.
+- Send bulk announcements with `gws gmail +send` — use clear subject lines.
+- Share Drive folders with new hires using `gws drive permissions create`.
+- Track onboarding progress in Sheets with `gws sheets +append`.
+
+## Tips
+- Always use `--sanitize` for PII-sensitive operations.
+- Use `gws gmail +triage --query 'label:hr-requests'` to filter HR inbox.

--- a/skills/google-workspace/references/persona-it-admin.md
+++ b/skills/google-workspace/references/persona-it-admin.md
@@ -1,0 +1,17 @@
+# IT Administrator
+
+Administer IT — monitor security, review audit logs, and configure Workspace.
+
+## Relevant Workflows
+- `gws workflow +standup-report`
+
+## Instructions
+- Start the day with `gws workflow +standup-report` to review pending items.
+- Monitor activity with `gws admin-reports activities list`.
+- Review user usage reports with `gws admin-reports userUsageReport get`.
+- Configure Drive sharing policies to enforce organizational security.
+- Use `gws gmail +triage --query 'label:it-requests'` to triage IT support inbox.
+
+## Tips
+- Always use `--dry-run` before bulk operations.
+- Review `gws auth status` regularly to verify service account permissions.

--- a/skills/google-workspace/references/persona-project-manager.md
+++ b/skills/google-workspace/references/persona-project-manager.md
@@ -1,0 +1,21 @@
+# Project Manager
+
+Coordinate projects — track progress, share docs, and communicate with stakeholders.
+
+## Relevant Workflows
+- `gws workflow +standup-report`
+- `gws workflow +weekly-digest`
+- `gws workflow +file-announce`
+
+## Instructions
+- Start the week with `gws workflow +weekly-digest` for a snapshot of upcoming meetings and unread items.
+- Track project status in Sheets using `gws sheets +append` to log updates.
+- Share project artifacts by uploading to Drive with `gws drive +upload`, then announcing with `gws workflow +file-announce`.
+- Send status update emails to stakeholders with `gws gmail +send`.
+- Use `gws gmail +triage` to stay on top of project correspondence.
+- Create project docs with `gws docs +write`.
+
+## Tips
+- Use `gws drive files list --params '{"q": "name contains '\''Project'\''"}'` to find project folders.
+- Pipe triage output through `jq` for filtering by sender or subject.
+- Use `--dry-run` before any write operations to preview what will happen.

--- a/skills/google-workspace/references/persona-researcher.md
+++ b/skills/google-workspace/references/persona-researcher.md
@@ -1,0 +1,18 @@
+# Researcher
+
+Organize research — manage references, notes, and collaboration.
+
+## Relevant Workflows
+- `gws workflow +file-announce`
+
+## Instructions
+- Organize research papers and notes in Drive folders with `gws drive +upload`.
+- Write research notes and summaries with `gws docs +write`.
+- Track research data in Sheets — use `gws sheets +append` for data logging.
+- Share findings with collaborators via `gws workflow +file-announce`.
+- Request peer reviews via `gws gmail +send`.
+
+## Tips
+- Use `gws drive files list` with search queries to find specific documents.
+- Keep a running log of experiments and findings in a shared Sheet.
+- Use `--format csv` when exporting data for analysis tools.

--- a/skills/google-workspace/references/persona-sales-ops.md
+++ b/skills/google-workspace/references/persona-sales-ops.md
@@ -1,0 +1,21 @@
+# Sales Operations
+
+Manage sales workflows — track deals, send proposals, and maintain client communications.
+
+## Relevant Workflows
+- `gws workflow +meeting-prep`
+- `gws workflow +email-to-task`
+- `gws workflow +weekly-digest`
+
+## Instructions
+- Prepare for client calls with `gws workflow +meeting-prep` to review attendees and agenda.
+- Log deal updates in a tracking spreadsheet with `gws sheets +append`.
+- Convert follow-up emails into tasks with `gws workflow +email-to-task`.
+- Share proposals by uploading to Drive with `gws drive +upload`.
+- Get a weekly pipeline summary with `gws workflow +weekly-digest`.
+- Send client communications with `gws gmail +send` and `gws gmail +reply`.
+
+## Tips
+- Use `gws gmail +triage --query 'from:client-domain.com'` to filter client emails.
+- Keep all client-facing documents in a dedicated shared Drive folder.
+- Use `gws sheets +read` to review deal pipeline data before calls.

--- a/skills/google-workspace/references/persona-team-lead.md
+++ b/skills/google-workspace/references/persona-team-lead.md
@@ -1,0 +1,22 @@
+# Team Lead
+
+Lead a team — run standups, coordinate work, and communicate effectively.
+
+## Relevant Workflows
+- `gws workflow +standup-report`
+- `gws workflow +meeting-prep`
+- `gws workflow +weekly-digest`
+- `gws workflow +email-to-task`
+
+## Instructions
+- Run daily standups with `gws workflow +standup-report` — share output in team Chat with `gws chat +send`.
+- Prepare for 1:1s with `gws workflow +meeting-prep`.
+- Get weekly snapshots with `gws workflow +weekly-digest`.
+- Delegate email action items with `gws workflow +email-to-task`.
+- Track team OKRs in a shared Sheet with `gws sheets +append`.
+- Send team updates with `gws gmail +send`.
+- Share documents via `gws workflow +file-announce`.
+
+## Tips
+- Use `--format table` for quick team status views.
+- Use `--sanitize` for any operations involving sensitive team data.

--- a/skills/google-workspace/references/recipe-backup-sheet-as-csv.md
+++ b/skills/google-workspace/references/recipe-backup-sheet-as-csv.md
@@ -1,0 +1,9 @@
+# Export a Google Sheet as CSV
+
+Export a spreadsheet as CSV for local backup.
+
+## Steps
+
+1. Get spreadsheet details: `gws sheets spreadsheets get --params '{"spreadsheetId": "SHEET_ID"}'`
+2. Export as CSV: `gws drive files export --params '{"fileId": "SHEET_ID", "mimeType": "text/csv"}'`
+3. Or read values directly: `gws sheets +read --spreadsheet SHEET_ID --range 'Sheet1' --format csv`

--- a/skills/google-workspace/references/recipe-bulk-download-folder.md
+++ b/skills/google-workspace/references/recipe-bulk-download-folder.md
@@ -1,0 +1,9 @@
+# Bulk Download Drive Folder
+
+List and download all files from a folder.
+
+## Steps
+
+1. List files: `gws drive files list --params '{"q": "'\''FOLDER_ID'\'' in parents"}' --format json`
+2. Download each file: `gws drive files get --params '{"fileId": "FILE_ID", "alt": "media"}' -o filename.ext`
+3. Export Google Docs as PDF: `gws drive files export --params '{"fileId": "FILE_ID", "mimeType": "application/pdf"}' -o document.pdf`

--- a/skills/google-workspace/references/recipe-collect-form-responses.md
+++ b/skills/google-workspace/references/recipe-collect-form-responses.md
@@ -1,0 +1,8 @@
+# Check Form Responses
+
+Retrieve and review responses from a Google Form.
+
+## Steps
+
+1. Get form details: `gws forms forms get --params '{"formId": "FORM_ID"}'`
+2. Get responses: `gws forms forms responses list --params '{"formId": "FORM_ID"}' --format table`

--- a/skills/google-workspace/references/recipe-compare-sheet-tabs.md
+++ b/skills/google-workspace/references/recipe-compare-sheet-tabs.md
@@ -1,0 +1,9 @@
+# Compare Two Google Sheets Tabs
+
+Read data from two tabs to compare and identify differences.
+
+## Steps
+
+1. Read the first tab: `gws sheets +read --spreadsheet SHEET_ID --range "January!A1:D"`
+2. Read the second tab: `gws sheets +read --spreadsheet SHEET_ID --range "February!A1:D"`
+3. Compare the data and identify changes

--- a/skills/google-workspace/references/recipe-copy-sheet-for-new-month.md
+++ b/skills/google-workspace/references/recipe-copy-sheet-for-new-month.md
@@ -1,0 +1,9 @@
+# Copy a Google Sheet for a New Month
+
+Duplicate a template tab for a new month.
+
+## Steps
+
+1. Get spreadsheet details: `gws sheets spreadsheets get --params '{"spreadsheetId": "SHEET_ID"}'`
+2. Copy the template sheet: `gws sheets spreadsheets sheets copyTo --params '{"spreadsheetId": "SHEET_ID", "sheetId": 0}' --json '{"destinationSpreadsheetId": "SHEET_ID"}'`
+3. Rename the new tab: `gws sheets spreadsheets batchUpdate --params '{"spreadsheetId": "SHEET_ID"}' --json '{"requests": [{"updateSheetProperties": {"properties": {"sheetId": 123, "title": "February 2025"}, "fields": "title"}}]}'`

--- a/skills/google-workspace/references/recipe-copy-sheet-for-new-month.md
+++ b/skills/google-workspace/references/recipe-copy-sheet-for-new-month.md
@@ -6,4 +6,4 @@ Duplicate a template tab for a new month.
 
 1. Get spreadsheet details: `gws sheets spreadsheets get --params '{"spreadsheetId": "SHEET_ID"}'`
 2. Copy the template sheet: `gws sheets spreadsheets sheets copyTo --params '{"spreadsheetId": "SHEET_ID", "sheetId": 0}' --json '{"destinationSpreadsheetId": "SHEET_ID"}'`
-3. Rename the new tab: `gws sheets spreadsheets batchUpdate --params '{"spreadsheetId": "SHEET_ID"}' --json '{"requests": [{"updateSheetProperties": {"properties": {"sheetId": 123, "title": "February 2025"}, "fields": "title"}}]}'`
+3. Rename the new tab (replace `NEW_SHEET_ID` with the `sheetId` from the step 2 response): `gws sheets spreadsheets batchUpdate --params '{"spreadsheetId": "SHEET_ID"}' --json '{"requests": [{"updateSheetProperties": {"properties": {"sheetId": NEW_SHEET_ID, "title": "February 2025"}, "fields": "title"}}]}'`

--- a/skills/google-workspace/references/recipe-create-classroom-course.md
+++ b/skills/google-workspace/references/recipe-create-classroom-course.md
@@ -2,6 +2,9 @@
 
 Create a course and invite students.
 
+> [!NOTE]
+> Classroom is not enabled by default. You must enable the Google Classroom API in your GCP project and authenticate with `gws auth login --full` to include the required scopes.
+
 ## Steps
 
 1. Create the course: `gws classroom courses create --json '{"name": "Introduction to CS", "section": "Period 1", "room": "Room 101", "ownerId": "me"}'`

--- a/skills/google-workspace/references/recipe-create-classroom-course.md
+++ b/skills/google-workspace/references/recipe-create-classroom-course.md
@@ -1,0 +1,9 @@
+# Create a Google Classroom Course
+
+Create a course and invite students.
+
+## Steps
+
+1. Create the course: `gws classroom courses create --json '{"name": "Introduction to CS", "section": "Period 1", "room": "Room 101", "ownerId": "me"}'`
+2. Invite a student: `gws classroom invitations create --json '{"courseId": "COURSE_ID", "userId": "student@school.edu", "role": "STUDENT"}'`
+3. List enrolled students: `gws classroom courses students list --params '{"courseId": "COURSE_ID"}' --format table`

--- a/skills/google-workspace/references/recipe-create-doc-from-template.md
+++ b/skills/google-workspace/references/recipe-create-doc-from-template.md
@@ -1,0 +1,10 @@
+# Create a Google Doc from a Template
+
+Copy a template, fill in content, and share.
+
+## Steps
+
+1. Copy the template: `gws drive files copy --params '{"fileId": "TEMPLATE_DOC_ID"}' --json '{"name": "Project Brief - Q2 Launch"}'`
+2. Get the new doc ID from the response
+3. Add content: `gws docs +write --document NEW_DOC_ID --text '## Project: Q2 Launch'`
+4. Share with team: `gws drive permissions create --params '{"fileId": "NEW_DOC_ID"}' --json '{"role": "writer", "type": "user", "emailAddress": "team@company.com"}'`

--- a/skills/google-workspace/references/recipe-create-expense-tracker.md
+++ b/skills/google-workspace/references/recipe-create-expense-tracker.md
@@ -1,0 +1,10 @@
+# Create a Google Sheets Expense Tracker
+
+Set up a spreadsheet for tracking expenses.
+
+## Steps
+
+1. Create spreadsheet: `gws drive files create --json '{"name": "Expense Tracker 2025", "mimeType": "application/vnd.google-apps.spreadsheet"}'`
+2. Add headers: `gws sheets +append --spreadsheet SHEET_ID --values 'Date,Category,Description,Amount'`
+3. Add first entry: `gws sheets +append --spreadsheet SHEET_ID --values '2025-01-15,Travel,Flight to NYC,450.00'`
+4. Share with manager: `gws drive permissions create --params '{"fileId": "SHEET_ID"}' --json '{"role": "reader", "type": "user", "emailAddress": "manager@company.com"}'`

--- a/skills/google-workspace/references/recipe-create-feedback-form.md
+++ b/skills/google-workspace/references/recipe-create-feedback-form.md
@@ -1,0 +1,9 @@
+# Create and Share a Google Form
+
+Create a Form for feedback and share it via Gmail.
+
+## Steps
+
+1. Create form: `gws forms forms create --json '{"info": {"title": "Event Feedback", "documentTitle": "Event Feedback Form"}}'`
+2. Get the form URL from the response (responderUri field)
+3. Email the form: `gws gmail +send --to attendees@company.com --subject 'Please share your feedback' --body 'Fill out the form: FORM_URL'`

--- a/skills/google-workspace/references/recipe-create-gmail-filter.md
+++ b/skills/google-workspace/references/recipe-create-gmail-filter.md
@@ -1,0 +1,10 @@
+# Create a Gmail Filter
+
+Create a filter to automatically label, star, or categorize messages.
+
+## Steps
+
+1. List existing labels: `gws gmail users labels list --params '{"userId": "me"}' --format table`
+2. Create a new label: `gws gmail users labels create --params '{"userId": "me"}' --json '{"name": "Receipts"}'`
+3. Create a filter: `gws gmail users settings filters create --params '{"userId": "me"}' --json '{"criteria": {"from": "receipts@example.com"}, "action": {"addLabelIds": ["LABEL_ID"], "removeLabelIds": ["INBOX"]}}'`
+4. Verify filter: `gws gmail users settings filters list --params '{"userId": "me"}' --format table`

--- a/skills/google-workspace/references/recipe-create-meet-space.md
+++ b/skills/google-workspace/references/recipe-create-meet-space.md
@@ -1,0 +1,9 @@
+# Create a Google Meet Conference
+
+Create a meeting space and share the join link.
+
+## Steps
+
+1. Create meeting space: `gws meet spaces create --json '{"config": {"accessType": "OPEN"}}'`
+2. Copy the meeting URI from the response
+3. Email the link: `gws gmail +send --to team@company.com --subject 'Join the meeting' --body 'Join here: MEETING_URI'`

--- a/skills/google-workspace/references/recipe-create-presentation.md
+++ b/skills/google-workspace/references/recipe-create-presentation.md
@@ -1,0 +1,9 @@
+# Create a Google Slides Presentation
+
+Create a new presentation and share it.
+
+## Steps
+
+1. Create presentation: `gws slides presentations create --json '{"title": "Quarterly Review Q2"}'`
+2. Get the presentation ID from the response
+3. Share with team: `gws drive permissions create --params '{"fileId": "PRESENTATION_ID"}' --json '{"role": "writer", "type": "user", "emailAddress": "team@company.com"}'`

--- a/skills/google-workspace/references/recipe-create-shared-drive.md
+++ b/skills/google-workspace/references/recipe-create-shared-drive.md
@@ -1,0 +1,9 @@
+# Create and Configure a Shared Drive
+
+Create a Shared Drive and add members.
+
+## Steps
+
+1. Create shared drive: `gws drive drives create --params '{"requestId": "unique-id-123"}' --json '{"name": "Project X"}'`
+2. Add a member: `gws drive permissions create --params '{"fileId": "DRIVE_ID", "supportsAllDrives": true}' --json '{"role": "writer", "type": "user", "emailAddress": "member@company.com"}'`
+3. List members: `gws drive permissions list --params '{"fileId": "DRIVE_ID", "supportsAllDrives": true}'`

--- a/skills/google-workspace/references/recipe-create-vacation-responder.md
+++ b/skills/google-workspace/references/recipe-create-vacation-responder.md
@@ -1,0 +1,9 @@
+# Set Up a Gmail Vacation Responder
+
+Enable a Gmail out-of-office auto-reply.
+
+## Steps
+
+1. Enable vacation responder: `gws gmail users settings updateVacation --params '{"userId": "me"}' --json '{"enableAutoReply": true, "responseSubject": "Out of Office", "responseBodyPlainText": "I am out of the office until Jan 20. For urgent matters, contact backup@company.com.", "restrictToContacts": false, "restrictToDomain": false}'`
+2. Verify settings: `gws gmail users settings getVacation --params '{"userId": "me"}'`
+3. Disable when back: `gws gmail users settings updateVacation --params '{"userId": "me"}' --json '{"enableAutoReply": false}'`

--- a/skills/google-workspace/references/recipe-draft-email-from-doc.md
+++ b/skills/google-workspace/references/recipe-draft-email-from-doc.md
@@ -1,0 +1,9 @@
+# Draft a Gmail Message from a Google Doc
+
+Read content from a Google Doc and use it as the body of a Gmail message.
+
+## Steps
+
+1. Get the document content: `gws docs documents get --params '{"documentId": "DOC_ID"}'`
+2. Copy the text from the body content
+3. Send the email: `gws gmail +send --to recipient@example.com --subject 'Newsletter Update' --body 'CONTENT_FROM_DOC'`

--- a/skills/google-workspace/references/recipe-email-drive-link.md
+++ b/skills/google-workspace/references/recipe-email-drive-link.md
@@ -1,0 +1,9 @@
+# Email a Google Drive File Link
+
+Share a file and email the link with a message.
+
+## Steps
+
+1. Find the file: `gws drive files list --params '{"q": "name = '\''Quarterly Report'\''"}'`
+2. Share the file: `gws drive permissions create --params '{"fileId": "FILE_ID"}' --json '{"role": "reader", "type": "user", "emailAddress": "client@example.com"}'`
+3. Email the link: `gws gmail +send --to client@example.com --subject 'Quarterly Report' --body 'Hi, please find the report here: https://docs.google.com/document/d/FILE_ID'`

--- a/skills/google-workspace/references/recipe-find-large-files.md
+++ b/skills/google-workspace/references/recipe-find-large-files.md
@@ -1,0 +1,8 @@
+# Find Largest Files in Drive
+
+Identify large files consuming storage quota.
+
+## Steps
+
+1. List files sorted by size: `gws drive files list --params '{"orderBy": "quotaBytesUsed desc", "pageSize": 20, "fields": "files(id,name,size,mimeType,owners)"}' --format table`
+2. Review the output and identify files to archive or move

--- a/skills/google-workspace/references/recipe-forward-labeled-emails.md
+++ b/skills/google-workspace/references/recipe-forward-labeled-emails.md
@@ -1,0 +1,9 @@
+# Forward Labeled Gmail Messages
+
+Find messages with a specific label and forward them.
+
+## Steps
+
+1. Find labeled messages: `gws gmail users messages list --params '{"userId": "me", "q": "label:needs-review"}' --format table`
+2. Get message content: `gws gmail users messages get --params '{"userId": "me", "id": "MSG_ID"}'`
+3. Forward: `gws gmail +forward --message-id MSG_ID --to manager@company.com --body 'Forwarding for your review'`

--- a/skills/google-workspace/references/recipe-generate-report-from-sheet.md
+++ b/skills/google-workspace/references/recipe-generate-report-from-sheet.md
@@ -1,0 +1,10 @@
+# Generate a Google Docs Report from Sheet Data
+
+Read data from a Sheet and create a formatted Docs report.
+
+## Steps
+
+1. Read the data: `gws sheets +read --spreadsheet SHEET_ID --range "Sales!A1:D"`
+2. Create the report doc: `gws docs documents create --json '{"title": "Sales Report - January 2025"}'`
+3. Write the report: `gws docs +write --document DOC_ID --text '## Sales Report\n\n### Summary\nTotal deals: 45\nRevenue: $125,000'`
+4. Share: `gws drive permissions create --params '{"fileId": "DOC_ID"}' --json '{"role": "reader", "type": "user", "emailAddress": "cfo@company.com"}'`

--- a/skills/google-workspace/references/recipe-label-and-archive-emails.md
+++ b/skills/google-workspace/references/recipe-label-and-archive-emails.md
@@ -1,0 +1,9 @@
+# Label and Archive Gmail Threads
+
+Apply Gmail labels to matching messages and archive them.
+
+## Steps
+
+1. Search for matching emails: `gws gmail users messages list --params '{"userId": "me", "q": "from:notifications@service.com"}' --format table`
+2. Apply a label: `gws gmail users messages modify --params '{"userId": "me", "id": "MESSAGE_ID"}' --json '{"addLabelIds": ["LABEL_ID"]}'`
+3. Archive (remove from inbox): `gws gmail users messages modify --params '{"userId": "me", "id": "MESSAGE_ID"}' --json '{"removeLabelIds": ["INBOX"]}'`

--- a/skills/google-workspace/references/recipe-log-deal-update.md
+++ b/skills/google-workspace/references/recipe-log-deal-update.md
@@ -1,0 +1,9 @@
+# Log Deal Update to Sheet
+
+Append a deal status update to a sales tracking spreadsheet.
+
+## Steps
+
+1. Find the tracking sheet: `gws drive files list --params '{"q": "name = '\''Sales Pipeline'\'' and mimeType = '\''application/vnd.google-apps.spreadsheet'\''"}'`
+2. Read current data: `gws sheets +read --spreadsheet SHEET_ID --range "Pipeline!A1:F"`
+3. Append new row: `gws sheets +append --spreadsheet SHEET_ID --values '2024-03-15,Acme Corp,Proposal Sent,$50000,Q2,jdoe'`

--- a/skills/google-workspace/references/recipe-organize-drive-folder.md
+++ b/skills/google-workspace/references/recipe-organize-drive-folder.md
@@ -1,0 +1,10 @@
+# Organize Files into Google Drive Folders
+
+Create a folder structure and move files into the right locations.
+
+## Steps
+
+1. Create a project folder: `gws drive files create --json '{"name": "Q2 Project", "mimeType": "application/vnd.google-apps.folder"}'`
+2. Create sub-folders: `gws drive files create --json '{"name": "Documents", "mimeType": "application/vnd.google-apps.folder", "parents": ["PARENT_FOLDER_ID"]}'`
+3. Move existing files: `gws drive files update --params '{"fileId": "FILE_ID", "addParents": "FOLDER_ID", "removeParents": "OLD_PARENT_ID"}'`
+4. Verify structure: `gws drive files list --params '{"q": "FOLDER_ID in parents"}' --format table`

--- a/skills/google-workspace/references/recipe-review-meet-participants.md
+++ b/skills/google-workspace/references/recipe-review-meet-participants.md
@@ -1,0 +1,9 @@
+# Review Google Meet Attendance
+
+Review who attended a conference and for how long.
+
+## Steps
+
+1. List recent conferences: `gws meet conferenceRecords list --format table`
+2. List participants: `gws meet conferenceRecords participants list --params '{"parent": "conferenceRecords/CONFERENCE_ID"}' --format table`
+3. Get session details: `gws meet conferenceRecords participants participantSessions list --params '{"parent": "conferenceRecords/CONFERENCE_ID/participants/PARTICIPANT_ID"}' --format table`

--- a/skills/google-workspace/references/recipe-save-email-attachments.md
+++ b/skills/google-workspace/references/recipe-save-email-attachments.md
@@ -6,5 +6,7 @@ Find messages with attachments and save them to Drive.
 
 1. Search for emails with attachments: `gws gmail users messages list --params '{"userId": "me", "q": "has:attachment from:client@example.com"}' --format table`
 2. Get message details: `gws gmail users messages get --params '{"userId": "me", "id": "MESSAGE_ID"}'`
-3. Download attachment: `gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}' -o attachment.pdf`
-4. Upload to Drive: `gws drive +upload ./attachment.pdf --parent FOLDER_ID`
+3. Download attachment: `gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}' -o FILENAME.pdf`
+4. Upload to Drive: `gws drive +upload ./FILENAME.pdf --parent FOLDER_ID`
+
+Use a unique filename per attachment (e.g. based on attachment ID) to avoid overwrites when processing multiple attachments.

--- a/skills/google-workspace/references/recipe-save-email-attachments.md
+++ b/skills/google-workspace/references/recipe-save-email-attachments.md
@@ -1,0 +1,10 @@
+# Save Gmail Attachments to Google Drive
+
+Find messages with attachments and save them to Drive.
+
+## Steps
+
+1. Search for emails with attachments: `gws gmail users messages list --params '{"userId": "me", "q": "has:attachment from:client@example.com"}' --format table`
+2. Get message details: `gws gmail users messages get --params '{"userId": "me", "id": "MESSAGE_ID"}'`
+3. Download attachment: `gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}'`
+4. Upload to Drive: `gws drive +upload ./attachment.pdf --parent FOLDER_ID`

--- a/skills/google-workspace/references/recipe-save-email-attachments.md
+++ b/skills/google-workspace/references/recipe-save-email-attachments.md
@@ -6,5 +6,5 @@ Find messages with attachments and save them to Drive.
 
 1. Search for emails with attachments: `gws gmail users messages list --params '{"userId": "me", "q": "has:attachment from:client@example.com"}' --format table`
 2. Get message details: `gws gmail users messages get --params '{"userId": "me", "id": "MESSAGE_ID"}'`
-3. Download attachment: `gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}'`
+3. Download attachment: `gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}' -o attachment.pdf`
 4. Upload to Drive: `gws drive +upload ./attachment.pdf --parent FOLDER_ID`

--- a/skills/google-workspace/references/recipe-save-email-to-doc.md
+++ b/skills/google-workspace/references/recipe-save-email-to-doc.md
@@ -1,0 +1,10 @@
+# Save a Gmail Message to Google Docs
+
+Save a message body into a Doc for archival.
+
+## Steps
+
+1. Find the message: `gws gmail users messages list --params '{"userId": "me", "q": "subject:important from:boss@company.com"}' --format table`
+2. Get message content: `gws gmail users messages get --params '{"userId": "me", "id": "MSG_ID"}'`
+3. Create a doc: `gws docs documents create --json '{"title": "Saved Email - Important Update"}'`
+4. Write the email body: `gws docs +write --document DOC_ID --text 'EMAIL_CONTENT'`

--- a/skills/google-workspace/references/recipe-send-team-announcement.md
+++ b/skills/google-workspace/references/recipe-send-team-announcement.md
@@ -1,0 +1,8 @@
+# Announce via Gmail and Google Chat
+
+Send a team announcement via both Gmail and a Chat space.
+
+## Steps
+
+1. Send email: `gws gmail +send --to team@company.com --subject 'Important Update' --body 'Please review the attached policy changes.'`
+2. Post in Chat: `gws chat +send --space spaces/TEAM_SPACE --text 'Important Update: Please check your email for policy changes.'`

--- a/skills/google-workspace/references/recipe-share-doc-and-notify.md
+++ b/skills/google-workspace/references/recipe-share-doc-and-notify.md
@@ -1,0 +1,9 @@
+# Share a Google Doc and Notify Collaborators
+
+Share a document with edit access and email the link.
+
+## Steps
+
+1. Find the doc: `gws drive files list --params '{"q": "name contains '\''Project Brief'\'' and mimeType = '\''application/vnd.google-apps.document'\''"}'`
+2. Share with editor access: `gws drive permissions create --params '{"fileId": "DOC_ID"}' --json '{"role": "writer", "type": "user", "emailAddress": "reviewer@company.com"}'`
+3. Email the link: `gws gmail +send --to reviewer@company.com --subject 'Please review: Project Brief' --body 'I have shared the project brief with you: https://docs.google.com/document/d/DOC_ID'`

--- a/skills/google-workspace/references/recipe-share-folder-with-team.md
+++ b/skills/google-workspace/references/recipe-share-folder-with-team.md
@@ -1,0 +1,10 @@
+# Share a Google Drive Folder with a Team
+
+Share a folder and all its contents with collaborators.
+
+## Steps
+
+1. Find the folder: `gws drive files list --params '{"q": "name = '\''Project X'\'' and mimeType = '\''application/vnd.google-apps.folder'\''"}'`
+2. Share as editor: `gws drive permissions create --params '{"fileId": "FOLDER_ID"}' --json '{"role": "writer", "type": "user", "emailAddress": "colleague@company.com"}'`
+3. Share as viewer: `gws drive permissions create --params '{"fileId": "FOLDER_ID"}' --json '{"role": "reader", "type": "user", "emailAddress": "stakeholder@company.com"}'`
+4. Verify permissions: `gws drive permissions list --params '{"fileId": "FOLDER_ID"}' --format table`

--- a/skills/google-workspace/references/recipe-sync-contacts-to-sheet.md
+++ b/skills/google-workspace/references/recipe-sync-contacts-to-sheet.md
@@ -1,0 +1,9 @@
+# Export Google Contacts to Sheets
+
+Export Google Contacts directory to a spreadsheet.
+
+## Steps
+
+1. List contacts: `gws people people listDirectoryPeople --params '{"readMask": "names,emailAddresses,phoneNumbers", "sources": ["DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE"], "pageSize": 100}' --format json`
+2. Create headers: `gws sheets +append --spreadsheet SHEET_ID --values 'Name,Email,Phone'`
+3. Append each contact: `gws sheets +append --spreadsheet SHEET_ID --values 'Jane Doe,jane@company.com,+1-555-0100'`

--- a/skills/google-workspace/references/recipe-watch-drive-changes.md
+++ b/skills/google-workspace/references/recipe-watch-drive-changes.md
@@ -1,0 +1,9 @@
+# Watch for Drive Changes
+
+Subscribe to change notifications on a Drive file or folder.
+
+## Steps
+
+1. Create subscription: `gws events subscriptions create --json '{"targetResource": "//drive.googleapis.com/drives/DRIVE_ID", "eventTypes": ["google.workspace.drive.file.v1.updated"], "notificationEndpoint": {"pubsubTopic": "projects/PROJECT/topics/TOPIC"}, "payloadOptions": {"includeResource": true}}'`
+2. List active subscriptions: `gws events subscriptions list`
+3. Renew before expiry: `gws events +renew --name SUBSCRIPTION_ID`


### PR DESCRIPTION
## Summary

Adds a comprehensive `google-workspace` skill for the [`gws` CLI](https://github.com/googleworkspace/cli) (v0.16.0+).

### Structure

```
skills/google-workspace/
├── SKILL.md                              # Main skill (auth, syntax, flags, index)
└── references/                           # 76 reference files
    ├── gws-shared.md                     # Shared patterns
    ├── gws-{drive,sheets,gmail,...}.md    # 14 service APIs
    ├── gws-{drive-upload,...}.md          # 21 helper shortcuts
    ├── persona-{exec-assistant,...}.md    # 10 role-based personas
    └── recipe-{label-and-archive,...}.md  # 30 multi-step recipes
```

### What's included

- **14 services:** Drive, Sheets, Gmail, Docs, Slides, People, Chat, Meet, Forms, Admin Reports, Events, Keep, Model Armor, Workflow
- **21 helpers:** upload, read, append, send, triage, reply, reply-all, forward, watch, write, chat send, events subscribe/renew, model armor (3), workflow (5)
- **10 personas:** Exec Assistant, Project Manager, Team Lead, Sales Ops, Content Creator, Event Coordinator, Customer Support, HR Coordinator, IT Admin, Researcher
- **30 recipes:** Gmail (7), Drive (7), Sheets (7), Cross-service (9)

### Design decisions

- **Calendar and Tasks excluded as standalone services** — not in current auth scopes. Available via workflow helpers (`+standup-report`, `+meeting-prep`, `+weekly-digest`, `+email-to-task`, `+file-announce`)
- **Personas reference calendar naturally** ("check your calendar") but use no `gws calendar` or `gws tasks` commands directly
- **Progressive disclosure** — SKILL.md is a lean index; detailed API docs, flags, and examples are in reference files loaded on demand
- Based on upstream skills from https://github.com/googleworkspace/cli/blob/main/docs/skills.md

### Task

td-ec78bd