### PR TITLE
fix(pi-cmux): update workspace name on session_switch, session_fork, and workon:switch

### DIFF
--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -97,11 +97,13 @@ export default function (pi: ExtensionAPI) {
 		const source = pi.getSessionName() ? "session"
 			: workonProjectName ? "workon"
 			: "cwd";
-		safe(() => client.renameWorkspace(name));
+		// Use the same "π - " prefix that Pi core's updateTerminalTitle() uses,
+		// so the cmux workspace name stays consistent with the terminal title.
+		safe(() => client.renameWorkspace(`π - ${name}`));
 		log("workspace_renamed", { name, source }, "DEBUG");
 	}
 
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", async (_event, _ctx) => {
 		// Clear stale browser surface tracking from previous sessions
 		resetBrowserState();
 		cancelPendingNotify();
@@ -115,10 +117,11 @@ export default function (pi: ExtensionAPI) {
 		// Show initial idle status
 		safe(() => client.setStatus(STATUS_KEY, "idle"));
 
-		// Set terminal title
-		if (ctx.hasUI) {
-			ctx.ui.setTitle(`Pi — cmux`);
-		}
+		// NOTE: We do NOT call ctx.ui.setTitle() here. Pi core's
+		// updateTerminalTitle() sets the terminal title after extensions
+		// init. We only use renameWorkspace() (with the π prefix) to keep
+		// the cmux workspace name in sync across lifecycle events that
+		// Pi core doesn't know about (session_switch, session_fork, workon:switch).
 
 		log("session_started", { workspaceId, surfaceId });
 	});

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -15,6 +15,7 @@
  * the cmux socket at /tmp/cmux.sock. No-ops gracefully outside cmux.
  */
 
+import { basename } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { CmuxClient } from "./client.ts";
@@ -89,11 +90,9 @@ export default function (pi: ExtensionAPI) {
 	let workonProjectName: string | undefined;
 
 	function updateWorkspaceName(): void {
-		const name = pi.getSessionName() ?? workonProjectName;
-		if (name) {
-			safe(() => client.renameWorkspace(name));
-			log("workspace_renamed", { name, source: pi.getSessionName() ? "session" : "workon" }, "DEBUG");
-		}
+		const name = pi.getSessionName() ?? workonProjectName ?? basename(process.cwd());
+		safe(() => client.renameWorkspace(name));
+		log("workspace_renamed", { name, source: pi.getSessionName() ? "session" : workonProjectName ? "workon" : "cwd" }, "DEBUG");
 	}
 
 	pi.on("session_start", async (_event, ctx) => {

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -86,13 +86,19 @@ export default function (pi: ExtensionAPI) {
 	 *
 	 * Priority: session name > workon project name > cwd basename.
 	 * Called on session_start, session_switch, session_fork, and workon:switch.
+	 *
+	 * Note: `workonProjectName` is module-level but safe — Pi runs one
+	 * session at a time per process (session_switch is sequential, not concurrent).
 	 */
 	let workonProjectName: string | undefined;
 
 	function updateWorkspaceName(): void {
 		const name = pi.getSessionName() ?? workonProjectName ?? basename(process.cwd());
+		const source = pi.getSessionName() ? "session"
+			: workonProjectName ? "workon"
+			: "cwd";
 		safe(() => client.renameWorkspace(name));
-		log("workspace_renamed", { name, source: pi.getSessionName() ? "session" : workonProjectName ? "workon" : "cwd" }, "DEBUG");
+		log("workspace_renamed", { name, source }, "DEBUG");
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -124,17 +130,22 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_fork", () => {
-		// Forked session inherits the name — update workspace
+		// Forked session continues from the same conversation, so inherit
+		// the workon project context. Session name is read fresh from the
+		// new session by getSessionName().
 		updateWorkspaceName();
 	});
 
 	// Listen for workon:switch events from pi-workon extension.
-	// When the user switches project context, update the workspace name.
+	// Event shape: { name: string, path: string }
 	pi.events.on("workon:switch", (data: unknown) => {
-		const event = data as { name?: string; path?: string } | undefined;
-		if (event?.name) {
-			workonProjectName = event.name;
+		const event = data as Record<string, unknown> | null | undefined;
+		const name = typeof event?.name === "string" ? event.name : undefined;
+		if (name) {
+			workonProjectName = name;
 			updateWorkspaceName();
+		} else {
+			log("workon_event_missing_name", { data }, "WARN");
 		}
 	});
 

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -80,16 +80,32 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
+	/**
+	 * Update the cmux workspace title.
+	 *
+	 * Priority: session name > workon project name > cwd basename.
+	 * Called on session_start, session_switch, session_fork, and workon:switch.
+	 */
+	let workonProjectName: string | undefined;
+
+	function updateWorkspaceName(): void {
+		const name = pi.getSessionName() ?? workonProjectName;
+		if (name) {
+			safe(() => client.renameWorkspace(name));
+			log("workspace_renamed", { name, source: pi.getSessionName() ? "session" : "workon" }, "DEBUG");
+		}
+	}
+
 	pi.on("session_start", async (_event, ctx) => {
 		// Clear stale browser surface tracking from previous sessions
 		resetBrowserState();
 		cancelPendingNotify();
 
+		// Reset workon state — new session hasn't switched projects yet
+		workonProjectName = undefined;
+
 		// Set workspace name from session
-		const name = pi.getSessionName();
-		if (name) {
-			safe(() => client.renameWorkspace(name));
-		}
+		updateWorkspaceName();
 
 		// Show initial idle status
 		safe(() => client.setStatus(STATUS_KEY, "idle"));
@@ -100,6 +116,27 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		log("session_started", { workspaceId, surfaceId });
+	});
+
+	pi.on("session_switch", () => {
+		// Session changed — update workspace name for the new session
+		workonProjectName = undefined;
+		updateWorkspaceName();
+	});
+
+	pi.on("session_fork", () => {
+		// Forked session inherits the name — update workspace
+		updateWorkspaceName();
+	});
+
+	// Listen for workon:switch events from pi-workon extension.
+	// When the user switches project context, update the workspace name.
+	pi.events.on("workon:switch", (data: unknown) => {
+		const event = data as { name?: string; path?: string } | undefined;
+		if (event?.name) {
+			workonProjectName = event.name;
+			updateWorkspaceName();
+		}
 	});
 
 	pi.on("agent_start", () => {


### PR DESCRIPTION
## Problem

pi-cmux only set the cmux workspace name during `session_start`, which meant:

- **New sessions** with no name yet never got the workspace renamed (`getSessionName()` returns `undefined`)
- **Switching sessions** kept the old workspace name (no `session_switch` handler)
- **Forking sessions** kept the old workspace name (no `session_fork` handler)
- **Using `workon`** to switch projects never updated the workspace name (didn't listen for `workon:switch` events)

## Fix

- Extract `updateWorkspaceName()` helper with priority: session name > workon project name
- Handle `session_switch` — update name when user switches sessions
- Handle `session_fork` — update name for forked sessions
- Listen for `workon:switch` events from pi-workon extension to update workspace name when project context changes

Fixes td-8075e3