### PR TITLE
fix(pi-a2a): make ask_owner tool cancellable via abort signal

### DIFF
--- a/extensions/pi-a2a/SKILL.md
+++ b/extensions/pi-a2a/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: a2a
+description: >
+  Communicate with remote agents via A2A protocol, discover available agents,
+  and ask the human owner for clarification via the A2A Hub. Use when asked
+  to send messages to other agents, discover what agents are available, or
+  when you need human input to proceed.
+
+  **Triggers — use this skill when:**
+  - You need human input to proceed (approval, decision, clarification)
+  - User asks to "send a message to another agent"
+  - User asks to "discover agents" or "what agents are available"
+  - You're stuck and need to escalate to the owner
+  - A long-running task needs human approval before continuing
+---
+
+# A2A — Agent-to-Agent Communication & Human-in-the-Loop
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `a2a_discover` | Find remote agents on the hub or static registry |
+| `a2a_send` | Send a message to a remote agent by name, ID, or URL |
+| `ask_owner` | Ask the human owner a question and wait for their response |
+
+---
+
+## ask_owner — Human-in-the-Loop
+
+Use `ask_owner` when you **genuinely cannot proceed** without human input.
+The tool blocks your turn until the owner responds through the hub's web UI.
+
+### When to Use
+
+- **Approval needed** — destructive operations, merging PRs, deploying
+- **Ambiguous requirements** — multiple valid approaches, unclear scope
+- **Escalation** — blocked on something outside your control
+- **Design decisions** — architectural choices with significant trade-offs
+
+### When NOT to Use
+
+- You can make a reasonable decision yourself
+- The answer is in the codebase, docs, or context
+- It's a minor style/formatting choice
+
+### Always Include Handoff Context
+
+**Every `ask_owner` call MUST include the `handoff` parameter.** The owner
+may not respond before your session expires. Without handoff context, all
+progress is lost. The handoff enables a fresh agent to continue the work.
+
+```json
+{
+  "question": "The PR has conflicting review feedback — reviewer A wants JWT, reviewer B wants session tokens. Which approach should I take?",
+  "handoff": {
+    "done": [
+      "Implemented Express server with route scaffolding",
+      "Added user model with Kysely migrations",
+      "PR #45 created on branch td-abc123/auth"
+    ],
+    "remaining": [
+      "Implement auth middleware (blocked on JWT vs sessions decision)",
+      "Write integration tests for auth endpoints",
+      "Update API docs"
+    ],
+    "decisions": [
+      "Using PostgreSQL via Kysely (not SQLite) for production readiness",
+      "Argon2 for password hashing over bcrypt"
+    ],
+    "uncertain": [
+      "JWT vs session tokens — conflicting reviewer feedback",
+      "Whether to support OAuth2 providers in this PR or defer"
+    ],
+    "project": "my-api",
+    "branch": "td-abc123/auth",
+    "taskId": "td-abc123"
+  },
+  "priority": "normal",
+  "timeoutMinutes": 120
+}
+```
+
+### Handoff Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `done` | Yes | What's been completed — be specific (files, commits, PRs) |
+| `remaining` | Yes | What still needs to be done — ordered by priority |
+| `decisions` | If any | Key choices made and why |
+| `uncertain` | If any | Open questions beyond the one being asked |
+| `project` | Yes | Project name or path |
+| `branch` | If applicable | Git branch being worked on |
+| `taskId` | If applicable | td task ID |
+
+### Priority Levels
+
+| Priority | When to use |
+|----------|-------------|
+| `low` | Nice-to-know, no urgency |
+| `normal` | Default — standard question |
+| `urgent` | Blocking critical work, needs fast response |
+
+### Timeout
+
+- Default: 60 minutes
+- Max: 4320 minutes (72 hours)
+- Set longer timeouts for questions the owner might not see immediately
+- The tool is cancellable — Ctrl+C aborts and cancels the hub request
+
+---
+
+## a2a_discover — Find Agents
+
+```json
+{ "q": "search query", "tags": ["coding"], "category": ["development-tools"] }
+```
+
+All parameters are optional. Omit everything to list all agents.
+Returns agent names, descriptions, skills, availability, and health status.
+
+---
+
+## a2a_send — Message an Agent
+
+```json
+{ "agent": "Agent Name", "message": "Your request here" }
+```
+
+The `agent` field accepts:
+- Agent name (from `a2a_discover` results)
+- Agent ID (UUID from hub)
+- Direct URL (`https://...`)
+
+The response arrives asynchronously — you'll see it when it comes back.
+If the remote agent acknowledges but needs time, you'll get an ACK and the
+full response arrives later as an inbound message.

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -1062,11 +1062,15 @@ export default function (pi: ExtensionAPI) {
 			 */
 			function cancellableSleep(ms: number): Promise<void> {
 				return new Promise((resolve) => {
-					const timer = setTimeout(resolve, ms);
-					signal?.addEventListener("abort", () => {
+					const onAbort = () => {
 						clearTimeout(timer);
 						resolve();
-					}, { once: true });
+					};
+					const timer = setTimeout(() => {
+						signal?.removeEventListener("abort", onAbort);
+						resolve();
+					}, ms);
+					signal?.addEventListener("abort", onAbort, { once: true });
 				});
 			}
 

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -999,7 +999,7 @@ export default function (pi: ExtensionAPI) {
 			priority: Type.Optional(Type.Union([Type.Literal("low"), Type.Literal("normal"), Type.Literal("urgent")], { description: "Priority level. Default: normal" })),
 			timeoutMinutes: Type.Optional(Type.Number({ description: "How long to wait for a response in minutes. Default: 60, max: 4320 (72 hours)" })),
 		}),
-		async execute(_toolCallId, params) {
+		async execute(_toolCallId, params, signal) {
 			const { config } = loadConfig(cwd);
 			const hubConfig = config.hub;
 
@@ -1038,7 +1038,7 @@ export default function (pi: ExtensionAPI) {
 
 			log("ask_owner_waiting", { clarificationId, question: question.slice(0, 100), timeoutMinutes });
 
-			// Poll until answered, expired, cancelled, or timeout.
+			// Poll until answered, expired, cancelled, abort, or timeout.
 			// Capture hubAgentId now — session_start resets it to null,
 			// and we need the original value for cancel/poll calls.
 			// Safe to assert non-null: guarded by the hubAgentId check above.
@@ -1046,19 +1046,58 @@ export default function (pi: ExtensionAPI) {
 			const deadline = Date.now() + timeoutMs;
 			const myToken = sessionToken;
 
+			/**
+			 * Cancellable sleep that resolves on timeout OR when the abort
+			 * signal fires, whichever comes first.
+			 */
+			function cancellableSleep(ms: number): Promise<void> {
+				return new Promise((resolve) => {
+					const timer = setTimeout(resolve, ms);
+					signal?.addEventListener("abort", () => {
+						clearTimeout(timer);
+						resolve();
+					}, { once: true });
+				});
+			}
+
+			/** Cancel the hub request and return a result. */
+			async function cancelAndReturn(reason: string, logEvent: string): Promise<ReturnType<typeof txt>> {
+				await cancelClarification(capturedAgentId, clarificationId, hubConfig!, log);
+				log(logEvent, { clarificationId });
+				return txt(reason);
+			}
+
 			while (Date.now() < deadline) {
-				// Abort if session restarted while we were waiting
-				if (sessionToken !== myToken) {
-					await cancelClarification(capturedAgentId, clarificationId, hubConfig, log);
-					return txt("⚠️ Session restarted — clarification request cancelled.");
+				// Abort if user cancelled (Ctrl+C / Escape)
+				if (signal?.aborted) {
+					return cancelAndReturn(
+						"🚫 Cancelled — clarification request withdrawn.",
+						"ask_owner_aborted",
+					);
 				}
 
-				await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-
-				// Check again after sleep
+				// Abort if session restarted while we were waiting
 				if (sessionToken !== myToken) {
-					await cancelClarification(capturedAgentId, clarificationId, hubConfig, log);
-					return txt("⚠️ Session restarted — clarification request cancelled.");
+					return cancelAndReturn(
+						"⚠️ Session restarted — clarification request cancelled.",
+						"ask_owner_session_reset",
+					);
+				}
+
+				await cancellableSleep(pollIntervalMs);
+
+				// Re-check abort after sleep
+				if (signal?.aborted) {
+					return cancelAndReturn(
+						"🚫 Cancelled — clarification request withdrawn.",
+						"ask_owner_aborted",
+					);
+				}
+				if (sessionToken !== myToken) {
+					return cancelAndReturn(
+						"⚠️ Session restarted — clarification request cancelled.",
+						"ask_owner_session_reset",
+					);
 				}
 
 				const poll = await pollClarification(capturedAgentId, clarificationId, hubConfig, log);

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -996,6 +996,15 @@ export default function (pi: ExtensionAPI) {
 		parameters: Type.Object({
 			question: Type.String({ description: "The question to ask the owner (max 2000 chars)" }),
 			context: Type.Optional(Type.Object({}, { additionalProperties: true, description: "Optional structured metadata to help the owner understand the context" })),
+			handoff: Type.Optional(Type.Object({
+				done: Type.Optional(Type.Array(Type.String(), { description: "What has been completed so far" })),
+				remaining: Type.Optional(Type.Array(Type.String(), { description: "What still needs to be done" })),
+				decisions: Type.Optional(Type.Array(Type.String(), { description: "Key decisions made during this session" })),
+				uncertain: Type.Optional(Type.Array(Type.String(), { description: "Open questions or areas of uncertainty" })),
+				project: Type.Optional(Type.String({ description: "Project name or path for context" })),
+				branch: Type.Optional(Type.String({ description: "Git branch being worked on" })),
+				taskId: Type.Optional(Type.String({ description: "td task ID if applicable" })),
+			}, { additionalProperties: true, description: "Structured handoff context so work can resume in a new session if the current one expires. Include what's done, what remains, key decisions, and open questions." })),
 			priority: Type.Optional(Type.Union([Type.Literal("low"), Type.Literal("normal"), Type.Literal("urgent")], { description: "Priority level. Default: normal" })),
 			timeoutMinutes: Type.Optional(Type.Number({ description: "How long to wait for a response in minutes. Default: 60, max: 4320 (72 hours)" })),
 		}),
@@ -1023,6 +1032,7 @@ export default function (pi: ExtensionAPI) {
 				log,
 				{
 					context: params.context,
+					handoff: params.handoff,
 					priority: params.priority,
 				},
 			);


### PR DESCRIPTION
## Problem

The `ask_owner` tool blocked the TUI with an uncancellable polling loop. The `execute()` function ignored the `signal` (AbortSignal) parameter, so Ctrl+C and Escape had no effect — the user was stuck until timeout or owner reply.

## Fix

- Accept the `signal` parameter in `execute()`
- Replace bare `setTimeout` sleep with `cancellableSleep()` that resolves immediately when the signal fires
- Check `signal.aborted` before and after each sleep cycle
- Cancel the hub clarification request on abort so it doesn't linger
- Extract `cancelAndReturn()` helper to DRY the cleanup+log+return pattern
- Add distinct log events: `ask_owner_aborted` vs `ask_owner_session_reset`

Fixes td-90a2dc