### PR TITLE
fix(pi-cmux): remove competing workspace/title setters that race with pi core

### DIFF
--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -80,24 +80,21 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", async (_event, _ctx) => {
 		// Clear stale browser surface tracking from previous sessions
 		resetBrowserState();
 		cancelPendingNotify();
 
-		// Set workspace name from session
-		const name = pi.getSessionName();
-		if (name) {
-			safe(() => client.renameWorkspace(name));
-		}
-
 		// Show initial idle status
 		safe(() => client.setStatus(STATUS_KEY, "idle"));
 
-		// Set terminal title
-		if (ctx.hasUI) {
-			ctx.ui.setTitle(`Pi — cmux`);
-		}
+		// NOTE: We intentionally do NOT call renameWorkspace() or ctx.ui.setTitle()
+		// here. Pi core's updateTerminalTitle() sets the terminal title to
+		// "π - ${sessionName} - ${cwdBasename}" after extensions init, and cmux
+		// derives the workspace name from the terminal title. Calling
+		// renameWorkspace(name) without the "π - " prefix, or setTitle() with a
+		// hardcoded string, would race with the core title and produce
+		// inconsistent workspace names.
 
 		log("session_started", { workspaceId, surfaceId });
 	});


### PR DESCRIPTION
## Problem

Pi-cmux's `session_start` handler had two calls that raced with pi core's `updateTerminalTitle()`:

1. `ctx.ui.setTitle('Pi — cmux')` — synchronous OSC write that sometimes overwrote the core title
2. `client.renameWorkspace(name)` — async fire-and-forget RPC that renamed the workspace without the `π - ` prefix

Since `updateTerminalTitle()` runs after `initExtensions()` resolves, and `renameWorkspace()` is async, the timing was unpredictable. Some workspaces got the correct `π - project` name, others got just the raw session name or `Pi — cmux`.

## Fix

Remove both competing calls. Pi core owns the terminal title (`π - ${sessionName} - ${cwdBasename}`), and cmux derives the workspace name from it. No need for the extension to duplicate or fight this.

Closes td-be0f4e