### PR TITLE
feat(pi-a2a): make ask_owner non-blocking with background poller

### DIFF
--- a/extensions/pi-a2a/SKILL.md
+++ b/extensions/pi-a2a/SKILL.md
@@ -22,14 +22,30 @@ description: >
 |------|---------|
 | `a2a_discover` | Find remote agents on the hub or static registry |
 | `a2a_send` | Send a message to a remote agent by name, ID, or URL |
-| `ask_owner` | Ask the human owner a question and wait for their response |
+| `ask_owner` | Ask the human owner a question (non-blocking) |
 
 ---
 
 ## ask_owner — Human-in-the-Loop
 
 Use `ask_owner` when you **genuinely cannot proceed** without human input.
-The tool blocks your turn until the owner responds through the hub's web UI.
+The tool submits your question to the hub and **returns immediately** — it
+does NOT block your session. When the owner responds, a **fresh pi
+subprocess** is automatically spawned with your handoff context + the
+owner's answer to continue the work.
+
+### How It Works
+
+1. You call `ask_owner` with a question + handoff context
+2. The question is submitted to the A2A Hub — you get an immediate confirmation
+3. You continue with other work or end your session
+4. The owner answers through the hub's web UI (could be minutes or hours later)
+5. A background poller detects the response
+6. A fresh `pi` subprocess is spawned with a self-contained prompt containing:
+   - The original question
+   - The owner's response
+   - Your full handoff context (done, remaining, decisions, etc.)
+7. The new session picks up where you left off — no prior conversation context needed
 
 ### When to Use
 
@@ -46,9 +62,9 @@ The tool blocks your turn until the owner responds through the hub's web UI.
 
 ### Always Include Handoff Context
 
-**Every `ask_owner` call MUST include the `handoff` parameter.** The owner
-may not respond before your session expires. Without handoff context, all
-progress is lost. The handoff enables a fresh agent to continue the work.
+**Every `ask_owner` call MUST include the `handoff` parameter.** The response
+will be handled by a completely fresh session with zero prior context. Without
+handoff context, the new session has no idea what to do.
 
 ```json
 {
@@ -76,8 +92,7 @@ progress is lost. The handoff enables a fresh agent to continue the work.
     "branch": "td-abc123/auth",
     "taskId": "td-abc123"
   },
-  "priority": "normal",
-  "timeoutMinutes": 120
+  "priority": "normal"
 }
 ```
 
@@ -89,7 +104,7 @@ progress is lost. The handoff enables a fresh agent to continue the work.
 | `remaining` | Yes | What still needs to be done — ordered by priority |
 | `decisions` | If any | Key choices made and why |
 | `uncertain` | If any | Open questions beyond the one being asked |
-| `project` | Yes | Project name or path |
+| `project` | Yes | Project name or absolute path to project root |
 | `branch` | If applicable | Git branch being worked on |
 | `taskId` | If applicable | td task ID |
 
@@ -101,12 +116,32 @@ progress is lost. The handoff enables a fresh agent to continue the work.
 | `normal` | Default — standard question |
 | `urgent` | Blocking critical work, needs fast response |
 
-### Timeout
+### Poller Configuration
 
-- Default: 60 minutes
-- Max: 4320 minutes (72 hours)
-- Set longer timeouts for questions the owner might not see immediately
-- The tool is cancellable — Ctrl+C aborts and cancels the hub request
+The background poller must be enabled in `settings.json` for responses to be
+automatically processed:
+
+```json
+{
+  "pi-a2a": {
+    "poller": {
+      "enabled": true,
+      "intervalSeconds": 60,
+      "extensions": ["extensions/pi-github", "extensions/pi-memory"],
+      "skills": ["td", "github", "code-review"],
+      "model": "claude-sonnet-4-5"
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `false` | Enable the poller |
+| `intervalSeconds` | `60` | Poll interval (15–600) |
+| `extensions` | `[]` | Extension paths for spawned subprocesses |
+| `skills` | `[]` | Skill paths for spawned subprocesses |
+| `model` | (default) | Model override for spawned subprocesses |
 
 ---
 

--- a/extensions/pi-a2a/SKILL.md
+++ b/extensions/pi-a2a/SKILL.md
@@ -143,6 +143,14 @@ automatically processed:
 | `skills` | `[]` | Skill paths for spawned subprocesses |
 | `model` | (default) | Model override for spawned subprocesses |
 
+### Security Note
+
+The poller spawns `pi` subprocesses with full tool access, using prompts
+built entirely from hub-returned data (question, response, handoff context).
+**Hub compromise = arbitrary code execution on the agent host.** Use HTTPS
+for `hub.url` in production. The `handoff.project` path is validated (must
+exist and be a directory) before being used as the subprocess working directory.
+
 ---
 
 ## a2a_discover — Find Agents

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -424,7 +424,7 @@ export async function acknowledgeClarification(
 
 	const result = await hubRpc(rpcUrl, "clarification.acknowledge", { agentId, clarificationId }, hubConfig.apiKey, log, "hub_clarification_acknowledge");
 	if (result) {
-		const acknowledged = result.acknowledged as boolean ?? true;
+		const acknowledged = (result.acknowledged as boolean) ?? false;
 		log("hub_clarification_acknowledge_result", { clarificationId, acknowledged });
 		return acknowledged;
 	}

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -360,6 +360,77 @@ export async function cancelClarification(
 	return result !== null;
 }
 
+// ── Answered clarification types ─────────────────────────────
+
+export interface AnsweredClarification {
+	clarificationId: string;
+	question: string;
+	handoff: Record<string, unknown> | null;
+	context: Record<string, unknown> | null;
+	priority: "low" | "normal" | "urgent";
+	response: string;
+	answeredAt: string;
+	createdAt: string;
+}
+
+/**
+ * List all answered but unacknowledged clarifications for this agent.
+ *
+ * Returns the full payload for each (question, handoff context, owner
+ * response) so a fresh subprocess can resume work without local state.
+ */
+export async function listAnsweredClarifications(
+	agentId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<AnsweredClarification[]> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	log("hub_clarification_list_answered_start", { agentId });
+
+	const result = await hubRpc(rpcUrl, "clarification.list_answered", { agentId }, hubConfig.apiKey, log, "hub_clarification_list_answered");
+	if (result && Array.isArray(result.clarifications)) {
+		const items = (result.clarifications as Record<string, unknown>[]).map((c) => ({
+			clarificationId: c.clarificationId as string,
+			question: c.question as string,
+			handoff: (c.handoff as Record<string, unknown> | null) ?? null,
+			context: (c.context as Record<string, unknown> | null) ?? null,
+			priority: (c.priority as "low" | "normal" | "urgent") ?? "normal",
+			response: c.response as string,
+			answeredAt: c.answeredAt as string,
+			createdAt: c.createdAt as string,
+		}));
+		log("hub_clarification_list_answered_success", { agentId, count: items.length });
+		return items;
+	}
+	return [];
+}
+
+/**
+ * Acknowledge a clarification so it won't appear in future list_answered calls.
+ *
+ * Atomic: if two agents race, only the first acknowledgement succeeds
+ * (subsequent calls return ok but acknowledged=false).
+ */
+export async function acknowledgeClarification(
+	agentId: string,
+	clarificationId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<boolean> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+
+	log("hub_clarification_acknowledge", { agentId, clarificationId });
+
+	const result = await hubRpc(rpcUrl, "clarification.acknowledge", { agentId, clarificationId }, hubConfig.apiKey, log, "hub_clarification_acknowledge");
+	if (result) {
+		const acknowledged = result.acknowledged as boolean ?? true;
+		log("hub_clarification_acknowledge_result", { clarificationId, acknowledged });
+		return acknowledged;
+	}
+	return false;
+}
+
 /**
  * Report telemetry to the A2A Hub.
  *

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -390,16 +390,26 @@ export async function listAnsweredClarifications(
 
 	const result = await hubRpc(rpcUrl, "clarification.list_answered", { agentId }, hubConfig.apiKey, log, "hub_clarification_list_answered");
 	if (result && Array.isArray(result.clarifications)) {
-		const items = (result.clarifications as Record<string, unknown>[]).map((c) => ({
-			clarificationId: c.clarificationId as string,
-			question: c.question as string,
-			handoff: (c.handoff as Record<string, unknown> | null) ?? null,
-			context: (c.context as Record<string, unknown> | null) ?? null,
-			priority: (c.priority as "low" | "normal" | "urgent") ?? "normal",
-			response: c.response as string,
-			answeredAt: c.answeredAt as string,
-			createdAt: c.createdAt as string,
-		}));
+		const items: AnsweredClarification[] = [];
+		for (const c of result.clarifications as Record<string, unknown>[]) {
+			const clarificationId = (c.clarificationId as string) ?? "";
+			// Skip malformed items — without a clarificationId we can't
+			// acknowledge them, which would cause an infinite retry loop.
+			if (!clarificationId) {
+				log("hub_clarification_list_answered_skip_malformed", { raw: JSON.stringify(c).slice(0, 200) }, "WARN");
+				continue;
+			}
+			items.push({
+				clarificationId,
+				question: (c.question as string) ?? "",
+				handoff: (c.handoff as Record<string, unknown> | null) ?? null,
+				context: (c.context as Record<string, unknown> | null) ?? null,
+				priority: (c.priority as "low" | "normal" | "urgent") ?? "normal",
+				response: (c.response as string) ?? "",
+				answeredAt: (c.answeredAt as string) ?? "",
+				createdAt: (c.createdAt as string) ?? "",
+			});
+		}
 		log("hub_clarification_list_answered_success", { agentId, count: items.length });
 		return items;
 	}

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -391,23 +391,29 @@ export async function listAnsweredClarifications(
 	const result = await hubRpc(rpcUrl, "clarification.list_answered", { agentId }, hubConfig.apiKey, log, "hub_clarification_list_answered");
 	if (result && Array.isArray(result.clarifications)) {
 		const items: AnsweredClarification[] = [];
-		for (const c of result.clarifications as Record<string, unknown>[]) {
-			const clarificationId = (c.clarificationId as string) ?? "";
+		for (const c of result.clarifications as unknown[]) {
+			// Guard against null or non-object elements from hub
+			if (!c || typeof c !== "object") {
+				log("hub_clarification_list_answered_skip_non_object", { raw: JSON.stringify(c).slice(0, 100) }, "WARN");
+				continue;
+			}
+			const rec = c as Record<string, unknown>;
+			const clarificationId = (rec.clarificationId as string) ?? "";
 			// Skip malformed items — without a clarificationId we can't
 			// acknowledge them, which would cause an infinite retry loop.
 			if (!clarificationId) {
-				log("hub_clarification_list_answered_skip_malformed", { raw: JSON.stringify(c).slice(0, 200) }, "WARN");
+				log("hub_clarification_list_answered_skip_malformed", { raw: JSON.stringify(rec).slice(0, 200) }, "WARN");
 				continue;
 			}
 			items.push({
 				clarificationId,
-				question: (c.question as string) ?? "",
-				handoff: (c.handoff as Record<string, unknown> | null) ?? null,
-				context: (c.context as Record<string, unknown> | null) ?? null,
-				priority: (c.priority as "low" | "normal" | "urgent") ?? "normal",
-				response: (c.response as string) ?? "",
-				answeredAt: (c.answeredAt as string) ?? "",
-				createdAt: (c.createdAt as string) ?? "",
+				question: (rec.question as string) ?? "",
+				handoff: (rec.handoff as Record<string, unknown> | null) ?? null,
+				context: (rec.context as Record<string, unknown> | null) ?? null,
+				priority: (rec.priority as "low" | "normal" | "urgent") ?? "normal",
+				response: (rec.response as string) ?? "",
+				answeredAt: (rec.answeredAt as string) ?? "",
+				createdAt: (rec.createdAt as string) ?? "",
 			});
 		}
 		log("hub_clarification_list_answered_success", { agentId, count: items.length });

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -34,6 +34,7 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
+import { resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
@@ -796,17 +797,30 @@ export default function (pi: ExtensionAPI) {
 		const prompt = buildClarificationPrompt(c);
 
 		// Determine working directory from handoff context.
-		// Validate that the project path exists and is a directory —
-		// the handoff data comes from the hub and must not be trusted blindly.
+		// Validate that the project path exists, is a directory, and is
+		// under a safe root — the handoff data comes from the hub and must
+		// not be trusted blindly. Restrict to HOME subtree to limit blast
+		// radius even if the hub is compromised.
 		let spawnCwd = cwd;
 		const projectPath = c.handoff?.project as string | undefined;
 		if (projectPath) {
 			try {
-				const stat = statSync(projectPath);
-				if (stat.isDirectory()) {
-					spawnCwd = projectPath;
+				const resolved = resolve(projectPath);
+				const home = process.env.HOME ?? "";
+				const safeRoots = [home, cwd].filter(Boolean);
+				const isSafe = safeRoots.some((root) =>
+					resolved === root || resolved.startsWith(root + "/"),
+				);
+
+				if (!isSafe) {
+					log("poller_rejected_project_path", { clarificationId: c.clarificationId, projectPath, reason: "outside allowed roots" }, "WARN");
 				} else {
-					log("poller_invalid_project_path", { clarificationId: c.clarificationId, projectPath, reason: "not a directory" }, "WARN");
+					const stat = statSync(resolved);
+					if (stat.isDirectory()) {
+						spawnCwd = resolved;
+					} else {
+						log("poller_invalid_project_path", { clarificationId: c.clarificationId, projectPath, reason: "not a directory" }, "WARN");
+					}
 				}
 			} catch {
 				log("poller_invalid_project_path", { clarificationId: c.clarificationId, projectPath, reason: "does not exist" }, "WARN");

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -32,6 +32,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
@@ -46,11 +47,11 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult, type AsyncTaskResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification } from "./hub.ts";
+import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification } from "./hub.ts";
 import { sendA2AMessage, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
-import type { HubConfig, RemoteAgentSummary, TelemetrySnapshot } from "./types.ts";
+import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot } from "./types.ts";
 
 const DEFAULT_PORT = 3100;
 
@@ -133,6 +134,7 @@ export default function (pi: ExtensionAPI) {
 		label: "A2A",
 	});
 	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
+	let pollerInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
 	let staticRegistry: StaticAgentRegistry | null = null;
 	/** This agent's own public A2A URL — included in pi:sender for reply routing. */
@@ -414,6 +416,10 @@ export default function (pi: ExtensionAPI) {
 		}
 		pendingResolve = null;
 		pendingNonce = null;
+		if (pollerInterval) {
+			clearInterval(pollerInterval);
+			pollerInterval = null;
+		}
 		if (telemetryInterval) {
 			clearInterval(telemetryInterval);
 			telemetryInterval = null;
@@ -621,6 +627,9 @@ export default function (pi: ExtensionAPI) {
 				sendTelemetry(config).catch(() => {});
 			}
 		}
+
+		// Start clarification response poller (if configured)
+		startPoller(config);
 	});
 
 	// Re-enrich on first agent turn to catch late-registering extension tools
@@ -642,6 +651,12 @@ export default function (pi: ExtensionAPI) {
 			pendingResolve({ ok: false, response: "", error: "Session shutdown", durationMs: Date.now() - pendingStartTime });
 			pendingResolve = null;
 			pendingNonce = null;
+		}
+
+		// Stop poller interval
+		if (pollerInterval) {
+			clearInterval(pollerInterval);
+			pollerInterval = null;
 		}
 
 		// Stop telemetry interval
@@ -678,6 +693,233 @@ export default function (pi: ExtensionAPI) {
 			await stopServer(log);
 		}
 	});
+
+	// ── Clarification Response Poller ─────────────────────────
+	//
+	// Periodically checks the hub for owner responses to ask_owner questions.
+	// When a response is found, spawns a fresh pi subprocess with the handoff
+	// context + owner answer — completely independent of the current session.
+
+	/** Guard against concurrent poll cycles. */
+	let pollerRunning = false;
+
+	/**
+	 * Build a self-contained prompt for a fresh pi subprocess from an
+	 * answered clarification. Includes full handoff context + owner response.
+	 */
+	function buildClarificationPrompt(c: AnsweredClarification): string {
+		const lines: string[] = [];
+
+		lines.push("# Owner Response — Resume Work\n");
+		lines.push("You are a fresh agent session spawned to handle an owner's response to a previous question.");
+		lines.push("You have NO prior conversation context. Everything you need is below.\n");
+
+		// Owner's Q&A
+		lines.push("## Question Asked");
+		lines.push(`> ${c.question}\n`);
+		lines.push("## Owner's Response");
+		lines.push(c.response);
+		lines.push("");
+
+		// Handoff context
+		if (c.handoff) {
+			const h = c.handoff;
+
+			if (h.project || h.branch || h.taskId) {
+				lines.push("## Project Context");
+				if (h.project) lines.push(`- **Project:** ${h.project}`);
+				if (h.branch) lines.push(`- **Branch:** ${h.branch}`);
+				if (h.taskId) lines.push(`- **Task:** ${h.taskId}`);
+				lines.push("");
+			}
+
+			if (Array.isArray(h.done) && h.done.length > 0) {
+				lines.push("## What's Been Done");
+				for (const item of h.done) lines.push(`- ${item}`);
+				lines.push("");
+			}
+
+			if (Array.isArray(h.remaining) && h.remaining.length > 0) {
+				lines.push("## What's Left");
+				for (const item of h.remaining) lines.push(`- ${item}`);
+				lines.push("");
+			}
+
+			if (Array.isArray(h.decisions) && h.decisions.length > 0) {
+				lines.push("## Key Decisions");
+				for (const item of h.decisions) lines.push(`- ${item}`);
+				lines.push("");
+			}
+
+			if (Array.isArray(h.uncertain) && h.uncertain.length > 0) {
+				lines.push("## Open Questions");
+				for (const item of h.uncertain) lines.push(`- ${item}`);
+				lines.push("");
+			}
+
+			// Include any extra handoff fields not in the standard schema
+			const standardKeys = new Set(["done", "remaining", "decisions", "uncertain", "project", "branch", "taskId"]);
+			const extraKeys = Object.keys(h).filter((k) => !standardKeys.has(k));
+			if (extraKeys.length > 0) {
+				lines.push("## Additional Context");
+				for (const key of extraKeys) {
+					const val = typeof h[key] === "string" ? h[key] : JSON.stringify(h[key]);
+					lines.push(`- **${key}:** ${val}`);
+				}
+				lines.push("");
+			}
+		}
+
+		// Additional context metadata
+		if (c.context && Object.keys(c.context).length > 0) {
+			lines.push("## Metadata");
+			lines.push("```json");
+			lines.push(JSON.stringify(c.context, null, 2));
+			lines.push("```");
+			lines.push("");
+		}
+
+		lines.push("## Instructions");
+		lines.push("Use the owner's response and the handoff context above to continue the work.");
+		lines.push("Start by reading the relevant files and understanding the current state, then proceed with the remaining tasks.");
+
+		return lines.join("\n");
+	}
+
+	/**
+	 * Spawn a fresh pi subprocess to handle an answered clarification.
+	 * The subprocess runs in the project directory with configured extensions/skills.
+	 */
+	function spawnClarificationHandler(c: AnsweredClarification, pollerConfig: PollerConfig): void {
+		const prompt = buildClarificationPrompt(c);
+
+		// Determine working directory from handoff context
+		const projectPath = c.handoff?.project as string | undefined;
+		const spawnCwd = projectPath ?? cwd;
+
+		// Build pi command args
+		const args: string[] = ["-p", prompt];
+
+		// Disable extension/skill discovery — only load what's configured
+		args.push("-ne", "-ns");
+
+		// Add configured extensions
+		if (pollerConfig.extensions?.length) {
+			for (const ext of pollerConfig.extensions) {
+				args.push("-e", ext);
+			}
+		}
+
+		// Add configured skills
+		if (pollerConfig.skills?.length) {
+			for (const skill of pollerConfig.skills) {
+				args.push("--skill", skill);
+			}
+		}
+
+		// Model override
+		if (pollerConfig.model) {
+			args.push("--model", pollerConfig.model);
+		}
+
+		// Don't save session — these are ephemeral
+		args.push("--no-session");
+
+		log("poller_spawn", {
+			clarificationId: c.clarificationId,
+			cwd: spawnCwd,
+			extensions: pollerConfig.extensions ?? [],
+			skills: pollerConfig.skills ?? [],
+			model: pollerConfig.model ?? "default",
+			promptLength: prompt.length,
+		});
+
+		const child = spawn("pi", args, {
+			cwd: spawnCwd,
+			stdio: "ignore",
+			detached: true,
+			env: {
+				...process.env,
+				// Don't inherit cmux env — subprocess is independent
+				CMUX_WORKSPACE_ID: undefined,
+				CMUX_SURFACE_ID: undefined,
+			},
+		});
+
+		child.on("error", (err) => {
+			log("poller_spawn_error", { clarificationId: c.clarificationId, error: err.message }, "ERROR");
+		});
+
+		child.on("exit", (code) => {
+			log("poller_spawn_exit", { clarificationId: c.clarificationId, exitCode: code });
+		});
+
+		// Detach — don't let the child keep this process alive
+		child.unref();
+	}
+
+	/**
+	 * Run one poll cycle: check hub for answered clarifications,
+	 * spawn handlers, and acknowledge.
+	 */
+	async function pollForClarificationResponses(): Promise<void> {
+		if (pollerRunning || !hubAgentId) return;
+		pollerRunning = true;
+
+		try {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+			const pollerConfig = config.poller;
+			if (!hubConfig || !pollerConfig?.enabled) return;
+
+			const answered = await listAnsweredClarifications(hubAgentId, hubConfig, log);
+			if (answered.length === 0) return;
+
+			log("poller_found_answers", { count: answered.length });
+
+			for (const c of answered) {
+				// Acknowledge first — atomic, prevents double-processing
+				const acked = await acknowledgeClarification(hubAgentId!, c.clarificationId, hubConfig, log);
+				if (!acked) {
+					log("poller_acknowledge_failed", { clarificationId: c.clarificationId }, "WARN");
+					continue;
+				}
+
+				// Spawn a fresh pi subprocess
+				spawnClarificationHandler(c, pollerConfig);
+			}
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			log("poller_error", { error: msg }, "WARN");
+		} finally {
+			pollerRunning = false;
+		}
+	}
+
+	/**
+	 * Start the background poller if configured.
+	 * Called from session_start after hub registration.
+	 */
+	function startPoller(config: ReturnType<typeof loadConfig>["config"]): void {
+		if (pollerInterval) {
+			clearInterval(pollerInterval);
+			pollerInterval = null;
+		}
+
+		const pollerConfig = config.poller;
+		if (!pollerConfig?.enabled || !config.hub?.apiKey) return;
+
+		const intervalSec = Math.min(Math.max(pollerConfig.intervalSeconds ?? 60, 15), 600);
+		const intervalMs = intervalSec * 1000;
+
+		log("poller_started", { intervalSeconds: intervalSec, extensions: pollerConfig.extensions ?? [], skills: pollerConfig.skills ?? [] });
+
+		// Run an initial poll immediately, then on interval
+		pollForClarificationResponses().catch(() => {});
+		pollerInterval = setInterval(() => {
+			pollForClarificationResponses().catch(() => {});
+		}, intervalMs);
+	}
 
 	// ── Tools ─────────────────────────────────────────────────
 
@@ -991,8 +1233,11 @@ export default function (pi: ExtensionAPI) {
 		description:
 			"Ask your human owner a question via the A2A Hub when you need clarification, " +
 			"a decision, or approval to proceed. The owner answers through the hub's web UI. " +
-			"This tool blocks until the owner responds (or timeout/expiry). " +
-			"Use sparingly — only when you genuinely cannot proceed without human input.",
+			"This tool returns immediately — it does NOT block. When the owner responds, " +
+			"a fresh pi subprocess is automatically spawned with your handoff context and " +
+			"the owner's answer to continue the work. Include thorough handoff context " +
+			"(done, remaining, decisions, project, branch, taskId) so the new session " +
+			"can pick up where you left off.",
 		parameters: Type.Object({
 			question: Type.String({ description: "The question to ask the owner (max 2000 chars)" }),
 			context: Type.Optional(Type.Object({}, { additionalProperties: true, description: "Optional structured metadata to help the owner understand the context" })),
@@ -1004,11 +1249,10 @@ export default function (pi: ExtensionAPI) {
 				project: Type.Optional(Type.String({ description: "Project name or path for context" })),
 				branch: Type.Optional(Type.String({ description: "Git branch being worked on" })),
 				taskId: Type.Optional(Type.String({ description: "td task ID if applicable" })),
-			}, { additionalProperties: true, description: "Structured handoff context so work can resume in a new session if the current one expires. Include what's done, what remains, key decisions, and open questions." })),
+			}, { additionalProperties: true, description: "Structured handoff context so work can resume in a fresh session. Include what's done, what remains, key decisions, and open questions. This is critical — the new session has no prior context." })),
 			priority: Type.Optional(Type.Union([Type.Literal("low"), Type.Literal("normal"), Type.Literal("urgent")], { description: "Priority level. Default: normal" })),
-			timeoutMinutes: Type.Optional(Type.Number({ description: "How long to wait for a response in minutes. Default: 60, max: 4320 (72 hours)" })),
 		}),
-		async execute(_toolCallId, params, signal) {
+		async execute(_toolCallId, params) {
 			const { config } = loadConfig(cwd);
 			const hubConfig = config.hub;
 
@@ -1020,11 +1264,8 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			const question = params.question.slice(0, 2000);
-			const timeoutMinutes = Math.min(Math.max(params.timeoutMinutes ?? 60, 1), 4320);
-			const timeoutMs = timeoutMinutes * 60 * 1000;
-			const pollIntervalMs = 15_000; // 15 seconds
 
-			// Submit the clarification request
+			// Submit the clarification request — non-blocking
 			const clarification = await requestClarification(
 				hubAgentId,
 				question,
@@ -1043,108 +1284,22 @@ export default function (pi: ExtensionAPI) {
 
 			const { clarificationId } = clarification;
 			const expiryNote = clarification.expiresAt
-				? ` (expires ${clarification.expiresAt})`
+				? ` Expires: ${clarification.expiresAt}.`
 				: "";
 
-			log("ask_owner_waiting", { clarificationId, question: question.slice(0, 100), timeoutMinutes });
+			log("ask_owner_submitted", { clarificationId, question: question.slice(0, 100) });
 
-			// Poll until answered, expired, cancelled, abort, or timeout.
-			// Capture hubAgentId now — session_start resets it to null,
-			// and we need the original value for cancel/poll calls.
-			// Safe to assert non-null: guarded by the hubAgentId check above.
-			const capturedAgentId = hubAgentId!;
-			const deadline = Date.now() + timeoutMs;
-			const myToken = sessionToken;
+			const pollerEnabled = config.poller?.enabled;
+			const pollerNote = pollerEnabled
+				? "The background poller will automatically spawn a fresh session when the owner responds."
+				: "⚠️ The poller is not enabled — set `pi-a2a.poller.enabled: true` in settings.json to auto-process responses.";
 
-			/**
-			 * Cancellable sleep that resolves on timeout OR when the abort
-			 * signal fires, whichever comes first.
-			 */
-			function cancellableSleep(ms: number): Promise<void> {
-				return new Promise((resolve) => {
-					const onAbort = () => {
-						clearTimeout(timer);
-						resolve();
-					};
-					const timer = setTimeout(() => {
-						signal?.removeEventListener("abort", onAbort);
-						resolve();
-					}, ms);
-					signal?.addEventListener("abort", onAbort, { once: true });
-				});
-			}
-
-			/** Cancel the hub request and return a result. */
-			async function cancelAndReturn(reason: string, logEvent: string): Promise<ReturnType<typeof txt>> {
-				await cancelClarification(capturedAgentId, clarificationId, hubConfig!, log);
-				log(logEvent, { clarificationId });
-				return txt(reason);
-			}
-
-			while (Date.now() < deadline) {
-				// Abort if user cancelled (Ctrl+C / Escape)
-				if (signal?.aborted) {
-					return cancelAndReturn(
-						"🚫 Cancelled — clarification request withdrawn.",
-						"ask_owner_aborted",
-					);
-				}
-
-				// Abort if session restarted while we were waiting
-				if (sessionToken !== myToken) {
-					return cancelAndReturn(
-						"⚠️ Session restarted — clarification request cancelled.",
-						"ask_owner_session_reset",
-					);
-				}
-
-				await cancellableSleep(pollIntervalMs);
-
-				// Re-check abort after sleep
-				if (signal?.aborted) {
-					return cancelAndReturn(
-						"🚫 Cancelled — clarification request withdrawn.",
-						"ask_owner_aborted",
-					);
-				}
-				if (sessionToken !== myToken) {
-					return cancelAndReturn(
-						"⚠️ Session restarted — clarification request cancelled.",
-						"ask_owner_session_reset",
-					);
-				}
-
-				const poll = await pollClarification(capturedAgentId, clarificationId, hubConfig, log);
-
-				if (!poll) {
-					// Network error — keep trying until timeout
-					log("ask_owner_poll_error", { clarificationId }, "WARN");
-					continue;
-				}
-
-				switch (poll.status) {
-					case "answered":
-						log("ask_owner_answered", { clarificationId, responseLength: poll.response?.length ?? 0 });
-						return txt(`✅ **Owner responded:**\n\n${poll.response}`);
-
-					case "expired":
-						log("ask_owner_expired", { clarificationId });
-						return txt(`⏰ Clarification request expired${expiryNote}. The owner did not respond in time. Proceed with your best judgment or try again.`);
-
-					case "cancelled":
-						log("ask_owner_cancelled", { clarificationId });
-						return txt("🚫 Clarification request was cancelled. Proceed with your best judgment or try again.");
-
-					case "pending":
-						// Still waiting — continue polling
-						break;
-				}
-			}
-
-			// Timeout reached — cancel the pending request
-			await cancelClarification(capturedAgentId, clarificationId, hubConfig, log);
-			log("ask_owner_timeout", { clarificationId, timeoutMinutes });
-			return txt(`⏰ Timed out after ${timeoutMinutes} minute(s) waiting for owner response. The clarification request has been cancelled. Proceed with your best judgment or try again with a longer timeout.`);
+			return txt(
+				`📤 **Question submitted to owner** (id: ${clarificationId})\n\n` +
+				`> ${question}\n\n` +
+				`${pollerNote}${expiryNote}\n\n` +
+				`You can continue with other work — this does not block.`,
+			);
 		},
 	});
 

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -33,6 +33,7 @@
 
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
@@ -420,6 +421,7 @@ export default function (pi: ExtensionAPI) {
 			clearInterval(pollerInterval);
 			pollerInterval = null;
 		}
+		pollerRunning = false;
 		if (telemetryInterval) {
 			clearInterval(telemetryInterval);
 			telemetryInterval = null;
@@ -793,9 +795,23 @@ export default function (pi: ExtensionAPI) {
 	function spawnClarificationHandler(c: AnsweredClarification, pollerConfig: PollerConfig): void {
 		const prompt = buildClarificationPrompt(c);
 
-		// Determine working directory from handoff context
+		// Determine working directory from handoff context.
+		// Validate that the project path exists and is a directory —
+		// the handoff data comes from the hub and must not be trusted blindly.
+		let spawnCwd = cwd;
 		const projectPath = c.handoff?.project as string | undefined;
-		const spawnCwd = projectPath ?? cwd;
+		if (projectPath) {
+			try {
+				const stat = statSync(projectPath);
+				if (stat.isDirectory()) {
+					spawnCwd = projectPath;
+				} else {
+					log("poller_invalid_project_path", { clarificationId: c.clarificationId, projectPath, reason: "not a directory" }, "WARN");
+				}
+			} catch {
+				log("poller_invalid_project_path", { clarificationId: c.clarificationId, projectPath, reason: "does not exist" }, "WARN");
+			}
+		}
 
 		// Build pi command args
 		const args: string[] = ["-p", prompt];
@@ -866,20 +882,24 @@ export default function (pi: ExtensionAPI) {
 		if (pollerRunning || !hubAgentId) return;
 		pollerRunning = true;
 
+		// Snapshot hubAgentId — session_start can reset it to null between
+		// any await points. Using a local const avoids stale references.
+		const agentId = hubAgentId;
+
 		try {
 			const { config } = loadConfig(cwd);
 			const hubConfig = config.hub;
 			const pollerConfig = config.poller;
 			if (!hubConfig || !pollerConfig?.enabled) return;
 
-			const answered = await listAnsweredClarifications(hubAgentId, hubConfig, log);
+			const answered = await listAnsweredClarifications(agentId, hubConfig, log);
 			if (answered.length === 0) return;
 
 			log("poller_found_answers", { count: answered.length });
 
 			for (const c of answered) {
 				// Acknowledge first — atomic, prevents double-processing
-				const acked = await acknowledgeClarification(hubAgentId!, c.clarificationId, hubConfig, log);
+				const acked = await acknowledgeClarification(agentId, c.clarificationId, hubConfig, log);
 				if (!acked) {
 					log("poller_acknowledge_failed", { clarificationId: c.clarificationId }, "WARN");
 					continue;

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -423,6 +423,7 @@ export default function (pi: ExtensionAPI) {
 			pollerInterval = null;
 		}
 		pollerRunning = false;
+		pollerSessionToken++;
 		if (telemetryInterval) {
 			clearInterval(telemetryInterval);
 			telemetryInterval = null;
@@ -703,8 +704,11 @@ export default function (pi: ExtensionAPI) {
 	// When a response is found, spawns a fresh pi subprocess with the handoff
 	// context + owner answer — completely independent of the current session.
 
-	/** Guard against concurrent poll cycles. */
+	/** Guard against concurrent poll cycles. Paired with pollerSessionToken
+	 *  so that a stale poll's finally block doesn't clear the guard for
+	 *  a new session's active poll. */
 	let pollerRunning = false;
+	let pollerSessionToken = 0;
 
 	/**
 	 * Build a self-contained prompt for a fresh pi subprocess from an
@@ -895,6 +899,7 @@ export default function (pi: ExtensionAPI) {
 	async function pollForClarificationResponses(): Promise<void> {
 		if (pollerRunning || !hubAgentId) return;
 		pollerRunning = true;
+		const myPollerToken = pollerSessionToken;
 
 		// Snapshot hubAgentId — session_start can reset it to null between
 		// any await points. Using a local const avoids stale references.
@@ -919,14 +924,31 @@ export default function (pi: ExtensionAPI) {
 					continue;
 				}
 
-				// Spawn a fresh pi subprocess
-				spawnClarificationHandler(c, pollerConfig);
+				// Spawn a fresh pi subprocess — wrapped in try/catch because
+				// spawn() can throw synchronously (e.g. ENOENT if pi binary
+				// is missing). After acknowledge the item is consumed, so a
+				// spawn failure means the work is lost. Log prominently.
+				try {
+					spawnClarificationHandler(c, pollerConfig);
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					log("poller_spawn_failed_after_ack", {
+						clarificationId: c.clarificationId,
+						error: msg,
+						question: c.question.slice(0, 100),
+					}, "ERROR");
+				}
 			}
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			log("poller_error", { error: msg }, "WARN");
 		} finally {
-			pollerRunning = false;
+			// Only clear the guard if this poll belongs to the current session.
+			// A stale poll from a previous session must not reset the flag for
+			// a new session's active poll.
+			if (pollerSessionToken === myPollerToken) {
+				pollerRunning = false;
+			}
 		}
 	}
 

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -34,6 +34,24 @@ export interface A2AConfig {
 	sendTimeoutMs?: number;
 	/** Manually configured remote agents (no hub required). */
 	staticAgents?: StaticAgentConfig[];
+	/** Clarification response poller settings.
+	 *  When enabled, periodically checks the hub for answered owner clarifications
+	 *  and spawns a fresh pi subprocess to handle each response. */
+	poller?: PollerConfig;
+}
+
+/** Configuration for the background clarification poller. */
+export interface PollerConfig {
+	/** Enable the poller. Defaults to false. */
+	enabled?: boolean;
+	/** Poll interval in seconds. Defaults to 60. Min 15, max 600. */
+	intervalSeconds?: number;
+	/** Extension paths to load in spawned pi subprocesses. */
+	extensions?: string[];
+	/** Skill paths to load in spawned pi subprocesses. */
+	skills?: string[];
+	/** Model to use for spawned pi subprocesses. */
+	model?: string;
 }
 
 /** Configuration for a manually defined remote agent. */


### PR DESCRIPTION
## Summary

Redesigns `ask_owner` from a blocking poll loop to an async fire-and-forget model with automatic response handling via background poller + subprocess spawning.

## Problem

Previously, `ask_owner` blocked the agent's turn for up to 72 hours polling for a response. This:
- Prevented the agent from doing other work while waiting
- Tied the response to the same session/conversation context
- Could mess up other flows of work if the response arrived mid-task

## Solution

### 1. Non-blocking `ask_owner`
The tool now submits the question + handoff context to the hub and returns immediately. The agent continues with other work or ends its session.

### 2. Background poller
A configurable `setInterval` poller checks the hub for answered clarifications. When found:
1. **Acknowledge** on the hub (atomic, prevents duplicate processing across sessions)
2. **Build** a self-contained prompt from handoff context + owner's response
3. **Spawn** a fresh `pi` subprocess in the correct project directory

### 3. Fresh subprocess
The spawned pi process:
- Runs with `--no-session -ne -ns` (ephemeral, no inherited extensions/skills)
- Only loads extensions/skills configured in the poller settings
- Gets a complete handoff prompt with: question, response, project context, done/remaining/decisions
- Has zero prior conversation context — completely independent of the host session

### Configuration

```json
{
  "pi-a2a": {
    "poller": {
      "enabled": true,
      "intervalSeconds": 60,
      "extensions": ["extensions/pi-github"],
      "skills": ["td", "github"],
      "model": "claude-sonnet-4-5"
    }
  }
}
```

### New hub API methods
This PR adds client-side calls for two new hub endpoints (being implemented separately on the A2A Hub):
- `clarification.list_answered` — returns answered + unacknowledged clarifications with full context
- `clarification.acknowledge` — marks as processed (atomic first-write-wins)

## Files changed

| File | Change |
|------|--------|
| `extensions/pi-a2a/src/types.ts` | Added `PollerConfig` interface |
| `extensions/pi-a2a/src/hub.ts` | Added `listAnsweredClarifications()` + `acknowledgeClarification()` |
| `extensions/pi-a2a/src/index.ts` | Non-blocking `ask_owner`, background poller, subprocess spawning |
| `extensions/pi-a2a/SKILL.md` | Updated docs to reflect async behavior + poller config |

Closes td-63b27d