### PR TITLE
feat: add pi-mobile extension — PWA mobile app

### DIFF
--- a/extensions/pi-mobile/AGENTS.md
+++ b/extensions/pi-mobile/AGENTS.md
@@ -1,0 +1,91 @@
+---
+name: pi-mobile
+description: PWA mobile app for Pi agents — mounts on pi-webserver at /mobile
+---
+
+## Overview
+
+Pi extension that serves a mobile-first PWA at `/mobile`. Uses Preact + HTM from CDN (no build step). Dark mode by default, scrollable bottom tab navigation with 11 screens, installable as a home screen app.
+
+## Architecture
+
+```
+pi-mobile/
+├── src/
+│   └── index.ts          # Extension entry — web:mount + web:mount-api + SSE broadcasting
+├── public/
+│   ├── app.html          # SPA shell — all 11 screens (Preact + HTM from esm.sh CDN)
+│   ├── manifest.json     # PWA manifest (standalone, dark theme)
+│   └── sw.js             # Service worker (app shell caching strategy)
+├── package.json          # Pi extension metadata
+├── tsconfig.json         # TypeScript strict mode, ES2022
+└── README.md
+```
+
+## Extension Pattern
+
+Follows the standard pi-webserver mount pattern:
+
+- **`web:mount`** at `/mobile` — serves HTML, manifest.json, sw.js, screen modules
+- **`web:mount-api`** at `/mobile` — API routes at `/api/mobile/*`
+- **`web:ready`** listener — re-mounts if webserver starts late
+- SPA fallback: all unknown sub-routes serve the app shell (client-side routing)
+- SSE broadcast: agent events forwarded to all connected mobile clients
+
+## API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/mobile/health` | GET | Health check |
+| `/api/mobile/status` | GET | Agent health, system info, tools, memory |
+| `/api/mobile/chat/prompt` | POST | Submit prompt to agent |
+| `/api/mobile/chat/events` | GET | SSE stream of agent events |
+| `/api/mobile/td/issues` | GET/POST | List/create td issues |
+| `/api/mobile/td/issues/:id` | GET/PATCH | Show/update issue |
+| `/api/mobile/files/list` | GET | List directory contents |
+| `/api/mobile/files/read` | GET | Read file content |
+| `/api/mobile/cron/jobs` | GET | List cron jobs |
+| `/api/mobile/cron/jobs/:name/toggle` | POST | Enable/disable job |
+| `/api/mobile/cron/jobs/:name/run` | POST | Trigger manual run |
+| `/api/mobile/skills` | GET | List registered tools |
+| `/api/mobile/extensions` | GET | List extensions (grouped tools) |
+| `/api/mobile/crm/contacts` | GET/POST | List/create contacts |
+| `/api/mobile/calendar/events` | GET/POST | List/create events |
+| `/api/mobile/logs/events` | GET | SSE stream of log events |
+
+## Frontend Stack
+
+- **Preact 10** + **HTM 3** — imported from `esm.sh` CDN, no build step
+- **CSS Custom Properties** — theming via `--color-*` variables
+- **Dark mode by default** — `#0a0a0f` background, indigo `#6366f1` accent
+- **Mobile-first** — max-width 480px on mobile, 600px on desktop
+- **Safe areas** — respects `env(safe-area-inset-*)` for notch/home indicator
+- **Scrollable tab bar** — supports 11+ tabs without overflow
+
+## Conventions
+
+- All frontend in a single `public/app.html` — Preact components, CSS, no build step
+- Static files in `public/` — loaded at import time via `fs.readFileSync`
+- All API routes return JSON with consistent `{ error }` for errors
+- SSE connections use keepalive pings (15s) and auto-reconnect on client
+- CRM/Calendar/Cron APIs gracefully return empty lists when extensions not installed
+- Path traversal prevention on Files API (resolves to cwd, rejects escapes)
+- Tab screens are Preact components — one function per screen
+- Error boundaries wrap each tab screen independently
+- `td` commands proxied via `pi.exec()` with 15s timeout
+
+## Screens
+
+| Tab | Screen | Features |
+|-----|--------|----------|
+| 💬 Chat | Streaming conversation | SSE streaming, prompt submission, markdown rendering, typing indicators, auto-scroll |
+| 📊 Status | Health dashboard | Agent health, uptime, Node/memory/heap stats, tool count, SSE connections |
+| 📋 Tasks | td issue management | Issue list with status/priority filters, create/update via td CLI proxy |
+| 📁 Files | Workspace browser | Directory listing, file viewer, breadcrumb navigation, path traversal prevention |
+| 📜 Logs | Live log viewer | SSE log stream, level filters, pin-to-bottom, buffer limit (500), clear |
+| ⏰ Cron | Job management | Job list, enable/disable toggle, manual run, schedule display |
+| 🧠 Skills | Tool browser | Search/filter, tool descriptions |
+| 👥 CRM | Contact management | Contact list with search, phone/email links |
+| 📅 Calendar | Event management | Upcoming events list |
+| 🧩 Extensions | Extension browser | Tools grouped by extension prefix, tool counts |
+| ⚙️ Settings | Configuration | Agent URL, API key, connection test, theme, clear data |

--- a/extensions/pi-mobile/README.md
+++ b/extensions/pi-mobile/README.md
@@ -1,0 +1,106 @@
+# pi-mobile
+
+PWA mobile app for Pi coding agents. Mounts on pi-webserver at `/mobile`, giving you mobile control over any Pi agent.
+
+## Screens
+
+| Tab | Description |
+|-----|-------------|
+| 💬 **Chat** | Send messages with streaming responses via SSE |
+| 📊 **Status** | Agent health, system metrics, uptime, tool count |
+| 📋 **Tasks** | td issue list with filters, create/update tasks |
+| 📁 **Files** | Browse workspace files, view content |
+| 📜 **Logs** | Live log stream with level filters |
+| ⏰ **Cron** | Manage scheduled jobs — toggle, run, view schedule |
+| 🧠 **Skills** | Browse registered tools with search |
+| 👥 **CRM** | Contact list with search (via pi-personal-crm) |
+| 📅 **Calendar** | Upcoming events (via pi-calendar) |
+| 🧩 **Extensions** | View installed extensions and their tools |
+| ⚙️ **Settings** | Connection config, API key, theme |
+
+## Setup
+
+### 1. Install the extension
+
+Add `pi-mobile` to your Pi extensions:
+
+```bash
+# Symlink to extensions directory
+ln -s ~/Dev/pi-mobile ~/.pi/agent/extensions/pi-mobile
+
+# Install dependencies
+cd ~/.pi/agent/extensions/pi-mobile
+npm install
+```
+
+Or add to `settings.json`:
+
+```json
+{
+  "extensions": ["~/Dev/pi-mobile"]
+}
+```
+
+### 2. Ensure pi-webserver is running
+
+pi-mobile mounts on the shared pi-webserver. Make sure `pi-webserver` is enabled.
+
+### 3. Access the app
+
+```
+http://localhost:<webserver-port>/mobile
+```
+
+## Install as PWA
+
+### iOS (Safari)
+1. Open `/mobile` in Safari
+2. Tap **Share** (📤) → **Add to Home Screen** → **Add**
+
+### Android (Chrome)
+1. Open `/mobile` in Chrome
+2. Tap **⋮** → **Install app** → **Install**
+
+## Remote Access via Tailscale
+
+1. Install [Tailscale](https://tailscale.com) on both devices
+2. Access via Tailscale hostname:
+
+```
+http://your-machine.tail12345.ts.net:<port>/mobile
+```
+
+**Important:** Set an API key when binding to external interfaces:
+
+```json
+{
+  "pi-webserver": {
+    "bind": "0.0.0.0",
+    "apiKey": "your-secret-key"
+  }
+}
+```
+
+## Architecture
+
+```
+pi-mobile/
+├── src/
+│   └── index.ts          # Extension + API endpoints + SSE broadcasting
+├── public/
+│   ├── app.html          # SPA — 11 Preact screens, dark theme (no build step)
+│   ├── manifest.json     # PWA manifest
+│   └── sw.js             # Service worker
+├── package.json
+├── tsconfig.json
+├── AGENTS.md
+└── README.md
+```
+
+### Tech Stack
+
+- **Preact + HTM** from esm.sh CDN — no build step
+- **CSS Custom Properties** — dark mode theming
+- **Service Worker** — offline caching (stale-while-revalidate)
+- **SSE** — real-time agent events and log streaming
+- **pi-webserver** — shared HTTP server with event-bus mount system

--- a/extensions/pi-mobile/package-lock.json
+++ b/extensions/pi-mobile/package-lock.json
@@ -1,0 +1,3800 @@
+{
+	"name": "@e9n/pi-mobile",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@e9n/pi-mobile",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"typescript": "^5.9.3"
+			},
+			"peerDependencies": {
+				"@mariozechner/pi-coding-agent": "*"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1018.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1018.0.tgz",
+			"integrity": "sha512-uJYVPDn+5n63hISPg/Q0YXITuqdWeC+wssIWKKvnX2Tgn+rPo5piAhvyCE2YzxGoBdBVHIUfu/KyGzUc7OgBYA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/credential-provider-node": "^3.972.26",
+				"@aws-sdk/eventstream-handler-node": "^3.972.12",
+				"@aws-sdk/middleware-eventstream": "^3.972.8",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.26",
+				"@aws-sdk/middleware-websocket": "^3.972.14",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/token-providers": "3.1018.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.12",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.12",
+				"@smithy/eventstream-serde-node": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.27",
+				"@smithy/middleware-retry": "^4.4.44",
+				"@smithy/middleware-serde": "^4.2.15",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.43",
+				"@smithy/util-defaults-mode-node": "^4.2.47",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/util-stream": "^4.5.20",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.973.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.25.tgz",
+			"integrity": "sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/xml-builder": "^3.972.16",
+				"@smithy/core": "^3.23.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.23.tgz",
+			"integrity": "sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.25.tgz",
+			"integrity": "sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.20",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.25.tgz",
+			"integrity": "sha512-G/v/PicYn4qs7xCv4vT6I4QKdvMyRvsgIFNBkUueCGlbLo7/PuKcNKgUozmLSsaYnE7jIl6UrfkP07EUubr48w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/credential-provider-env": "^3.972.23",
+				"@aws-sdk/credential-provider-http": "^3.972.25",
+				"@aws-sdk/credential-provider-login": "^3.972.25",
+				"@aws-sdk/credential-provider-process": "^3.972.23",
+				"@aws-sdk/credential-provider-sso": "^3.972.25",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.25.tgz",
+			"integrity": "sha512-bUdmyJeVua7SmD+g2a65x2/0YqsGn4K2k4GawI43js0odaNaIzpIhLtHehUnPnfLuyhPWbJR1NyuIO4iMVfM0w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.26.tgz",
+			"integrity": "sha512-5XSK74rCXxCNj+UWv5bjq1EccYkiyW4XOHFU9NXnsCcQF8dJuHdua1qFg0m/LIwVOWklbKsrcnMtfxIXwgvwzQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.23",
+				"@aws-sdk/credential-provider-http": "^3.972.25",
+				"@aws-sdk/credential-provider-ini": "^3.972.25",
+				"@aws-sdk/credential-provider-process": "^3.972.23",
+				"@aws-sdk/credential-provider-sso": "^3.972.25",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.23.tgz",
+			"integrity": "sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.25.tgz",
+			"integrity": "sha512-r4OGAfHmlEa1QBInHWz+/dOD4tRljcjVNQe9wJ/AJNXEj1d2WdsRLppvRFImRV6FIs+bTpjtL0a23V5ELQpRPw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/token-providers": "3.1018.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.25.tgz",
+			"integrity": "sha512-uM1OtoJgj+yK3MlAmda8uR9WJJCdm5HB25JyCeFL5a5q1Fbafalf4uKidFO3/L0Pgd+Fsflkb4cM6jHIswi3QQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+			"integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+			"integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+			"integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+			"integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+			"integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.26.tgz",
+			"integrity": "sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@smithy/core": "^3.23.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-retry": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+			"integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-format-url": "^3.972.8",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.996.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.15.tgz",
+			"integrity": "sha512-k6WAVNkub5DrU46iPQvH1m0xc1n+0dX79+i287tYJzf5g1yU2rX3uf4xNeL5JvK1NtYgfwMnsxHqhOXFBn367A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.26",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.12",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.27",
+				"@smithy/middleware-retry": "^4.4.44",
+				"@smithy/middleware-serde": "^4.2.15",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.43",
+				"@smithy/util-defaults-mode-node": "^4.2.47",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+			"integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1018.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1018.0.tgz",
+			"integrity": "sha512-97OPNJHy37wmGOX44xAcu6E9oSTiqK9uPcy/fWpmN5uB3JuEp1f6x60Xot/jp+FxwhQWIFUsVJFnm3QKqt7T6Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+			"integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-endpoints": "^3.3.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+			"integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+			"integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.12.tgz",
+			"integrity": "sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"fast-xml-parser": "5.5.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.46.0.tgz",
+			"integrity": "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+			"integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+				"@mariozechner/clipboard-darwin-universal": "0.3.2",
+				"@mariozechner/clipboard-darwin-x64": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+			"integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+			"integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+			"integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+			"integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+			"integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+			"integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+			"integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/jiti": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"std-env": "^3.10.0",
+				"yoctocolors": "^2.1.2"
+			},
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.63.1.tgz",
+			"integrity": "sha512-h0B20xfs/iEVR2EC4gwiE8hKI1TPeB8REdRJMgV+uXKH7gpeIZ9+s8Dp9nX35ZR0QUjkNey2+ULk2DxQtdg14Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.63.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.63.1.tgz",
+			"integrity": "sha512-wjgwY+yfrFO6a9QdAfjWpH7iSrDean6GsKDDMohNcLCy6PreMxHOZvNM0NwJARL1tZoZovr7ikAQfLGFZbnjsw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.73.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "1.14.1",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.63.1.tgz",
+			"integrity": "sha512-XSoMyLtuMA7ePK1UBWqSJ/BBdtBdJUHY9nbtnNyG6GeW7Gbgd+iqljIuwmAUf8wlYL981UIfYM/WIPQ6t/dIxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.63.1",
+				"@mariozechner/pi-ai": "^0.63.1",
+				"@mariozechner/pi-tui": "^0.63.1",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"ajv": "^8.17.1",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.63.1.tgz",
+			"integrity": "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+			"integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+			"peer": true,
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.24.1"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@smithy/abort-controller": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+			"integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "4.4.13",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+			"integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.23.12",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+			"integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-stream": "^4.5.20",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+			"integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+			"integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+			"integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+			"integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+			"integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+			"integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.15",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+			"integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+			"integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+			"integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+			"integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.27",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+			"integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.12",
+				"@smithy/middleware-serde": "^4.2.15",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.4.44",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+			"integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.15",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+			"integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+			"integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+			"integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+			"integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/abort-controller": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+			"integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+			"integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+			"integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+			"integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+			"integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+			"integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+			"integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.12.7",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+			"integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.12",
+				"@smithy/middleware-endpoint": "^4.4.27",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.20",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+			"integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/querystring-parser": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.43",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+			"integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.47",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+			"integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+			"integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+			"integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+			"integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "4.5.20",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+			"integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/koffi": {
+			"version": "2.15.2",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
+			"integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"url": "https://liberapay.com/Koromix"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/lru-cache": {
+			"version": "11.2.7",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+			"integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+			"integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+			"integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
+			}
+		}
+	}
+}

--- a/extensions/pi-mobile/package.json
+++ b/extensions/pi-mobile/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@e9n/pi-mobile",
+	"version": "0.1.0",
+	"description": "PWA mobile app for Pi agents — mounts on pi-webserver at /mobile",
+	"type": "module",
+	"keywords": [
+		"pi-package"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit"
+	},
+	"author": "Espen Nilsen <hi@e9n.dev>",
+	"license": "MIT",
+	"peerDependencies": {
+		"@mariozechner/pi-coding-agent": "*"
+	},
+	"devDependencies": {
+		"typescript": "^5.9.3"
+	},
+	"files": [
+		"CHANGELOG.md",
+		"README.md",
+		"package.json",
+		"public",
+		"src"
+	]
+}

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -1,0 +1,1349 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+	<title>Pi Agent</title>
+
+	<!-- PWA -->
+	<link rel="manifest" href="/mobile/manifest.json">
+	<meta name="theme-color" content="#6366f1">
+	<meta name="mobile-web-app-capable" content="yes">
+
+	<!-- iOS PWA support -->
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+	<meta name="apple-mobile-web-app-title" content="Pi">
+
+	<style>
+		/* ── CSS Custom Properties ────────────────────────── */
+		:root {
+			--color-bg: #0a0a0f;
+			--color-bg-surface: #12121a;
+			--color-bg-elevated: #1a1a25;
+			--color-bg-hover: #22222f;
+			--color-border: #2a2a3a;
+			--color-text: #e4e4ed;
+			--color-text-dim: #8888a0;
+			--color-text-muted: #55556a;
+			--color-accent: #6366f1;
+			--color-accent-hover: #818cf8;
+			--color-accent-dim: #4f46e5;
+			--color-success: #22c55e;
+			--color-warning: #f59e0b;
+			--color-error: #ef4444;
+			--color-info: #3b82f6;
+			--radius: 12px;
+			--radius-sm: 8px;
+			--radius-xs: 4px;
+			--tab-height: 56px;
+			--safe-bottom: env(safe-area-inset-bottom, 0px);
+			--safe-top: env(safe-area-inset-top, 0px);
+		}
+
+		/* ── Reset ───────────────────────────────────────── */
+		*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+		html, body {
+			height: 100%;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+			background: var(--color-bg);
+			color: var(--color-text);
+			-webkit-font-smoothing: antialiased;
+			-webkit-tap-highlight-color: transparent;
+			overscroll-behavior: none;
+		}
+		body { display: flex; flex-direction: column; }
+
+		/* ── App layout ──────────────────────────────────── */
+		#app {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			width: 100%;
+			max-width: 480px;
+			margin: 0 auto;
+		}
+		@media (min-width: 768px) { #app { max-width: 600px; } }
+
+		/* ── Header ──────────────────────────────────────── */
+		.header {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			padding: 8px 16px;
+			padding-top: calc(8px + var(--safe-top));
+			background: var(--color-bg-surface);
+			border-bottom: 1px solid var(--color-border);
+			min-height: 48px;
+			flex-shrink: 0;
+		}
+		.header-title { font-size: 17px; font-weight: 600; letter-spacing: -0.02em; }
+		.header-status { display: flex; align-items: center; gap: 6px; font-size: 13px; color: var(--color-text-dim); }
+		.status-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-text-muted); }
+		.status-dot.connected { background: var(--color-success); }
+		.status-dot.error { background: var(--color-error); }
+
+		/* ── Tab content ─────────────────────────────────── */
+		.tab-content {
+			flex: 1;
+			overflow-y: auto;
+			-webkit-overflow-scrolling: touch;
+			display: flex;
+			flex-direction: column;
+		}
+
+		/* ── Bottom tab bar ──────────────────────────────── */
+		.tab-bar {
+			display: flex;
+			align-items: stretch;
+			background: var(--color-bg-surface);
+			border-top: 1px solid var(--color-border);
+			height: var(--tab-height);
+			padding-bottom: var(--safe-bottom);
+			flex-shrink: 0;
+			overflow-x: auto;
+			-webkit-overflow-scrolling: touch;
+			scrollbar-width: none;
+		}
+		.tab-bar::-webkit-scrollbar { display: none; }
+		.tab-item {
+			flex: 0 0 auto;
+			min-width: 56px;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			gap: 2px;
+			background: none;
+			border: none;
+			color: var(--color-text-muted);
+			font-size: 10px;
+			font-weight: 500;
+			cursor: pointer;
+			transition: color 0.15s;
+			-webkit-tap-highlight-color: transparent;
+			padding: 4px 0;
+		}
+		.tab-item:active { opacity: 0.7; }
+		.tab-item.active { color: var(--color-accent); }
+		.tab-icon { font-size: 22px; line-height: 1; }
+		.tab-label { font-size: 10px; letter-spacing: 0.02em; }
+
+		/* ── Screen placeholder ──────────────────────────── */
+		.screen-placeholder {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			height: 100%;
+			gap: 12px;
+			color: var(--color-text-dim);
+			padding: 16px;
+		}
+		.screen-placeholder .icon { font-size: 48px; opacity: 0.4; }
+		.screen-placeholder .label { font-size: 15px; font-weight: 500; }
+		.screen-placeholder .hint { font-size: 13px; color: var(--color-text-muted); text-align: center; max-width: 260px; line-height: 1.5; }
+
+		/* ── Spinner ─────────────────────────────────────── */
+		.spinner { width: 32px; height: 32px; border: 3px solid var(--color-border); border-top-color: var(--color-accent); border-radius: 50%; animation: spin 0.8s linear infinite; }
+		@keyframes spin { to { transform: rotate(360deg); } }
+
+		/* ── Error boundary ──────────────────────────────── */
+		.error-boundary { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; padding: 32px 16px; text-align: center; }
+		.error-boundary .error-icon { font-size: 36px; }
+		.error-boundary .error-message { font-size: 14px; color: var(--color-error); max-width: 300px; word-break: break-word; }
+		.error-boundary button { background: var(--color-accent); color: white; border: none; border-radius: var(--radius-sm); padding: 8px 20px; font-size: 14px; font-weight: 500; cursor: pointer; }
+		.error-boundary button:active { opacity: 0.8; }
+
+		/* ── Chat screen ─────────────────────────────────── */
+		.chat-container { display: flex; flex-direction: column; height: 100%; }
+		.chat-messages { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+		.chat-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 8px; color: var(--color-text-muted); }
+		.chat-empty .icon { font-size: 40px; opacity: 0.3; }
+		.chat-empty .text { font-size: 14px; }
+
+		.msg { max-width: 85%; padding: 10px 14px; border-radius: var(--radius); font-size: 15px; line-height: 1.5; word-wrap: break-word; }
+		.msg-user { align-self: flex-end; background: var(--color-accent); color: white; border-bottom-right-radius: var(--radius-xs); }
+		.msg-agent { align-self: flex-start; background: var(--color-bg-elevated); color: var(--color-text); border-bottom-left-radius: var(--radius-xs); }
+		.msg-agent pre { background: var(--color-bg); padding: 8px 10px; border-radius: var(--radius-xs); overflow-x: auto; font-size: 13px; margin: 6px 0; }
+		.msg-agent code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 13px; }
+		.msg-agent p { margin: 0 0 8px 0; }
+		.msg-agent p:last-child { margin-bottom: 0; }
+		.msg-agent ul, .msg-agent ol { margin: 4px 0; padding-left: 20px; }
+		.msg-agent strong { font-weight: 600; }
+		.msg-agent em { font-style: italic; color: var(--color-text-dim); }
+		.msg-agent a { color: var(--color-accent-hover); text-decoration: none; }
+
+		.msg-system { align-self: center; background: none; color: var(--color-text-muted); font-size: 12px; padding: 4px 8px; }
+
+		.msg-tool { align-self: flex-start; background: var(--color-bg-elevated); border-left: 3px solid var(--color-warning); padding: 6px 10px; font-size: 12px; color: var(--color-text-dim); border-radius: var(--radius-xs); max-width: 90%; }
+		.msg-tool .tool-name { font-weight: 600; color: var(--color-warning); }
+		.msg-tool.error { border-left-color: var(--color-error); }
+		.msg-tool.error .tool-name { color: var(--color-error); }
+
+		.typing-indicator { align-self: flex-start; padding: 8px 14px; display: flex; gap: 4px; align-items: center; }
+		.typing-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-text-muted); animation: typing 1.4s infinite; }
+		.typing-dot:nth-child(2) { animation-delay: 0.2s; }
+		.typing-dot:nth-child(3) { animation-delay: 0.4s; }
+		@keyframes typing { 0%, 60%, 100% { opacity: 0.3; transform: scale(0.8); } 30% { opacity: 1; transform: scale(1); } }
+
+		.chat-input-bar {
+			display: flex;
+			align-items: flex-end;
+			gap: 8px;
+			padding: 8px 12px;
+			padding-bottom: calc(8px + var(--safe-bottom));
+			background: var(--color-bg-surface);
+			border-top: 1px solid var(--color-border);
+			flex-shrink: 0;
+		}
+		.chat-input {
+			flex: 1;
+			background: var(--color-bg-elevated);
+			border: 1px solid var(--color-border);
+			border-radius: 20px;
+			padding: 8px 16px;
+			color: var(--color-text);
+			font-size: 15px;
+			font-family: inherit;
+			resize: none;
+			min-height: 38px;
+			max-height: 120px;
+			outline: none;
+			line-height: 1.4;
+		}
+		.chat-input:focus { border-color: var(--color-accent); }
+		.chat-input::placeholder { color: var(--color-text-muted); }
+		.chat-send {
+			width: 38px;
+			height: 38px;
+			border-radius: 50%;
+			background: var(--color-accent);
+			border: none;
+			color: white;
+			font-size: 18px;
+			cursor: pointer;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			flex-shrink: 0;
+			transition: opacity 0.15s;
+		}
+		.chat-send:disabled { opacity: 0.4; cursor: default; }
+		.chat-send:active:not(:disabled) { opacity: 0.8; }
+
+		/* ── Status screen ───────────────────────────────── */
+		.status-cards { display: flex; flex-direction: column; gap: 12px; padding: 16px; }
+		.status-card {
+			background: var(--color-bg-surface);
+			border: 1px solid var(--color-border);
+			border-radius: var(--radius);
+			padding: 14px 16px;
+		}
+		.status-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+		.status-card-title { font-size: 14px; font-weight: 600; color: var(--color-text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
+		.status-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; }
+		.status-badge.healthy { background: rgba(34,197,94,0.15); color: var(--color-success); }
+		.status-badge.degraded { background: rgba(245,158,11,0.15); color: var(--color-warning); }
+		.status-badge.down { background: rgba(239,68,68,0.15); color: var(--color-error); }
+		.status-badge.unknown { background: rgba(85,85,106,0.15); color: var(--color-text-muted); }
+		.status-row { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; border-bottom: 1px solid var(--color-border); }
+		.status-row:last-child { border-bottom: none; }
+		.status-row-label { font-size: 13px; color: var(--color-text-dim); }
+		.status-row-value { font-size: 13px; font-weight: 500; }
+		.pulse { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--color-success); animation: pulse-ring 2s infinite; }
+		@keyframes pulse-ring { 0% { box-shadow: 0 0 0 0 rgba(34,197,94,0.5); } 70% { box-shadow: 0 0 0 6px rgba(34,197,94,0); } 100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); } }
+
+		/* ── Tasks screen ────────────────────────────────── */
+		.tasks-container { display: flex; flex-direction: column; height: 100%; }
+		.tasks-header { padding: 12px 16px; display: flex; gap: 8px; flex-shrink: 0; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+		.tasks-filter {
+			padding: 6px 14px;
+			border-radius: 16px;
+			border: 1px solid var(--color-border);
+			background: none;
+			color: var(--color-text-dim);
+			font-size: 13px;
+			font-weight: 500;
+			cursor: pointer;
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+		.tasks-filter.active { background: var(--color-accent); color: white; border-color: var(--color-accent); }
+		.tasks-list { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 0 16px 16px; }
+		.task-item {
+			background: var(--color-bg-surface);
+			border: 1px solid var(--color-border);
+			border-radius: var(--radius-sm);
+			padding: 12px 14px;
+			margin-bottom: 8px;
+			cursor: pointer;
+		}
+		.task-item:active { background: var(--color-bg-hover); }
+		.task-title { font-size: 14px; font-weight: 500; margin-bottom: 6px; }
+		.task-meta { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+		.task-badge {
+			font-size: 11px;
+			font-weight: 600;
+			padding: 2px 7px;
+			border-radius: 4px;
+			text-transform: uppercase;
+			letter-spacing: 0.03em;
+		}
+		.task-badge.open { background: rgba(99,102,241,0.15); color: var(--color-accent); }
+		.task-badge.in_progress { background: rgba(245,158,11,0.15); color: var(--color-warning); }
+		.task-badge.in_review { background: rgba(59,130,246,0.15); color: var(--color-info); }
+		.task-badge.blocked { background: rgba(239,68,68,0.15); color: var(--color-error); }
+		.task-badge.closed { background: rgba(85,85,106,0.15); color: var(--color-text-muted); }
+		.task-badge.P0, .task-badge.P1 { background: rgba(239,68,68,0.15); color: var(--color-error); }
+		.task-badge.P2 { background: rgba(245,158,11,0.15); color: var(--color-warning); }
+		.task-badge.P3, .task-badge.P4 { background: rgba(85,85,106,0.15); color: var(--color-text-muted); }
+		.task-id { font-size: 11px; color: var(--color-text-muted); font-family: 'SF Mono', monospace; }
+		.task-points { font-size: 11px; color: var(--color-text-muted); }
+		.tasks-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 40px 16px; color: var(--color-text-muted); gap: 8px; }
+		.task-fab {
+			position: fixed;
+			bottom: calc(var(--tab-height) + var(--safe-bottom) + 16px);
+			right: calc(50% - 210px);
+			width: 48px;
+			height: 48px;
+			border-radius: 50%;
+			background: var(--color-accent);
+			color: white;
+			border: none;
+			font-size: 24px;
+			cursor: pointer;
+			box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+		@media (max-width: 479px) { .task-fab { right: 16px; } }
+		.task-fab:active { opacity: 0.8; }
+
+		/* ── Generic list styles ─────────────────────────── */
+		.list-container { display: flex; flex-direction: column; height: 100%; }
+		.list-header { padding: 12px 16px; flex-shrink: 0; }
+		.list-search {
+			width: 100%;
+			background: var(--color-bg-elevated);
+			border: 1px solid var(--color-border);
+			border-radius: var(--radius-sm);
+			padding: 8px 12px;
+			color: var(--color-text);
+			font-size: 14px;
+			outline: none;
+		}
+		.list-search:focus { border-color: var(--color-accent); }
+		.list-search::placeholder { color: var(--color-text-muted); }
+		.list-body { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 0 16px 16px; }
+		.list-item {
+			background: var(--color-bg-surface);
+			border: 1px solid var(--color-border);
+			border-radius: var(--radius-sm);
+			padding: 12px 14px;
+			margin-bottom: 8px;
+		}
+		.list-item-title { font-size: 14px; font-weight: 500; margin-bottom: 4px; }
+		.list-item-desc { font-size: 12px; color: var(--color-text-dim); line-height: 1.4; }
+		.list-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 40px 16px; color: var(--color-text-muted); gap: 8px; }
+
+		/* ── Files screen ────────────────────────────────── */
+		.file-breadcrumb { display: flex; align-items: center; gap: 4px; padding: 8px 16px; font-size: 13px; color: var(--color-text-dim); overflow-x: auto; flex-shrink: 0; }
+		.file-breadcrumb button { background: none; border: none; color: var(--color-accent); font-size: 13px; cursor: pointer; padding: 2px 4px; }
+		.file-breadcrumb span { color: var(--color-text-muted); }
+		.file-item { display: flex; align-items: center; gap: 10px; }
+		.file-item .file-icon { font-size: 18px; flex-shrink: 0; }
+		.file-item .file-info { flex: 1; min-width: 0; }
+		.file-item .file-name { font-size: 14px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+		.file-item .file-meta { font-size: 11px; color: var(--color-text-muted); }
+		.file-viewer { flex: 1; overflow: auto; padding: 12px 16px; }
+		.file-viewer pre { background: var(--color-bg-surface); border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: 12px; font-size: 13px; font-family: 'SF Mono', monospace; overflow-x: auto; line-height: 1.5; white-space: pre; color: var(--color-text); }
+
+		/* ── Logs screen ─────────────────────────────────── */
+		.logs-container { display: flex; flex-direction: column; height: 100%; }
+		.logs-filters { display: flex; gap: 6px; padding: 8px 16px; flex-shrink: 0; overflow-x: auto; }
+		.log-filter { padding: 4px 10px; border-radius: 12px; border: 1px solid var(--color-border); background: none; color: var(--color-text-dim); font-size: 12px; cursor: pointer; white-space: nowrap; }
+		.log-filter.active { background: var(--color-bg-elevated); color: var(--color-text); border-color: var(--color-accent); }
+		.logs-output { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; padding: 8px 12px; font-family: 'SF Mono', monospace; font-size: 12px; line-height: 1.6; }
+		.log-entry { padding: 2px 4px; border-bottom: 1px solid rgba(42,42,58,0.5); }
+		.log-entry .log-time { color: var(--color-text-muted); margin-right: 8px; }
+		.log-entry .log-level { font-weight: 600; margin-right: 6px; }
+		.log-entry .log-level.info { color: var(--color-info); }
+		.log-entry .log-level.warn { color: var(--color-warning); }
+		.log-entry .log-level.error { color: var(--color-error); }
+		.log-entry .log-level.debug { color: var(--color-text-muted); }
+		.log-entry .log-source { color: var(--color-accent); margin-right: 6px; }
+		.log-entry .log-msg { color: var(--color-text); }
+
+		/* ── Cron screen ─────────────────────────────────── */
+		.cron-item .cron-schedule { font-size: 12px; font-family: 'SF Mono', monospace; color: var(--color-accent); margin-bottom: 4px; }
+		.cron-item .cron-meta { display: flex; gap: 8px; align-items: center; }
+		.cron-toggle { width: 42px; height: 24px; border-radius: 12px; border: none; cursor: pointer; position: relative; transition: background 0.2s; }
+		.cron-toggle.on { background: var(--color-success); }
+		.cron-toggle.off { background: var(--color-text-muted); }
+		.cron-toggle::after { content: ''; position: absolute; width: 20px; height: 20px; border-radius: 50%; background: white; top: 2px; left: 2px; transition: transform 0.2s; }
+		.cron-toggle.on::after { transform: translateX(18px); }
+
+		/* ── Settings screen ─────────────────────────────── */
+		.settings-section { padding: 16px; }
+		.settings-section-title { font-size: 12px; font-weight: 600; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
+		.settings-row { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; border-bottom: 1px solid var(--color-border); }
+		.settings-row:last-child { border-bottom: none; }
+		.settings-row-label { font-size: 14px; }
+		.settings-row-value { font-size: 14px; color: var(--color-text-dim); }
+		.settings-input { background: var(--color-bg-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: 8px 12px; color: var(--color-text); font-size: 14px; width: 100%; outline: none; margin-top: 6px; }
+		.settings-input:focus { border-color: var(--color-accent); }
+		.settings-btn { background: var(--color-accent); color: white; border: none; border-radius: var(--radius-sm); padding: 10px 20px; font-size: 14px; font-weight: 500; cursor: pointer; width: 100%; margin-top: 8px; }
+		.settings-btn:active { opacity: 0.8; }
+		.settings-btn.danger { background: var(--color-error); }
+	</style>
+</head>
+<body>
+	<div id="app"></div>
+
+	<script type="module">
+		import { h, render, Component } from "https://esm.sh/preact@10.25.4";
+		import { useState, useCallback, useEffect, useRef, useMemo } from "https://esm.sh/preact@10.25.4/hooks";
+		import htm from "https://esm.sh/htm@3.1.1";
+
+		const html = htm.bind(h);
+
+		// ── Shared helpers ─────────────────────────────────
+
+		const api = (path, opts) => fetch("/api/mobile" + path, opts).then(r => r.json()).catch(() => ({ error: "Network error" }));
+		const apiPost = (path, body) => api(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+		// Minimal markdown → HTML (handles **bold**, *italic*, `code`, ```blocks```, links, lists)
+		function md(text) {
+			if (!text) return "";
+			return text
+				.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+				.replace(/`([^`]+)`/g, '<code>$1</code>')
+				.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+				.replace(/\*(.+?)\*/g, '<em>$1</em>')
+				.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+				.replace(/^### (.+)$/gm, '<strong>$1</strong>')
+				.replace(/^## (.+)$/gm, '<strong>$1</strong>')
+				.replace(/^# (.+)$/gm, '<strong>$1</strong>')
+				.replace(/^[-*] (.+)$/gm, '• $1')
+				.replace(/\n/g, '<br>');
+		}
+
+		// ── Tab definitions ────────────────────────────────
+
+		const TABS = [
+			{ id: "chat",   icon: "💬", label: "Chat" },
+			{ id: "status", icon: "📊", label: "Status" },
+			{ id: "tasks",  icon: "📋", label: "Tasks" },
+			{ id: "files",  icon: "📁", label: "Files" },
+			{ id: "logs",   icon: "📜", label: "Logs" },
+			{ id: "cron",   icon: "⏰", label: "Cron" },
+			{ id: "skills", icon: "🧠", label: "Skills" },
+			{ id: "crm",      icon: "👥", label: "CRM" },
+			{ id: "calendar", icon: "📅", label: "Calendar" },
+			{ id: "extensions", icon: "🧩", label: "Extensions" },
+			{ id: "settings", icon: "⚙️", label: "Settings" },
+		];
+
+		// ── Chat Screen ────────────────────────────────────
+
+		function ChatScreen() {
+			const [messages, setMessages] = useState([]);
+			const [input, setInput] = useState("");
+			const [sending, setSending] = useState(false);
+			const [agentWorking, setAgentWorking] = useState(false);
+			const messagesRef = useRef(null);
+			const inputRef = useRef(null);
+
+			// Auto-scroll to bottom
+			useEffect(() => {
+				if (messagesRef.current) {
+					messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
+				}
+			}, [messages, agentWorking]);
+
+			// SSE connection for agent events
+			useEffect(() => {
+				let es = null;
+				let reconnectTimer = null;
+
+				function connect() {
+					es = new EventSource("/api/mobile/chat/events");
+
+					es.onmessage = (e) => {
+						try {
+							const data = JSON.parse(e.data);
+							switch (data.type) {
+								case "connected":
+									break;
+								case "agent_start":
+									setAgentWorking(true);
+									break;
+								case "agent_end":
+									setAgentWorking(false);
+									break;
+								case "turn_end":
+									if (data.content) {
+										for (const block of data.content) {
+											if (block.type === "text" && block.text) {
+												setMessages(prev => [...prev, { type: "agent", text: block.text, time: Date.now() }]);
+											}
+										}
+									}
+									break;
+								case "tool_start":
+									setMessages(prev => [...prev, { type: "tool", name: data.toolName, status: "running", time: Date.now() }]);
+									break;
+								case "tool_end":
+									setMessages(prev => {
+										const updated = [...prev];
+										// Find the matching tool_start and update it
+										for (let i = updated.length - 1; i >= 0; i--) {
+											if (updated[i].type === "tool" && updated[i].name === data.toolName && updated[i].status === "running") {
+												updated[i] = { ...updated[i], status: data.isError ? "error" : "done" };
+												break;
+											}
+										}
+										return updated;
+									});
+									break;
+							}
+						} catch {}
+					};
+
+					es.onerror = () => {
+						es.close();
+						reconnectTimer = setTimeout(connect, 3000);
+					};
+				}
+
+				connect();
+				return () => {
+					if (es) es.close();
+					if (reconnectTimer) clearTimeout(reconnectTimer);
+				};
+			}, []);
+
+			const handleSend = useCallback(async () => {
+				const text = input.trim();
+				if (!text || sending) return;
+				setInput("");
+				setSending(true);
+				setMessages(prev => [...prev, { type: "user", text, time: Date.now() }]);
+
+				try {
+					await apiPost("/chat/prompt", { prompt: text });
+				} catch {}
+				setSending(false);
+			}, [input, sending]);
+
+			const handleKeyDown = useCallback((e) => {
+				if (e.key === "Enter" && !e.shiftKey) {
+					e.preventDefault();
+					handleSend();
+				}
+			}, [handleSend]);
+
+			// Auto-resize textarea
+			const handleInput = useCallback((e) => {
+				setInput(e.target.value);
+				e.target.style.height = "auto";
+				e.target.style.height = Math.min(e.target.scrollHeight, 120) + "px";
+			}, []);
+
+			return html`
+				<div class="chat-container">
+					<div class="chat-messages" ref=${messagesRef}>
+						${messages.length === 0 && !agentWorking && html`
+							<div class="chat-empty">
+								<div class="icon">💬</div>
+								<div class="text">Send a message to your Pi agent</div>
+							</div>
+						`}
+						${messages.map((msg, i) => {
+							if (msg.type === "user") {
+								return html`<div key=${i} class="msg msg-user">${msg.text}</div>`;
+							}
+							if (msg.type === "agent") {
+								return html`<div key=${i} class="msg msg-agent" dangerouslySetInnerHTML=${{ __html: md(msg.text) }} />`;
+							}
+							if (msg.type === "tool") {
+								return html`
+									<div key=${i} class="msg-tool ${msg.status === 'error' ? 'error' : ''}">
+										<span class="tool-name">${msg.status === 'running' ? '⏳' : msg.status === 'error' ? '❌' : '✅'} ${msg.name}</span>
+									</div>
+								`;
+							}
+							if (msg.type === "system") {
+								return html`<div key=${i} class="msg msg-system">${msg.text}</div>`;
+							}
+						})}
+						${agentWorking && html`
+							<div class="typing-indicator">
+								<div class="typing-dot"></div>
+								<div class="typing-dot"></div>
+								<div class="typing-dot"></div>
+							</div>
+						`}
+					</div>
+					<div class="chat-input-bar">
+						<textarea
+							ref=${inputRef}
+							class="chat-input"
+							placeholder="Message your agent..."
+							value=${input}
+							onInput=${handleInput}
+							onKeyDown=${handleKeyDown}
+							rows="1"
+						/>
+						<button class="chat-send" onClick=${handleSend} disabled=${!input.trim() || sending}>↑</button>
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Status Screen ──────────────────────────────────
+
+		function fmtUptime(seconds) {
+			if (!seconds) return "—";
+			const d = Math.floor(seconds / 86400);
+			const h = Math.floor((seconds % 86400) / 3600);
+			const m = Math.floor((seconds % 3600) / 60);
+			if (d > 0) return d + "d " + h + "h";
+			if (h > 0) return h + "h " + m + "m";
+			return m + "m";
+		}
+
+		function StatusScreen() {
+			const [data, setData] = useState(null);
+			const [loading, setLoading] = useState(true);
+
+			async function refresh() {
+				setLoading(true);
+				const result = await api("/status");
+				setData(result);
+				setLoading(false);
+			}
+
+			useEffect(() => { refresh(); const iv = setInterval(refresh, 30000); return () => clearInterval(iv); }, []);
+
+			if (loading && !data) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			const agent = data?.agent || {};
+			const sys = data?.system || {};
+			const tools = data?.tools || {};
+
+			return html`
+				<div class="status-cards">
+					<div class="status-card">
+						<div class="status-card-header">
+							<span class="status-card-title">Agent</span>
+							<span class="status-badge ${agent.status === 'healthy' ? 'healthy' : agent.status === 'degraded' ? 'degraded' : 'unknown'}">${agent.status || 'Unknown'}</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Heartbeat</span>
+							<span class="status-row-value"><span class="pulse" /> Live</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Version</span>
+							<span class="status-row-value">${agent.version || '—'}</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Uptime</span>
+							<span class="status-row-value">${fmtUptime(sys.uptimeSeconds)}</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Last Check</span>
+							<span class="status-row-value">${data?.timestamp ? new Date(data.timestamp).toLocaleTimeString() : '—'}</span>
+						</div>
+					</div>
+
+					<div class="status-card">
+						<div class="status-card-header">
+							<span class="status-card-title">System</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Node</span>
+							<span class="status-row-value">${sys.nodeVersion || '—'}</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Platform</span>
+							<span class="status-row-value">${sys.platform || '—'} / ${sys.arch || '—'}</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Memory</span>
+							<span class="status-row-value">${sys.memoryMB || '—'} MB RSS</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">Heap</span>
+							<span class="status-row-value">${sys.heapUsedMB || '—'} / ${sys.heapTotalMB || '—'} MB</span>
+						</div>
+					</div>
+
+					<div class="status-card">
+						<div class="status-card-header">
+							<span class="status-card-title">Tools</span>
+							<span class="status-badge healthy">${tools.count || 0}</span>
+						</div>
+						${(tools.names || []).map(name => html`
+							<div class="status-row" key=${name}>
+								<span class="status-row-label">${name}</span>
+								<span class="status-row-value" style="color: var(--color-success)">●</span>
+							</div>
+						`)}
+					</div>
+
+					<div class="status-card">
+						<div class="status-card-header">
+							<span class="status-card-title">Connections</span>
+						</div>
+						<div class="status-row">
+							<span class="status-row-label">SSE Clients</span>
+							<span class="status-row-value">${data?.sseClients ?? 0}</span>
+						</div>
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Tasks Screen ───────────────────────────────────
+
+		const STATUS_ORDER = ["in_progress", "in_review", "blocked", "open", "closed"];
+		const STATUS_EMOJI = { open: "○", in_progress: "◉", in_review: "◎", blocked: "✕", closed: "✓" };
+
+		function TasksScreen() {
+			const [issues, setIssues] = useState([]);
+			const [filter, setFilter] = useState("active");
+			const [loading, setLoading] = useState(true);
+
+			async function refresh() {
+				setLoading(true);
+				const data = await api("/td/issues");
+				if (data.issues) {
+					setIssues(data.issues);
+				}
+				setLoading(false);
+			}
+
+			useEffect(() => { refresh(); }, []);
+
+			const filtered = useMemo(() => {
+				let list = issues;
+				if (filter === "active") list = issues.filter(i => i.status !== "closed");
+				else if (filter !== "all") list = issues.filter(i => i.status === filter);
+				return list.sort((a, b) => {
+					const sa = STATUS_ORDER.indexOf(a.status);
+					const sb = STATUS_ORDER.indexOf(b.status);
+					if (sa !== sb) return sa - sb;
+					const pa = parseInt(a.priority?.[1] || "5");
+					const pb = parseInt(b.priority?.[1] || "5");
+					return pa - pb;
+				});
+			}, [issues, filter]);
+
+			if (loading && issues.length === 0) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			return html`
+				<div class="tasks-container">
+					<div class="tasks-header">
+						${["active", "open", "in_progress", "in_review", "blocked", "closed", "all"].map(f => html`
+							<button key=${f} class="tasks-filter ${filter === f ? 'active' : ''}" onClick=${() => setFilter(f)}>
+								${f === "active" ? "Active" : f === "in_progress" ? "In Progress" : f === "in_review" ? "In Review" : f.charAt(0).toUpperCase() + f.slice(1)}
+							</button>
+						`)}
+					</div>
+					<div class="tasks-list">
+						${filtered.length === 0 && html`
+							<div class="tasks-empty">
+								<div style="font-size: 32px; opacity: 0.3">📋</div>
+								<div>No tasks match "${filter}"</div>
+							</div>
+						`}
+						${filtered.map(issue => html`
+							<div key=${issue.id} class="task-item">
+								<div class="task-title">${STATUS_EMOJI[issue.status] || "○"} ${issue.title}</div>
+								<div class="task-meta">
+									<span class="task-id">${issue.id}</span>
+									<span class="task-badge ${issue.status}">${issue.status}</span>
+									<span class="task-badge ${issue.priority}">${issue.priority}</span>
+									${issue.type && html`<span class="task-badge">${issue.type}</span>`}
+									${issue.points ? html`<span class="task-points">${issue.points}pt</span>` : null}
+								</div>
+							</div>
+						`)}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Files Screen ───────────────────────────────────
+
+		const FILE_ICONS = { directory: "📁", ts: "📘", js: "📒", json: "📋", md: "📝", html: "🌐", css: "🎨", default: "📄" };
+		function fileIcon(name, type) {
+			if (type === "directory") return FILE_ICONS.directory;
+			const ext = name.split(".").pop()?.toLowerCase();
+			return FILE_ICONS[ext] || FILE_ICONS.default;
+		}
+		function fmtSize(bytes) {
+			if (!bytes) return "";
+			if (bytes < 1024) return bytes + " B";
+			if (bytes < 1024*1024) return (bytes/1024).toFixed(1) + " KB";
+			return (bytes/1024/1024).toFixed(1) + " MB";
+		}
+
+		function FilesScreen() {
+			const [currentPath, setCurrentPath] = useState(".");
+			const [items, setItems] = useState([]);
+			const [viewing, setViewing] = useState(null); // { path, content }
+			const [loading, setLoading] = useState(true);
+
+			async function loadDir(dirPath) {
+				setLoading(true);
+				setViewing(null);
+				const data = await api("/files/list?path=" + encodeURIComponent(dirPath));
+				if (data.items) {
+					setItems(data.items);
+					setCurrentPath(data.path || ".");
+				}
+				setLoading(false);
+			}
+
+			async function openFile(filePath) {
+				setLoading(true);
+				const data = await api("/files/read?path=" + encodeURIComponent(filePath));
+				if (data.content !== undefined) {
+					setViewing({ path: data.path, content: data.content, size: data.size });
+				}
+				setLoading(false);
+			}
+
+			useEffect(() => { loadDir("."); }, []);
+
+			const breadcrumbs = currentPath === "." ? ["root"] : ["root", ...currentPath.split("/")];
+
+			if (viewing) {
+				return html`
+					<div class="list-container">
+						<div class="file-breadcrumb">
+							<button onClick=${() => { setViewing(null); }}>← Back</button>
+							<span style="margin-left: 8px; color: var(--color-text-dim)">${viewing.path}</span>
+							<span style="margin-left: auto; color: var(--color-text-muted)">${fmtSize(viewing.size)}</span>
+						</div>
+						<div class="file-viewer">
+							<pre>${viewing.content}</pre>
+						</div>
+					</div>
+				`;
+			}
+
+			if (loading && items.length === 0) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			return html`
+				<div class="list-container">
+					<div class="file-breadcrumb">
+						${breadcrumbs.map((part, i) => html`
+							${i > 0 && html`<span>/</span>`}
+							<button key=${i} onClick=${() => {
+								if (i === 0) loadDir(".");
+								else loadDir(breadcrumbs.slice(1, i+1).join("/"));
+							}}>${part}</button>
+						`)}
+					</div>
+					<div class="list-body">
+						${currentPath !== "." && html`
+							<div class="list-item" onClick=${() => loadDir(currentPath.split("/").slice(0, -1).join("/") || ".")} style="cursor: pointer">
+								<div class="file-item">
+									<span class="file-icon">⬆️</span>
+									<div class="file-info"><div class="file-name">..</div></div>
+								</div>
+							</div>
+						`}
+						${items.map(item => html`
+							<div key=${item.name} class="list-item" style="cursor: pointer" onClick=${() => {
+								if (item.type === "directory") loadDir(item.path);
+								else openFile(item.path);
+							}}>
+								<div class="file-item">
+									<span class="file-icon">${fileIcon(item.name, item.type)}</span>
+									<div class="file-info">
+										<div class="file-name">${item.name}</div>
+										<div class="file-meta">${item.type === "directory" ? "Directory" : fmtSize(item.size)}</div>
+									</div>
+								</div>
+							</div>
+						`)}
+						${items.length === 0 && html`<div class="list-empty">Empty directory</div>`}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Logs Screen ────────────────────────────────────
+
+		const LOG_LEVELS = ["all", "info", "warn", "error", "debug"];
+
+		function LogsScreen() {
+			const [entries, setEntries] = useState([]);
+			const [filter, setFilter] = useState("all");
+			const [pinned, setPinned] = useState(true);
+			const outputRef = useRef(null);
+
+			useEffect(() => {
+				let es = null;
+				let reconnectTimer = null;
+
+				function connect() {
+					es = new EventSource("/api/mobile/logs/events");
+					es.onmessage = (e) => {
+						try {
+							const data = JSON.parse(e.data);
+							if (data.type === "connected") return;
+							setEntries(prev => {
+								const next = [...prev, data];
+								return next.length > 500 ? next.slice(-500) : next;
+							});
+						} catch {}
+					};
+					es.onerror = () => { es.close(); reconnectTimer = setTimeout(connect, 3000); };
+				}
+
+				connect();
+				return () => { if (es) es.close(); if (reconnectTimer) clearTimeout(reconnectTimer); };
+			}, []);
+
+			// Auto-scroll when pinned
+			useEffect(() => {
+				if (pinned && outputRef.current) {
+					outputRef.current.scrollTop = outputRef.current.scrollHeight;
+				}
+			}, [entries, pinned]);
+
+			const filtered = filter === "all" ? entries : entries.filter(e => e.level === filter);
+
+			return html`
+				<div class="logs-container">
+					<div class="logs-filters">
+						${LOG_LEVELS.map(l => html`
+							<button key=${l} class="log-filter ${filter === l ? 'active' : ''}" onClick=${() => setFilter(l)}>
+								${l.charAt(0).toUpperCase() + l.slice(1)}
+							</button>
+						`)}
+						<button class="log-filter ${pinned ? 'active' : ''}" onClick=${() => setPinned(!pinned)} style="margin-left: auto">
+							${pinned ? "📌 Pinned" : "📌 Unpin"}
+						</button>
+						<button class="log-filter" onClick=${() => setEntries([])}>Clear</button>
+					</div>
+					<div class="logs-output" ref=${outputRef}>
+						${filtered.length === 0 && html`
+							<div style="color: var(--color-text-muted); text-align: center; padding: 20px">Waiting for log events...</div>
+						`}
+						${filtered.map((entry, i) => html`
+							<div key=${i} class="log-entry">
+								<span class="log-time">${entry.time ? new Date(entry.time).toLocaleTimeString() : ""}</span>
+								<span class="log-level ${entry.level}">${(entry.level || "info").toUpperCase()}</span>
+								<span class="log-source">${entry.source || ""}</span>
+								<span class="log-msg">${entry.msg}</span>
+							</div>
+						`)}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Cron Screen ────────────────────────────────────
+
+		function CronScreen() {
+			const [jobs, setJobs] = useState([]);
+			const [loading, setLoading] = useState(true);
+
+			async function refresh() {
+				setLoading(true);
+				const data = await api("/cron/jobs");
+				if (data.jobs) setJobs(data.jobs);
+				else if (Array.isArray(data)) setJobs(data);
+				setLoading(false);
+			}
+
+			useEffect(() => { refresh(); }, []);
+
+			async function toggleJob(name, enabled) {
+				await apiPost("/cron/jobs/" + encodeURIComponent(name) + "/toggle", { enabled: !enabled });
+				refresh();
+			}
+
+			async function runJob(name) {
+				await apiPost("/cron/jobs/" + encodeURIComponent(name) + "/run", {});
+			}
+
+			if (loading && jobs.length === 0) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			if (jobs.length === 0) return html`
+				<div class="screen-placeholder">
+					<div class="icon">⏰</div>
+					<div class="label">No Cron Jobs</div>
+					<div class="hint">No scheduled jobs found. Configure pi-cron to add automated tasks.</div>
+				</div>
+			`;
+
+			return html`
+				<div class="list-container">
+					<div class="list-body" style="padding-top: 12px">
+						${jobs.map(job => html`
+							<div key=${job.name} class="list-item cron-item">
+								<div style="display: flex; justify-content: space-between; align-items: center">
+									<div class="list-item-title">${job.name}</div>
+									<button class="cron-toggle ${job.enabled !== false ? 'on' : 'off'}" onClick=${() => toggleJob(job.name, job.enabled !== false)} />
+								</div>
+								<div class="cron-schedule">${job.schedule || job.cron || "—"}</div>
+								<div class="cron-meta">
+									${job.lastRun && html`<span style="font-size: 11px; color: var(--color-text-muted)">Last: ${new Date(job.lastRun).toLocaleString()}</span>`}
+									${job.nextRun && html`<span style="font-size: 11px; color: var(--color-text-dim)">Next: ${new Date(job.nextRun).toLocaleString()}</span>`}
+									<button class="log-filter" style="margin-left: auto; font-size: 11px" onClick=${() => runJob(job.name)}>▶ Run</button>
+								</div>
+							</div>
+						`)}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Skills Screen ──────────────────────────────────
+
+		function SkillsScreen() {
+			const [skills, setSkills] = useState([]);
+			const [search, setSearch] = useState("");
+			const [loading, setLoading] = useState(true);
+
+			useEffect(() => {
+				(async () => {
+					const data = await api("/skills");
+					if (data.skills) setSkills(data.skills);
+					setLoading(false);
+				})();
+			}, []);
+
+			const filtered = search
+				? skills.filter(s => s.name.toLowerCase().includes(search.toLowerCase()) || s.description.toLowerCase().includes(search.toLowerCase()))
+				: skills;
+
+			if (loading) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			return html`
+				<div class="list-container">
+					<div class="list-header">
+						<input class="list-search" placeholder="Search skills..." value=${search} onInput=${e => setSearch(e.target.value)} />
+					</div>
+					<div class="list-body">
+						${filtered.length === 0 && html`<div class="list-empty">No skills match "${search}"</div>`}
+						${filtered.map(s => html`
+							<div key=${s.name} class="list-item">
+								<div class="list-item-title">🧠 ${s.label || s.name}</div>
+								<div class="list-item-desc">${s.description || "No description"}</div>
+							</div>
+						`)}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── CRM Screen ─────────────────────────────────────
+
+		function CrmScreen() {
+			const [contacts, setContacts] = useState([]);
+			const [search, setSearch] = useState("");
+			const [loading, setLoading] = useState(true);
+
+			useEffect(() => {
+				(async () => {
+					const data = await api("/crm/contacts");
+					if (data.contacts) setContacts(data.contacts);
+					else if (Array.isArray(data)) setContacts(data);
+					setLoading(false);
+				})();
+			}, []);
+
+			const filtered = search
+				? contacts.filter(c => {
+					const s = search.toLowerCase();
+					return (c.name || "").toLowerCase().includes(s) || (c.email || "").toLowerCase().includes(s) || (c.company || "").toLowerCase().includes(s);
+				})
+				: contacts;
+
+			if (loading) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			if (contacts.length === 0) return html`
+				<div class="screen-placeholder">
+					<div class="icon">👥</div>
+					<div class="label">No Contacts</div>
+					<div class="hint">No contacts found. The CRM extension may not be installed or has no data.</div>
+				</div>
+			`;
+
+			return html`
+				<div class="list-container">
+					<div class="list-header">
+						<input class="list-search" placeholder="Search contacts..." value=${search} onInput=${e => setSearch(e.target.value)} />
+					</div>
+					<div class="list-body">
+						${filtered.map(c => html`
+							<div key=${c.id || c.name} class="list-item">
+								<div class="list-item-title">👤 ${c.name}</div>
+								<div class="list-item-desc">
+									${c.company ? c.company + " • " : ""}${c.email || ""}
+									${c.phone ? html`<br/><a href="tel:${c.phone}" style="color: var(--color-accent)">${c.phone}</a>` : ""}
+								</div>
+							</div>
+						`)}
+						${filtered.length === 0 && html`<div class="list-empty">No contacts match "${search}"</div>`}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Calendar Screen ────────────────────────────────
+
+		function CalendarScreen() {
+			const [events, setEvents] = useState([]);
+			const [loading, setLoading] = useState(true);
+
+			useEffect(() => {
+				(async () => {
+					const data = await api("/calendar/events");
+					if (data.events) setEvents(data.events);
+					else if (Array.isArray(data)) setEvents(data);
+					setLoading(false);
+				})();
+			}, []);
+
+			if (loading) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			if (events.length === 0) return html`
+				<div class="screen-placeholder">
+					<div class="icon">📅</div>
+					<div class="label">No Events</div>
+					<div class="hint">No upcoming events found. The calendar extension may not be installed.</div>
+				</div>
+			`;
+
+			return html`
+				<div class="list-container">
+					<div class="list-body" style="padding-top: 12px">
+						${events.map((ev, i) => html`
+							<div key=${ev.id || i} class="list-item">
+								<div class="list-item-title">📅 ${ev.title || ev.name || "Untitled"}</div>
+								<div class="list-item-desc">
+									${ev.date || ev.start || ""} ${ev.time || ""}
+									${ev.description ? html`<br/>${ev.description}` : ""}
+								</div>
+							</div>
+						`)}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Extensions Screen ──────────────────────────────
+
+		function ExtensionsScreen() {
+			const [extensions, setExtensions] = useState([]);
+			const [loading, setLoading] = useState(true);
+
+			useEffect(() => {
+				(async () => {
+					const data = await api("/extensions");
+					if (data.extensions) setExtensions(data.extensions);
+					setLoading(false);
+				})();
+			}, []);
+
+			if (loading) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;
+
+			return html`
+				<div class="list-container">
+					<div class="list-body" style="padding-top: 12px">
+						${extensions.map(ext => html`
+							<div key=${ext.name} class="list-item">
+								<div style="display: flex; justify-content: space-between; align-items: center">
+									<div class="list-item-title">🧩 ${ext.name}</div>
+									<span class="status-badge healthy">${ext.toolCount} tools</span>
+								</div>
+								<div class="list-item-desc">${ext.tools.join(", ")}</div>
+							</div>
+						`)}
+						${extensions.length === 0 && html`<div class="list-empty">No extensions found</div>`}
+					</div>
+				</div>
+			`;
+		}
+
+		// ── Settings Screen ────────────────────────────────
+
+		function SettingsScreen() {
+			const [agentUrl, setAgentUrl] = useState(() => localStorage.getItem("pi-mobile-agent-url") || "");
+			const [apiKey, setApiKey] = useState(() => localStorage.getItem("pi-mobile-api-key") || "");
+			const [testResult, setTestResult] = useState(null);
+			const [theme, setTheme] = useState(() => localStorage.getItem("pi-mobile-theme") || "dark");
+
+			function saveUrl() {
+				localStorage.setItem("pi-mobile-agent-url", agentUrl);
+				setTestResult("saved");
+				setTimeout(() => setTestResult(null), 2000);
+			}
+
+			function saveApiKey() {
+				localStorage.setItem("pi-mobile-api-key", apiKey);
+				setTestResult("saved");
+				setTimeout(() => setTestResult(null), 2000);
+			}
+
+			async function testConnection() {
+				setTestResult("testing...");
+				try {
+					const url = agentUrl || "";
+					const res = await fetch((url ? url : "") + "/api/mobile/health", { signal: AbortSignal.timeout(5000) });
+					setTestResult(res.ok ? "✅ Connected" : "❌ HTTP " + res.status);
+				} catch (e) {
+					setTestResult("❌ " + (e.message || "Failed"));
+				}
+			}
+
+			function clearData() {
+				if (confirm("Clear all local data and settings?")) {
+					localStorage.clear();
+					location.reload();
+				}
+			}
+
+			return html`
+				<div style="overflow-y: auto; -webkit-overflow-scrolling: touch; height: 100%">
+					<div class="settings-section">
+						<div class="settings-section-title">Connection</div>
+						<div class="settings-row" style="flex-direction: column; align-items: stretch">
+							<div class="settings-row-label">Agent URL</div>
+							<input class="settings-input" placeholder="http://macbook.local:3000" value=${agentUrl} onInput=${e => setAgentUrl(e.target.value)} onBlur=${saveUrl} />
+						</div>
+						<div class="settings-row" style="flex-direction: column; align-items: stretch">
+							<div class="settings-row-label">API Key</div>
+							<input class="settings-input" type="password" placeholder="Optional — for remote access" value=${apiKey} onInput=${e => setApiKey(e.target.value)} onBlur=${saveApiKey} />
+						</div>
+						<button class="settings-btn" onClick=${testConnection}>
+							${testResult || "Test Connection"}
+						</button>
+					</div>
+
+					<div class="settings-section">
+						<div class="settings-section-title">Appearance</div>
+						<div class="settings-row">
+							<span class="settings-row-label">Theme</span>
+							<span class="settings-row-value">${theme === "dark" ? "🌙 Dark" : "☀️ Light"}</span>
+						</div>
+					</div>
+
+					<div class="settings-section">
+						<div class="settings-section-title">About</div>
+						<div class="settings-row">
+							<span class="settings-row-label">Version</span>
+							<span class="settings-row-value">0.1.0</span>
+						</div>
+						<div class="settings-row">
+							<span class="settings-row-label">Build</span>
+							<span class="settings-row-value">Preact + HTM</span>
+						</div>
+					</div>
+
+					<div class="settings-section">
+						<div class="settings-section-title">Data</div>
+						<button class="settings-btn danger" onClick=${clearData}>Clear All Local Data</button>
+					</div>
+				</div>
+			`;
+		}
+
+		const SCREENS = { chat: ChatScreen, status: StatusScreen, tasks: TasksScreen, files: FilesScreen, logs: LogsScreen, cron: CronScreen, skills: SkillsScreen, crm: CrmScreen, calendar: CalendarScreen, extensions: ExtensionsScreen, settings: SettingsScreen };
+
+		// ── Error Boundary ─────────────────────────────────
+
+		class ErrorBoundary extends Component {
+			constructor(props) { super(props); this.state = { error: null }; }
+			static getDerivedStateFromError(error) { return { error: error.message || "Something went wrong" }; }
+			render() {
+				if (this.state.error) {
+					return html`
+						<div class="error-boundary">
+							<div class="error-icon">⚠️</div>
+							<div class="error-message">${this.state.error}</div>
+							<button onClick=${() => this.setState({ error: null })}>Retry</button>
+						</div>
+					`;
+				}
+				return this.props.children;
+			}
+		}
+
+		// ── Header ─────────────────────────────────────────
+
+		function Header({ connected }) {
+			return html`
+				<header class="header">
+					<div class="header-title">π Agent</div>
+					<div class="header-status">
+						<div class="status-dot ${connected ? 'connected' : ''}" />
+						<span>${connected ? "Connected" : "Offline"}</span>
+					</div>
+				</header>
+			`;
+		}
+
+		// ── Tab Bar ────────────────────────────────────────
+
+		function TabBar({ activeTab, onTabChange }) {
+			return html`
+				<nav class="tab-bar">
+					${TABS.map(tab => html`
+						<button key=${tab.id} class="tab-item ${activeTab === tab.id ? 'active' : ''}" onClick=${() => onTabChange(tab.id)}>
+							<span class="tab-icon">${tab.icon}</span>
+							<span class="tab-label">${tab.label}</span>
+						</button>
+					`)}
+				</nav>
+			`;
+		}
+
+		// ── App ────────────────────────────────────────────
+
+		function App() {
+			const [activeTab, setActiveTab] = useState("chat");
+			const [connected, setConnected] = useState(false);
+
+			useEffect(() => {
+				let mounted = true;
+				async function check() {
+					try {
+						const res = await fetch("/api/mobile/health");
+						if (mounted) setConnected(res.ok);
+					} catch { if (mounted) setConnected(false); }
+				}
+				check();
+				const iv = setInterval(check, 30000);
+				return () => { mounted = false; clearInterval(iv); };
+			}, []);
+
+			const Screen = SCREENS[activeTab] || ChatScreen;
+
+			return html`
+				<${Header} connected=${connected} />
+				<main class="tab-content">
+					<${ErrorBoundary} key=${activeTab}><${Screen} /></${ErrorBoundary}>
+				</main>
+				<${TabBar} activeTab=${activeTab} onTabChange=${setActiveTab} />
+			`;
+		}
+
+		// ── Boot ───────────────────────────────────────────
+
+		render(html`<${App} />`, document.getElementById("app"));
+		if ("serviceWorker" in navigator) navigator.serviceWorker.register("/mobile/sw.js").catch(() => {});
+	</script>
+</body>
+</html>

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -1121,7 +1121,7 @@
 								<div class="list-item-title">👤 ${c.name}</div>
 								<div class="list-item-desc">
 									${c.company ? c.company + " • " : ""}${c.email || ""}
-									${c.phone ? html`<br/><a href="tel:${c.phone}" style="color: var(--color-accent)">${c.phone}</a>` : ""}
+									${c.phone && /^[+\d\s()\-\.]+$/.test(c.phone) ? html`<br/><a href="tel:${c.phone}" style="color: var(--color-accent)">${c.phone}</a>` : c.phone ? html`<br/><span>${c.phone}</span>` : ""}
 								</div>
 							</div>
 						`)}

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -422,17 +422,41 @@
 		// Minimal markdown → HTML (handles **bold**, *italic*, `code`, ```blocks```, links, lists)
 		function md(text) {
 			if (!text) return "";
-			return esc(text)
-				.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
-				.replace(/`([^`]+)`/g, '<code>$1</code>')
+			
+			// Escape HTML first
+			const escaped = esc(text);
+			
+			// Extract code blocks and inline code into placeholders to prevent subsequent transforms from affecting them
+			const codeBlocks = [];
+			const withPlaceholders = escaped
+				.replace(/```(\w*)\n([\s\S]*?)```/g, (match, lang, code) => {
+					codeBlocks.push(`<pre><code>${code}</code></pre>`);
+					return `\x00CODE_BLOCK_${codeBlocks.length - 1}\x00`;
+				})
+				.replace(/`([^`]+)`/g, (match, code) => {
+					codeBlocks.push(`<code>${code}</code>`);
+					return `\x00CODE_BLOCK_${codeBlocks.length - 1}\x00`;
+				});
+			
+			// Apply inline transforms (bold, italic, links, headings) on non-code text
+			const transformed = withPlaceholders
 				.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
 				.replace(/\*(.+?)\*/g, '<em>$1</em>')
-				.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>')
+				.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, url) => {
+					// Security: only allow http(s) URLs to prevent javascript: protocol XSS
+					const isHttpUrl = /^https?:\/\//i.test(url);
+					return isHttpUrl 
+						? `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>` 
+						: text;
+				})
 				.replace(/^### (.+)$/gm, '<strong>$1</strong>')
 				.replace(/^## (.+)$/gm, '<strong>$1</strong>')
 				.replace(/^# (.+)$/gm, '<strong>$1</strong>')
 				.replace(/^[-*] (.+)$/gm, '• $1')
 				.replace(/\n/g, '<br>');
+			
+			// Restore code blocks
+			return transformed.replace(/\x00CODE_BLOCK_(\d+)\x00/g, (match, index) => codeBlocks[parseInt(index)]);
 		}
 
 		// ── Tab definitions ────────────────────────────────
@@ -979,6 +1003,7 @@
 
 			async function runJob(name) {
 				await apiPost("/cron/jobs/" + encodeURIComponent(name) + "/run", {});
+				refresh();
 			}
 
 			if (loading && jobs.length === 0) return html`<div class="screen-placeholder"><div class="spinner" /></div>`;

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -414,10 +414,15 @@
 		const api = (path, opts) => fetch("/api/mobile" + path, opts).then(r => r.json()).catch(() => ({ error: "Network error" }));
 		const apiPost = (path, body) => api(path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
 
+		// HTML escape helper
+		function esc(s) {
+			return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+		}
+
 		// Minimal markdown → HTML (handles **bold**, *italic*, `code`, ```blocks```, links, lists)
 		function md(text) {
 			if (!text) return "";
-			return text
+			return esc(text)
 				.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
 				.replace(/`([^`]+)`/g, '<code>$1</code>')
 				.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
@@ -639,7 +644,7 @@
 					<div class="status-card">
 						<div class="status-card-header">
 							<span class="status-card-title">Agent</span>
-							<span class="status-badge ${agent.status === 'healthy' ? 'healthy' : agent.status === 'degraded' ? 'degraded' : 'unknown'}">${agent.status || 'Unknown'}</span>
+							<span class="status-badge ${agent.status === 'healthy' ? 'healthy' : agent.status === 'degraded' ? 'degraded' : agent.status === 'down' ? 'down' : 'unknown'}">${agent.status || 'Unknown'}</span>
 						</div>
 						<div class="status-row">
 							<span class="status-row-label">Heartbeat</span>

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -445,9 +445,10 @@
 				.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, url) => {
 					// Security: only allow http(s) URLs to prevent javascript: protocol XSS
 					const isHttpUrl = /^https?:\/\//i.test(url);
-					return isHttpUrl 
-						? `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>` 
-						: text;
+					if (!isHttpUrl) return text;
+					// Escape quotes to prevent attribute-injection XSS
+					const safeUrl = url.replace(/"/g, '%22').replace(/'/g, '%27');
+					return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`;
 				})
 				.replace(/^### (.+)$/gm, '<strong>$1</strong>')
 				.replace(/^## (.+)$/gm, '<strong>$1</strong>')

--- a/extensions/pi-mobile/public/manifest.json
+++ b/extensions/pi-mobile/public/manifest.json
@@ -1,0 +1,26 @@
+{
+	"name": "Pi Agent",
+	"short_name": "Pi",
+	"description": "Mobile control for Pi coding agents",
+	"start_url": "/mobile",
+	"scope": "/mobile",
+	"display": "standalone",
+	"orientation": "portrait",
+	"background_color": "#0a0a0f",
+	"theme_color": "#6366f1",
+	"categories": ["developer", "productivity"],
+	"icons": [
+		{
+			"src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect width='192' height='192' rx='32' fill='%236366f1'/><text x='96' y='130' text-anchor='middle' font-size='120' font-family='system-ui' fill='white'>π</text></svg>",
+			"sizes": "192x192",
+			"type": "image/svg+xml",
+			"purpose": "any"
+		},
+		{
+			"src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><rect width='512' height='512' rx='80' fill='%236366f1'/><text x='256' y='350' text-anchor='middle' font-size='320' font-family='system-ui' fill='white'>π</text></svg>",
+			"sizes": "512x512",
+			"type": "image/svg+xml",
+			"purpose": "any maskable"
+		}
+	]
+}

--- a/extensions/pi-mobile/public/sw.js
+++ b/extensions/pi-mobile/public/sw.js
@@ -63,6 +63,6 @@ self.addEventListener("fetch", (event) => {
 				return cached;
 			}
 			return fetch(event.request);
-		})
+		}).catch(() => fetch(event.request))
 	);
 });

--- a/extensions/pi-mobile/public/sw.js
+++ b/extensions/pi-mobile/public/sw.js
@@ -53,13 +53,12 @@ self.addEventListener("fetch", (event) => {
 		caches.match(event.request).then((cached) => {
 			if (cached) {
 				// Return cached version, but update cache in background
-				fetch(event.request).then((response) => {
+				const bgUpdate = fetch(event.request).then((response) => {
 					if (response.ok) {
-						caches.open(CACHE_NAME).then((cache) => {
-							cache.put(event.request, response);
-						});
+						return caches.open(CACHE_NAME).then((cache) => cache.put(event.request, response));
 					}
 				}).catch(() => {});
+				event.waitUntil(bgUpdate);
 				return cached;
 			}
 			return fetch(event.request);

--- a/extensions/pi-mobile/public/sw.js
+++ b/extensions/pi-mobile/public/sw.js
@@ -1,0 +1,68 @@
+/**
+ * Service Worker — App Shell caching strategy.
+ *
+ * Caches the app shell (HTML, manifest) for offline access.
+ * API requests are always network-first (never cached).
+ */
+
+const CACHE_NAME = "pi-mobile-v1";
+
+const APP_SHELL_URLS = [
+	"/mobile",
+	"/mobile/manifest.json",
+];
+
+// ── Install: pre-cache the app shell ─────────────────────────
+
+self.addEventListener("install", (event) => {
+	event.waitUntil(
+		caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL_URLS))
+	);
+	// Activate immediately — don't wait for old tabs to close
+	self.skipWaiting();
+});
+
+// ── Activate: clean up old caches ────────────────────────────
+
+self.addEventListener("activate", (event) => {
+	event.waitUntil(
+		caches.keys().then((keys) =>
+			Promise.all(
+				keys
+					.filter((key) => key !== CACHE_NAME)
+					.map((key) => caches.delete(key))
+			)
+		)
+	);
+	// Take control of all tabs immediately
+	self.clients.claim();
+});
+
+// ── Fetch: network-first for API, cache-first for app shell ──
+
+self.addEventListener("fetch", (event) => {
+	const url = new URL(event.request.url);
+
+	// API requests — always network, never cache
+	if (url.pathname.startsWith("/api/")) {
+		return;
+	}
+
+	// App shell — cache-first, fallback to network
+	event.respondWith(
+		caches.match(event.request).then((cached) => {
+			if (cached) {
+				// Return cached version, but update cache in background
+				fetch(event.request).then((response) => {
+					if (response.ok) {
+						caches.open(CACHE_NAME).then((cache) => {
+							cache.put(event.request, response);
+						});
+					}
+				}).catch(() => {});
+				return cached;
+			}
+			return fetch(event.request);
+		})
+	);
+});

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -212,7 +212,10 @@ async function handleTdApi(req: IncomingMessage, res: ServerResponse, subPath: s
 			const args = ["create", body.title || "Untitled"];
 			if (body.type) args.push("--type", body.type);
 			if (body.priority) args.push("--priority", body.priority);
-			if (body.labels) args.push("--label", body.labels);
+			if (body.labels) {
+				const labels = Array.isArray(body.labels) ? body.labels.join(",") : body.labels;
+				args.push("--label", labels);
+			}
 			if (body.minor) args.push("--minor");
 			const result = await runTd(args);
 			if (!result.ok) { json(res, 500, { error: result.error }); return; }

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -111,9 +111,9 @@ function broadcast(data: unknown): void {
 
 async function handleChatApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
 	if (subPath === "/prompt" && req.method === "POST") {
-		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
 		try {
 			const body = JSON.parse(await readBody(req));
+			if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
 			const prompt = body.prompt;
 			if (!prompt || typeof prompt !== "string") {
 				json(res, 400, { error: "Missing 'prompt' string in request body" });
@@ -346,10 +346,10 @@ async function handleCronApi(req: IncomingMessage, res: ServerResponse, subPath:
 
 	// POST /jobs/:name/toggle — enable/disable
 	if (subPath.match(/^\/jobs\/[^/]+\/toggle$/) && req.method === "POST") {
-		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
 		const name = decodeURIComponent(subPath.split("/")[2]);
 		try {
 			const body = JSON.parse(await readBody(req));
+			if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
 			const action = body.enabled ? "enable" : "disable";
 			const result = await _pi.exec("pi-cron", [action, name], { timeout: 10_000 });
 			json(res, 200, { ok: result.code === 0, output: result.stdout?.trim() });

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -1,0 +1,677 @@
+/**
+ * pi-mobile — PWA mobile app for Pi agents.
+ *
+ * Mounts on pi-webserver:
+ *   Page: /mobile              — PWA app shell (Preact + HTM)
+ *   Page: /mobile/manifest.json — PWA manifest
+ *   Page: /mobile/sw.js        — Service worker
+ *   Page: /mobile/screens/*.js  — Screen modules
+ *   API:  /api/mobile/health   — Health check
+ *   API:  /api/mobile/chat/*   — Chat proxy (prompt submission)
+ *   API:  /api/mobile/status   — Agent status
+ *   API:  /api/mobile/td/*     — Task management proxy
+ *   API:  /api/mobile/files/*  — File browser
+ *   API:  /api/mobile/logs/*   — Log streaming
+ *   API:  /api/mobile/cron/*   — Cron job management
+ *   API:  /api/mobile/skills   — Skills browser
+ *   API:  /api/mobile/extensions — Extensions list
+ *   API:  /api/mobile/crm/*    — CRM proxy
+ *   API:  /api/mobile/calendar/* — Calendar proxy
+ *   API:  /api/mobile/settings — Settings
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+// ── Static files ─────────────────────────────────────────────
+
+const PUBLIC_DIR = path.resolve(import.meta.dirname, "../public");
+
+function readPublicFile(filePath: string): string {
+	return fs.readFileSync(path.join(PUBLIC_DIR, filePath), "utf-8");
+}
+
+const APP_HTML = readPublicFile("app.html");
+const MANIFEST_JSON = readPublicFile("manifest.json");
+const SW_JS = readPublicFile("sw.js");
+
+/** Cache for screen JS modules — loaded lazily on first request. */
+const screenCache = new Map<string, string>();
+
+function getScreenJs(name: string): string | null {
+	if (screenCache.has(name)) return screenCache.get(name)!;
+	const filePath = path.join(PUBLIC_DIR, "screens", `${name}.js`);
+	if (!fs.existsSync(filePath)) return null;
+	const content = fs.readFileSync(filePath, "utf-8");
+	screenCache.set(name, content);
+	return content;
+}
+
+// ── HTTP helpers ─────────────────────────────────────────────
+
+function send(res: ServerResponse, status: number, contentType: string, body: string): void {
+	res.writeHead(status, { "Content-Type": contentType });
+	res.end(body);
+}
+
+function json(res: ServerResponse, status: number, data: unknown): void {
+	send(res, status, "application/json; charset=utf-8", JSON.stringify(data));
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (c: Buffer) => chunks.push(c));
+		req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+		req.on("error", reject);
+	});
+}
+
+// ── API: Chat ────────────────────────────────────────────────
+
+let _pi: ExtensionAPI | null = null;
+
+/** Active SSE client connections. */
+const sseClients = new Set<ServerResponse>();
+/** Active log SSE client connections. */
+const logClients = new Set<ServerResponse>();
+
+/** Broadcast a log entry to connected log SSE clients. */
+function broadcastLog(data: unknown): void {
+	const payload = `data: ${JSON.stringify(data)}\n\n`;
+	for (const res of logClients) {
+		if (!res.writable) { logClients.delete(res); continue; }
+		try { res.write(payload); } catch { logClients.delete(res); }
+	}
+}
+
+/** Broadcast an event to all connected SSE clients. */
+function broadcast(data: unknown): void {
+	const payload = `data: ${JSON.stringify(data)}\n\n`;
+	for (const res of sseClients) {
+		if (!res.writable) { sseClients.delete(res); continue; }
+		try { res.write(payload); } catch { sseClients.delete(res); }
+	}
+}
+
+async function handleChatApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	if (subPath === "/prompt" && req.method === "POST") {
+		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
+		try {
+			const body = JSON.parse(await readBody(req));
+			const prompt = body.prompt;
+			if (!prompt || typeof prompt !== "string") {
+				json(res, 400, { error: "Missing 'prompt' string in request body" });
+				return;
+			}
+			// Inject the message into the main agent conversation
+			_pi.sendMessage(
+				{
+					customType: "mobile-prompt",
+					content: `📱 **Mobile:** ${prompt}`,
+					display: true,
+				},
+				{ triggerTurn: true },
+			);
+			json(res, 200, { ok: true, message: "Prompt submitted" });
+		} catch {
+			json(res, 400, { error: "Invalid JSON body" });
+		}
+		return;
+	}
+
+	// SSE stream — broadcast agent events to connected mobile clients
+	if (subPath === "/events" && req.method === "GET") {
+		res.writeHead(200, {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache",
+			Connection: "keep-alive",
+			"X-Accel-Buffering": "no",
+		});
+		res.write(`data: ${JSON.stringify({ type: "connected", time: new Date().toISOString() })}\n\n`);
+
+		// Register this SSE connection for broadcast
+		sseClients.add(res);
+
+		// Keepalive ping every 15s
+		const keepalive = setInterval(() => {
+			if (!res.writable) { clearInterval(keepalive); return; }
+			try { res.write(": ping\n\n"); } catch { clearInterval(keepalive); }
+		}, 15_000);
+
+		req.on("close", () => {
+			clearInterval(keepalive);
+			sseClients.delete(res);
+		});
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── API: Tasks (td) ──────────────────────────────────────────
+
+async function runTd(args: string[]): Promise<{ ok: boolean; data?: string; error?: string }> {
+	if (!_pi) return { ok: false, error: "Agent not ready" };
+	try {
+		const result = await _pi.exec("td", args, { timeout: 15_000 });
+		const stdout = result.stdout?.trim() ?? "";
+		const stderr = result.stderr?.trim() ?? "";
+		if (result.code !== 0) return { ok: false, error: stderr || stdout || `Exit code ${result.code}` };
+		return { ok: true, data: stdout };
+	} catch (err: unknown) {
+		return { ok: false, error: err instanceof Error ? err.message : String(err) };
+	}
+}
+
+async function handleTdApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	// GET /issues — list issues as JSON
+	if (subPath === "/issues" && req.method === "GET") {
+		const result = await runTd(["list", "--json"]);
+		if (!result.ok) { json(res, 500, { error: result.error }); return; }
+		try {
+			json(res, 200, { issues: JSON.parse(result.data!) });
+		} catch {
+			json(res, 200, { issues: [], raw: result.data });
+		}
+		return;
+	}
+
+	// GET /issues/:id — show single issue
+	if (subPath.match(/^\/issues\/[a-z0-9-]+$/) && req.method === "GET") {
+		const id = subPath.split("/")[2];
+		const result = await runTd(["show", id, "--json"]);
+		if (!result.ok) { json(res, 404, { error: result.error }); return; }
+		try {
+			json(res, 200, JSON.parse(result.data!));
+		} catch {
+			json(res, 200, { raw: result.data });
+		}
+		return;
+	}
+
+	// POST /issues — create issue
+	if (subPath === "/issues" && req.method === "POST") {
+		try {
+			const body = JSON.parse(await readBody(req));
+			const args = ["create", body.title || "Untitled"];
+			if (body.type) args.push("--type", body.type);
+			if (body.priority) args.push("--priority", body.priority);
+			if (body.labels) args.push("--label", body.labels);
+			if (body.minor) args.push("--minor");
+			const result = await runTd(args);
+			if (!result.ok) { json(res, 500, { error: result.error }); return; }
+			json(res, 201, { ok: true, output: result.data });
+		} catch {
+			json(res, 400, { error: "Invalid JSON body" });
+		}
+		return;
+	}
+
+	// PATCH /issues/:id — update issue (status transitions)
+	if (subPath.match(/^\/issues\/[a-z0-9-]+$/) && req.method === "PATCH") {
+		const id = subPath.split("/")[2];
+		try {
+			const body = JSON.parse(await readBody(req));
+			let result;
+			if (body.action === "start") result = await runTd(["start", id]);
+			else if (body.action === "close") result = await runTd(["close", id]);
+			else if (body.action === "reopen") result = await runTd(["reopen", id]);
+			else if (body.priority) result = await runTd(["edit", id, "--priority", body.priority]);
+			else { json(res, 400, { error: "Unknown action" }); return; }
+			if (!result.ok) { json(res, 500, { error: result.error }); return; }
+			json(res, 200, { ok: true, output: result.data });
+		} catch {
+			json(res, 400, { error: "Invalid JSON body" });
+		}
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── API: CRM ─────────────────────────────────────────────────
+
+async function handleCrmApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
+
+	// GET /contacts — list contacts
+	if ((subPath === "/contacts" || subPath === "") && req.method === "GET") {
+		try {
+			const result = await _pi.exec("pi-crm", ["contacts", "list", "--json"], { timeout: 10_000 });
+			if (result.code === 0 && result.stdout) {
+				json(res, 200, JSON.parse(result.stdout));
+			} else {
+				json(res, 200, { contacts: [] });
+			}
+		} catch {
+			json(res, 200, { contacts: [] });
+		}
+		return;
+	}
+
+	// POST /contacts — create contact
+	if (subPath === "/contacts" && req.method === "POST") {
+		try {
+			const body = JSON.parse(await readBody(req));
+			const args = ["contacts", "create", body.name || "Unknown"];
+			if (body.email) args.push("--email", body.email);
+			if (body.company) args.push("--company", body.company);
+			const result = await _pi.exec("pi-crm", args, { timeout: 10_000 });
+			json(res, 201, { ok: result.code === 0, output: result.stdout?.trim() });
+		} catch {
+			json(res, 400, { error: "Invalid request" });
+		}
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── API: Calendar ────────────────────────────────────────────
+
+async function handleCalendarApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
+
+	// GET /events — list upcoming events
+	if ((subPath === "/events" || subPath === "") && req.method === "GET") {
+		try {
+			const result = await _pi.exec("pi-calendar", ["events", "list", "--json"], { timeout: 10_000 });
+			if (result.code === 0 && result.stdout) {
+				json(res, 200, JSON.parse(result.stdout));
+			} else {
+				json(res, 200, { events: [] });
+			}
+		} catch {
+			json(res, 200, { events: [] });
+		}
+		return;
+	}
+
+	// POST /events — create event
+	if (subPath === "/events" && req.method === "POST") {
+		try {
+			const body = JSON.parse(await readBody(req));
+			const args = ["events", "create", body.title || "Untitled"];
+			if (body.date) args.push("--date", body.date);
+			if (body.time) args.push("--time", body.time);
+			const result = await _pi.exec("pi-calendar", args, { timeout: 10_000 });
+			json(res, 201, { ok: result.code === 0, output: result.stdout?.trim() });
+		} catch {
+			json(res, 400, { error: "Invalid request" });
+		}
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── API: Cron ────────────────────────────────────────────────
+
+async function handleCronApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	// GET /jobs — list all cron jobs
+	if ((subPath === "/jobs" || subPath === "") && req.method === "GET") {
+		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
+		try {
+			const result = await _pi.exec("pi-cron", ["list", "--json"], { timeout: 10_000 });
+			if (result.code === 0 && result.stdout) {
+				json(res, 200, JSON.parse(result.stdout));
+			} else {
+				// pi-cron may not be installed — return empty list
+				json(res, 200, { jobs: [] });
+			}
+		} catch {
+			json(res, 200, { jobs: [] });
+		}
+		return;
+	}
+
+	// POST /jobs/:name/toggle — enable/disable
+	if (subPath.match(/^\/jobs\/[^/]+\/toggle$/) && req.method === "POST") {
+		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
+		const name = subPath.split("/")[2];
+		try {
+			const body = JSON.parse(await readBody(req));
+			const action = body.enabled ? "enable" : "disable";
+			const result = await _pi.exec("pi-cron", [action, name], { timeout: 10_000 });
+			json(res, 200, { ok: result.code === 0, output: result.stdout?.trim() });
+		} catch {
+			json(res, 400, { error: "Invalid request" });
+		}
+		return;
+	}
+
+	// POST /jobs/:name/run — trigger manual run
+	if (subPath.match(/^\/jobs\/[^/]+\/run$/) && req.method === "POST") {
+		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
+		const name = subPath.split("/")[2];
+		try {
+			const result = await _pi.exec("pi-cron", ["run", name], { timeout: 30_000 });
+			json(res, 200, { ok: result.code === 0, output: result.stdout?.trim() });
+		} catch {
+			json(res, 500, { error: "Run failed" });
+		}
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── API: Files ───────────────────────────────────────────────
+
+let _cwd = process.cwd();
+
+const SKIP_DIRS = new Set(["node_modules", ".git", ".todos", "dist", "build", ".next", ".nuxt", "__pycache__"]);
+
+function safeResolvePath(requestedPath: string): string | null {
+	const resolved = path.resolve(_cwd, requestedPath);
+	// Prevent path traversal — must stay within cwd
+	if (!resolved.startsWith(_cwd)) return null;
+	return resolved;
+}
+
+async function handleFilesApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	const url = new URL(req.url ?? "/", "http://localhost");
+	const filePath = url.searchParams.get("path") ?? "/";
+
+	// GET /list?path=/ — list directory contents
+	if ((subPath === "/list" || subPath === "") && req.method === "GET") {
+		const resolved = safeResolvePath(filePath);
+		if (!resolved) { json(res, 400, { error: "Invalid path" }); return; }
+
+		try {
+			const stat = fs.statSync(resolved);
+			if (!stat.isDirectory()) { json(res, 400, { error: "Not a directory" }); return; }
+
+			const entries = fs.readdirSync(resolved, { withFileTypes: true });
+			const items = entries
+				.filter(e => !e.name.startsWith(".") && !SKIP_DIRS.has(e.name))
+				.map(e => {
+					const fullPath = path.join(resolved, e.name);
+					const relativePath = path.relative(_cwd, fullPath);
+					try {
+						const s = fs.statSync(fullPath);
+						return {
+							name: e.name,
+							path: relativePath,
+							type: e.isDirectory() ? "directory" : "file",
+							size: e.isDirectory() ? 0 : s.size,
+							modified: s.mtime.toISOString(),
+						};
+					} catch {
+						return { name: e.name, path: relativePath, type: e.isDirectory() ? "directory" : "file", size: 0, modified: "" };
+					}
+				})
+				.sort((a, b) => {
+					if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+					return a.name.localeCompare(b.name);
+				});
+
+			json(res, 200, { path: path.relative(_cwd, resolved) || ".", items });
+		} catch {
+			json(res, 404, { error: "Directory not found" });
+		}
+		return;
+	}
+
+	// GET /read?path=src/index.ts — read file content
+	if (subPath === "/read" && req.method === "GET") {
+		const resolved = safeResolvePath(filePath);
+		if (!resolved) { json(res, 400, { error: "Invalid path" }); return; }
+
+		try {
+			const stat = fs.statSync(resolved);
+			if (stat.isDirectory()) { json(res, 400, { error: "Is a directory" }); return; }
+			if (stat.size > 512 * 1024) { json(res, 400, { error: "File too large (max 512KB)" }); return; }
+			const content = fs.readFileSync(resolved, "utf-8");
+			json(res, 200, { path: path.relative(_cwd, resolved), content, size: stat.size });
+		} catch {
+			json(res, 404, { error: "File not found" });
+		}
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── Route handlers ───────────────────────────────────────────
+
+function handlePage(_req: IncomingMessage, res: ServerResponse, subPath: string): void {
+	const p = subPath.replace(/\/+$/, "") || "/";
+
+	switch (p) {
+		case "/":
+			send(res, 200, "text/html; charset=utf-8", APP_HTML);
+			return;
+		case "/manifest.json":
+			send(res, 200, "application/manifest+json; charset=utf-8", MANIFEST_JSON);
+			return;
+		case "/sw.js":
+			send(res, 200, "application/javascript; charset=utf-8", SW_JS);
+			return;
+		default:
+			// Screen JS modules: /mobile/screens/chat.js → public/screens/chat.js
+			if (p.startsWith("/screens/") && p.endsWith(".js")) {
+				const screenName = p.slice("/screens/".length, -3);
+				const content = getScreenJs(screenName);
+				if (content) {
+					send(res, 200, "application/javascript; charset=utf-8", content);
+					return;
+				}
+			}
+			// SPA fallback
+			send(res, 200, "text/html; charset=utf-8", APP_HTML);
+			return;
+	}
+}
+
+async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {
+	const p = subPath.replace(/\/+$/, "") || "/";
+
+	// Health check
+	if (p === "/health") {
+		json(res, 200, { status: "ok", version: "0.1.0", timestamp: new Date().toISOString() });
+		return;
+	}
+
+	// Status API — aggregated agent health
+	if (p === "/status") {
+		const tools = _pi ? _pi.getAllTools() : [];
+		const uptime = process.uptime();
+		const mem = process.memoryUsage();
+		json(res, 200, {
+			agent: { name: "Pi Agent", status: _pi ? "healthy" : "down", version: "0.1.0" },
+			system: {
+				nodeVersion: process.version,
+				platform: process.platform,
+				arch: process.arch,
+				uptimeSeconds: Math.round(uptime),
+				memoryMB: Math.round(mem.rss / 1024 / 1024),
+				heapUsedMB: Math.round(mem.heapUsed / 1024 / 1024),
+				heapTotalMB: Math.round(mem.heapTotal / 1024 / 1024),
+			},
+			tools: { count: tools.length, names: tools.map(t => t.name).sort() },
+			sseClients: sseClients.size,
+			timestamp: new Date().toISOString(),
+		});
+		return;
+	}
+
+	// Chat API
+	if (p.startsWith("/chat")) {
+		await handleChatApi(req, res, p.slice("/chat".length) || "/");
+		return;
+	}
+
+	// Tasks API — proxy to td CLI
+	if (p.startsWith("/td")) {
+		await handleTdApi(req, res, p.slice("/td".length) || "/");
+		return;
+	}
+
+	// Files API — workspace file browser
+	if (p.startsWith("/files")) {
+		await handleFilesApi(req, res, p.slice("/files".length) || "/");
+		return;
+	}
+
+	// CRM API — contact management proxy
+	if (p.startsWith("/crm")) {
+		await handleCrmApi(req, res, p.slice("/crm".length) || "/");
+		return;
+	}
+
+	// Calendar API — event management proxy
+	if (p.startsWith("/calendar")) {
+		await handleCalendarApi(req, res, p.slice("/calendar".length) || "/");
+		return;
+	}
+
+	// Skills API — list registered skills
+	if (p === "/skills" && req.method === "GET") {
+		const tools = _pi ? _pi.getAllTools() : [];
+		const skills = tools.map(t => ({
+			name: t.name,
+			description: t.description ?? "",
+		}));
+		json(res, 200, { skills });
+		return;
+	}
+
+	// Extensions API — list registered tools/extensions
+	if (p === "/extensions" && req.method === "GET") {
+		const tools = _pi ? _pi.getAllTools() : [];
+		const grouped: Record<string, string[]> = {};
+		for (const t of tools) {
+			const prefix = t.name.includes("_") ? t.name.split("_")[0] : "core";
+			if (!grouped[prefix]) grouped[prefix] = [];
+			grouped[prefix].push(t.name);
+		}
+		const extensions = Object.entries(grouped).map(([name, toolNames]) => ({
+			name,
+			tools: toolNames,
+			toolCount: toolNames.length,
+		}));
+		json(res, 200, { extensions });
+		return;
+	}
+
+	// Cron API — job management
+	if (p.startsWith("/cron")) {
+		await handleCronApi(req, res, p.slice("/cron".length) || "/");
+		return;
+	}
+
+	// Logs API — live log streaming
+	if (p === "/logs/events" && req.method === "GET") {
+		res.writeHead(200, {
+			"Content-Type": "text/event-stream",
+			"Cache-Control": "no-cache",
+			Connection: "keep-alive",
+			"X-Accel-Buffering": "no",
+		});
+		res.write(`data: ${JSON.stringify({ type: "connected", time: new Date().toISOString() })}\n\n`);
+		logClients.add(res);
+		const keepalive = setInterval(() => {
+			if (!res.writable) { clearInterval(keepalive); return; }
+			try { res.write(": ping\n\n"); } catch { clearInterval(keepalive); }
+		}, 15_000);
+		req.on("close", () => { clearInterval(keepalive); logClients.delete(res); });
+		return;
+	}
+
+	json(res, 404, { error: "Not found" });
+}
+
+// ── Extension entry point ────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+	_pi = pi;
+
+	function mount(): void {
+		pi.events.emit("web:mount", {
+			name: "mobile",
+			label: "Mobile",
+			description: "PWA mobile app for Pi agents",
+			prefix: "/mobile",
+			handler: handlePage,
+		});
+
+		pi.events.emit("web:mount-api", {
+			name: "mobile-api",
+			label: "Mobile API",
+			description: "Mobile app API endpoints",
+			prefix: "/mobile",
+			handler: handleApi,
+		});
+	}
+
+	pi.events.on("web:ready", mount);
+	pi.on("session_start", async (_event, ctx) => {
+		_cwd = ctx.cwd;
+		mount();
+	});
+
+	// ── SSE event forwarding ──────────────────────────────
+	// Register once — broadcast to all connected SSE clients.
+
+	pi.on("agent_start", async () => {
+		broadcast({ type: "agent_start", time: new Date().toISOString() });
+	});
+
+	pi.on("agent_end", async () => {
+		broadcast({ type: "agent_end", time: new Date().toISOString() });
+	});
+
+	pi.on("turn_end", async (event) => {
+		const msg = event.message as { role?: string; content?: unknown[] } | undefined;
+		const content: unknown[] = [];
+		if (msg?.role === "assistant" && Array.isArray(msg.content)) {
+			for (const block of msg.content) {
+				const b = block as Record<string, unknown>;
+				if (b.type === "text") {
+					content.push({ type: "text", text: String(b.text ?? "").slice(0, 8192) });
+				} else if (b.type === "thinking") {
+					content.push({ type: "thinking", thinking: String(b.thinking ?? "").slice(0, 4096) });
+				}
+			}
+		}
+		broadcast({ type: "turn_end", turn: event.turnIndex, content, toolResults: event.toolResults.length });
+	});
+
+	pi.on("tool_call", async (event) => {
+		broadcast({ type: "tool_start", toolName: event.toolName, toolCallId: event.toolCallId });
+	});
+
+	pi.on("tool_result", async (event) => {
+		const content: unknown[] = [];
+		for (const c of event.content) {
+			const b = c as unknown as Record<string, unknown>;
+			if (b.type === "text") {
+				content.push({ type: "text", text: String(b.text ?? "").slice(0, 4096) });
+			}
+		}
+		broadcast({ type: "tool_end", toolName: event.toolName, toolCallId: event.toolCallId, isError: event.isError, content });
+	});
+
+	// ── Log event forwarding ──────────────────────────────
+
+	pi.on("tool_call", async (event) => {
+		broadcastLog({ level: "info", source: "tool", msg: `→ ${event.toolName}`, time: new Date().toISOString() });
+	});
+
+	pi.on("tool_result", async (event) => {
+		const level = event.isError ? "error" : "info";
+		broadcastLog({ level, source: "tool", msg: `← ${event.toolName}${event.isError ? " (error)" : ""}`, time: new Date().toISOString() });
+	});
+
+	pi.on("session_shutdown", async () => {
+		_pi = null;
+		for (const res of sseClients) { try { res.end(); } catch {} }
+		sseClients.clear();
+		for (const res of logClients) { try { res.end(); } catch {} }
+		logClients.clear();
+	});
+}

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -45,7 +45,7 @@ function getScreenJs(name: string): string | null {
 	const screensDir = path.join(PUBLIC_DIR, "screens");
 	const filePath = path.join(screensDir, `${name}.js`);
 	// Prevent path traversal — must stay within screens directory
-	if (!filePath.startsWith(screensDir + path.sep)) return null;
+	if (!filePath.startsWith(screensDir + path.sep) && filePath !== screensDir) return null;
 	if (!fs.existsSync(filePath)) return null;
 	const content = fs.readFileSync(filePath, "utf-8");
 	screenCache.set(name, content);

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -151,7 +151,7 @@ async function handleChatApi(req: IncomingMessage, res: ServerResponse, subPath:
 		// Keepalive ping every 15s
 		const keepalive = setInterval(() => {
 			if (!res.writable) { clearInterval(keepalive); return; }
-			try { res.write(": ping\n\n"); } catch { clearInterval(keepalive); }
+			try { res.write(": ping\n\n"); } catch { clearInterval(keepalive); sseClients.delete(res); }
 		}, 15_000);
 
 		req.on("close", () => {
@@ -594,7 +594,7 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: str
 		logClients.add(res);
 		const keepalive = setInterval(() => {
 			if (!res.writable) { clearInterval(keepalive); return; }
-			try { res.write(": ping\n\n"); } catch { clearInterval(keepalive); }
+			try { res.write(": ping\n\n"); } catch { clearInterval(keepalive); logClients.delete(res); }
 		}, 15_000);
 		req.on("close", () => { clearInterval(keepalive); logClients.delete(res); });
 		return;

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -42,7 +42,10 @@ const screenCache = new Map<string, string>();
 
 function getScreenJs(name: string): string | null {
 	if (screenCache.has(name)) return screenCache.get(name)!;
-	const filePath = path.join(PUBLIC_DIR, "screens", `${name}.js`);
+	const screensDir = path.join(PUBLIC_DIR, "screens");
+	const filePath = path.join(screensDir, `${name}.js`);
+	// Prevent path traversal — must stay within screens directory
+	if (!filePath.startsWith(screensDir + path.sep)) return null;
 	if (!fs.existsSync(filePath)) return null;
 	const content = fs.readFileSync(filePath, "utf-8");
 	screenCache.set(name, content);
@@ -61,9 +64,19 @@ function json(res: ServerResponse, status: number, data: unknown): void {
 }
 
 function readBody(req: IncomingMessage): Promise<string> {
+	const MAX_SIZE = 1024 * 1024; // 1 MB
 	return new Promise((resolve, reject) => {
 		const chunks: Buffer[] = [];
-		req.on("data", (c: Buffer) => chunks.push(c));
+		let totalSize = 0;
+		req.on("data", (c: Buffer) => {
+			totalSize += c.length;
+			if (totalSize > MAX_SIZE) {
+				req.destroy();
+				reject(new Error("Request body too large"));
+				return;
+			}
+			chunks.push(c);
+		});
 		req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
 		req.on("error", reject);
 	});
@@ -331,7 +344,7 @@ async function handleCronApi(req: IncomingMessage, res: ServerResponse, subPath:
 	// POST /jobs/:name/toggle — enable/disable
 	if (subPath.match(/^\/jobs\/[^/]+\/toggle$/) && req.method === "POST") {
 		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
-		const name = subPath.split("/")[2];
+		const name = decodeURIComponent(subPath.split("/")[2]);
 		try {
 			const body = JSON.parse(await readBody(req));
 			const action = body.enabled ? "enable" : "disable";
@@ -346,7 +359,7 @@ async function handleCronApi(req: IncomingMessage, res: ServerResponse, subPath:
 	// POST /jobs/:name/run — trigger manual run
 	if (subPath.match(/^\/jobs\/[^/]+\/run$/) && req.method === "POST") {
 		if (!_pi) { json(res, 503, { error: "Agent not ready" }); return; }
-		const name = subPath.split("/")[2];
+		const name = decodeURIComponent(subPath.split("/")[2]);
 		try {
 			const result = await _pi.exec("pi-cron", ["run", name], { timeout: 30_000 });
 			json(res, 200, { ok: result.code === 0, output: result.stdout?.trim() });
@@ -368,7 +381,7 @@ const SKIP_DIRS = new Set(["node_modules", ".git", ".todos", "dist", "build", ".
 function safeResolvePath(requestedPath: string): string | null {
 	const resolved = path.resolve(_cwd, requestedPath);
 	// Prevent path traversal — must stay within cwd
-	if (!resolved.startsWith(_cwd)) return null;
+	if (!resolved.startsWith(_cwd + path.sep) && resolved !== _cwd) return null;
 	return resolved;
 }
 
@@ -455,6 +468,11 @@ function handlePage(_req: IncomingMessage, res: ServerResponse, subPath: string)
 			// Screen JS modules: /mobile/screens/chat.js → public/screens/chat.js
 			if (p.startsWith("/screens/") && p.endsWith(".js")) {
 				const screenName = p.slice("/screens/".length, -3);
+				// Reject screen names with path traversal attempts
+				if (screenName.includes("/") || screenName.startsWith("..")) {
+					send(res, 404, "text/plain", "Not found");
+					return;
+				}
 				const content = getScreenJs(screenName);
 				if (content) {
 					send(res, 200, "application/javascript; charset=utf-8", content);
@@ -611,7 +629,6 @@ export default function (pi: ExtensionAPI) {
 	pi.events.on("web:ready", mount);
 	pi.on("session_start", async (_event, ctx) => {
 		_cwd = ctx.cwd;
-		mount();
 	});
 
 	// ── SSE event forwarding ──────────────────────────────

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -385,7 +385,15 @@ function safeResolvePath(requestedPath: string): string | null {
 	const resolved = path.resolve(_cwd, requestedPath);
 	// Prevent path traversal — must stay within cwd
 	if (!resolved.startsWith(_cwd + path.sep) && resolved !== _cwd) return null;
-	return resolved;
+	// Dereference symlinks to prevent sandbox escape
+	try {
+		const real = fs.realpathSync(resolved);
+		if (!real.startsWith(_cwd + path.sep) && real !== _cwd) return null;
+		return real;
+	} catch {
+		// Path doesn't exist yet (e.g. new file write) — allow if logical path is valid
+		return resolved;
+	}
 }
 
 async function handleFilesApi(req: IncomingMessage, res: ServerResponse, subPath: string): Promise<void> {

--- a/extensions/pi-mobile/tsconfig.json
+++ b/extensions/pi-mobile/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"types": ["node"]
+	},
+	"include": ["src"]
+}


### PR DESCRIPTION
Moves pi-mobile from standalone ~/Dev/pi-mobile repo into extensions/pi-mobile where it belongs.

11 screens, no build step, Preact+HTM from CDN, dark mode PWA.

Closes td-2d9f1a