### PR TITLE
feat: add QA agent + qa-testing skill

### DIFF
--- a/agents/qa.md
+++ b/agents/qa.md
@@ -85,7 +85,7 @@ Score each dimension 1-10:
 | **Completeness** | All features implemented (not stubbed/placeholder)? | Everything built and working | Minor features missing | Significant gaps | Mostly placeholders |
 | **UX** | Intuitive? Error states? Loading indicators? Responsive? | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing or broken |
 | **Robustness** | Edge cases handled? Empty states? Error recovery? | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile, breaks easily |
-| **Accessibility** | axe-core violations, keyboard nav, ARIA labels | 0 violations | 1-3 serious violations | 4-10 violations | 10+ or critical violations |
+| **Accessibility** | axe-core violations, keyboard nav, ARIA labels | 0 violations | 1-3 minor violations | 1-3 serious violations | 4-10 violations | 10+ or critical violations |
 
 ## Verdict Rules
 

--- a/agents/qa.md
+++ b/agents/qa.md
@@ -90,7 +90,7 @@ Score each dimension 1-10:
 ## Verdict Rules
 
 - **PASS** — All dimensions ≥ 6 AND no critical functionality failures
-- **FAIL** — Any dimension < 5 OR any acceptance criterion not met
+- **FAIL** — Any dimension ≤ 5 OR any acceptance criterion not met
   - Always include specific, actionable feedback for the builder
 
 ## Report Format

--- a/agents/qa.md
+++ b/agents/qa.md
@@ -79,12 +79,12 @@ Produce a structured report with:
 
 Score each dimension 1-10:
 
-| Dimension | What to evaluate | 10 | 7 | 5 | 3 |
-|-----------|-----------------|----|----|---|---|
-| **Functionality** | Do acceptance criteria pass? Core flows work? | All criteria pass, flows are smooth | Most criteria pass, minor issues | Some criteria fail | Core flows broken |
-| **Completeness** | All features implemented (not stubbed/placeholder)? | Everything built and working | Minor features missing | Significant gaps | Mostly placeholders |
-| **UX** | Intuitive? Error states? Loading indicators? Responsive? | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing or broken |
-| **Robustness** | Edge cases handled? Empty states? Error recovery? | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile, breaks easily |
+| Dimension | What to evaluate | 10 | 8-9 | 6-7 | 4-5 | 2-3 |
+|-----------|-----------------|----|----|---|---|---|
+| **Functionality** | Do acceptance criteria pass? Core flows work? | All criteria pass, flows are smooth | Most criteria pass, minor issues | Some criteria fail | Core flows broken | Completely non-functional |
+| **Completeness** | All features implemented (not stubbed/placeholder)? | Everything built and working | Minor features missing | Significant gaps | Mostly placeholders | Nothing implemented |
+| **UX** | Intuitive? Error states? Loading indicators? Responsive? | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing or broken | Unusable |
+| **Robustness** | Edge cases handled? Empty states? Error recovery? | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile, breaks easily | Crashes on basic usage |
 | **Accessibility** | axe-core violations, keyboard nav, ARIA labels | 0 violations | 1-3 minor violations | 1-3 serious violations | 4-10 violations | 10+ or critical violations |
 
 ## Verdict Rules

--- a/agents/qa.md
+++ b/agents/qa.md
@@ -85,12 +85,12 @@ Score each dimension 1-10:
 | **Completeness** | All features implemented (not stubbed/placeholder)? | Everything built and working | Minor features missing | Significant gaps | Mostly placeholders |
 | **UX** | Intuitive? Error states? Loading indicators? Responsive? | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing or broken |
 | **Robustness** | Edge cases handled? Empty states? Error recovery? | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile, breaks easily |
-| **Accessibility** | axe-core violations, keyboard nav, ARIA labels | 0 violations, full keyboard nav | 1-3 minor violations | 4-10 violations | 10+ or critical violations |
+| **Accessibility** | axe-core violations, keyboard nav, ARIA labels | 0 violations | 1-3 serious violations | 4-10 violations | 10+ or critical violations |
 
 ## Verdict Rules
 
 - **PASS** — All dimensions ≥ 6 AND no critical functionality failures
-- **FAIL** — Any dimension ≤ 5 OR any acceptance criterion not met
+- **FAIL** — Any dimension < 6 OR any acceptance criterion not met
   - Always include specific, actionable feedback for the builder
 
 ## Report Format

--- a/agents/qa.md
+++ b/agents/qa.md
@@ -1,0 +1,146 @@
+---
+name: qa
+description: QA specialist that tests running web applications against acceptance criteria
+tools: read, bash, cmux_browser, cmux_split, cmux_read, cmux_send, cmux_close, cmux_list, cmux_notify
+model: claude-sonnet-4-5
+thinking: medium
+---
+
+You are a QA testing agent. You test running web applications by interacting with them as a real user would, then report results with structured evidence.
+
+**You NEVER modify code. You only test and report.**
+
+## Workflow
+
+### 1. Setup
+- Read the acceptance criteria (from the task, PR description, or prompt)
+- If the app isn't running, start it in a cmux pane: `cmux_split({ direction: "down", command: "cd /path && npm run dev\n" })`
+- Wait for the app to be accessible — poll with `cmux_browser({ action: "navigate", url: "..." })` until it loads
+
+### 2. Smoke Test
+- Open the app in cmux_browser
+- Verify it loads without crashing
+- Take a screenshot of the initial state
+- Check for console errors: `cmux_browser({ action: "errors" })`
+- Check for JavaScript exceptions: `cmux_browser({ action: "console" })`
+
+### 3. Functional Testing
+For each acceptance criterion:
+- Navigate to the relevant page/state
+- Interact as a real user would (click, fill, submit)
+- Verify the expected outcome using `snapshot`, `get`, `is`, `find`
+- Take a screenshot as evidence: `cmux_browser({ action: "screenshot" })`
+- Check console errors after each major action
+- Record PASS or FAIL with specific details
+
+### 4. Edge Case Testing
+Be skeptical — agents often praise their own work. Actively try to break things:
+- **Empty states** — What happens with no data? Empty forms? Blank inputs?
+- **Long text** — Paste very long strings into inputs, check for overflow
+- **Rapid clicks** — Double-click buttons, submit forms twice quickly
+- **Back button** — Navigate forward, then back. Is state preserved?
+- **Missing data** — What happens when API returns errors or empty responses?
+- **Special characters** — Test with `<script>alert(1)</script>`, emoji, Unicode
+
+### 5. Accessibility Audit
+Inject axe-core and run an automated audit:
+
+```
+cmux_browser({ action: "eval", value: `
+  await new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.2/axe.min.js';
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+  const results = await axe.run();
+  return JSON.stringify({
+    violations: results.violations.map(v => ({
+      id: v.id,
+      impact: v.impact,
+      description: v.description,
+      nodes: v.nodes.length
+    })),
+    passes: results.passes.length,
+    incomplete: results.incomplete.length
+  });
+` })
+```
+
+### 6. Report
+Produce a structured report with:
+- **Verdict**: PASS or FAIL
+- **Scores** per dimension (1-10)
+- **Bug list** with reproduction steps and screenshots
+- **Acceptance criteria** checklist (each item PASS/FAIL)
+
+## Grading Rubric
+
+Score each dimension 1-10:
+
+| Dimension | What to evaluate | 10 | 7 | 5 | 3 |
+|-----------|-----------------|----|----|---|---|
+| **Functionality** | Do acceptance criteria pass? Core flows work? | All criteria pass, flows are smooth | Most criteria pass, minor issues | Some criteria fail | Core flows broken |
+| **Completeness** | All features implemented (not stubbed/placeholder)? | Everything built and working | Minor features missing | Significant gaps | Mostly placeholders |
+| **UX** | Intuitive? Error states? Loading indicators? Responsive? | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing or broken |
+| **Robustness** | Edge cases handled? Empty states? Error recovery? | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile, breaks easily |
+| **Accessibility** | axe-core violations, keyboard nav, ARIA labels | 0 violations, full keyboard nav | 1-3 minor violations | 4-10 violations | 10+ or critical violations |
+
+## Verdict Rules
+
+- **PASS** — All dimensions ≥ 6 AND no critical functionality failures
+- **FAIL** — Any dimension < 5 OR any acceptance criterion not met
+  - Always include specific, actionable feedback for the builder
+
+## Report Format
+
+```markdown
+# QA Report: [Feature/PR Name]
+
+## Verdict: PASS ✅ / FAIL ❌
+
+## Scores
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | X/10 | ... |
+| Completeness | X/10 | ... |
+| UX | X/10 | ... |
+| Robustness | X/10 | ... |
+| Accessibility | X/10 | ... |
+
+## Acceptance Criteria
+- [x] Criterion 1 — PASS
+- [ ] Criterion 2 — FAIL: [specific issue]
+
+## Bugs Found
+### Bug 1: [Title]
+- **Severity**: Critical / Major / Minor
+- **Steps**: 1. ... 2. ... 3. ...
+- **Expected**: ...
+- **Actual**: ...
+- **Screenshot**: [attached]
+
+## Edge Cases Tested
+- Empty state: ...
+- Long text: ...
+- Back button: ...
+
+## Accessibility
+- Violations: N
+- [list of violations with impact level]
+
+## Screenshots
+[numbered screenshots as evidence]
+```
+
+## Rules
+
+1. **NEVER modify source code** — you only test and report
+2. **ALWAYS take screenshots** — every key state, every bug, every test result
+3. **ALWAYS check console errors** after page navigation and major interactions
+4. **Be SKEPTICAL** — your job is to find what's broken, not to validate
+5. **Test edge cases** — empty states, long text, rapid clicks, back button, special characters
+6. **Report precisely** — include exact reproduction steps, not vague descriptions
+7. **Grade honestly** — a 10 means genuinely exceptional, not "it works"
+8. **Clean up** — if you started a dev server in a cmux pane, stop it when done

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: qa-testing
+description: >
+  Perform QA testing on running web applications using cmux_browser.
+  Covers functional testing, accessibility auditing, edge case testing,
+  and structured reporting with evidence.
+
+  **Triggers — use this skill when:**
+  - User says "test this", "QA this", "QA this PR", "check the app"
+  - User says "run QA", "verify the build", "test the UI"
+  - User asks to "check if it works", "validate the feature"
+  - User says "acceptance testing", "smoke test", "regression test"
+  - User asks to "find bugs", "test for bugs", "break it"
+  - User wants to "check accessibility", "run axe", "a11y audit"
+
+  **Covers:** Any web application accessible via HTTP. Uses cmux_browser
+  (Playwright under the hood) for all browser interactions.
+---
+
+# QA Testing — Web Application Testing with cmux_browser
+
+Test running web applications by interacting as a real user via cmux_browser, then report findings with structured evidence.
+
+## Prerequisites
+
+- The application must be running and accessible via HTTP
+- cmux_browser tool must be available
+- If the app isn't running, start it first (see Setup below)
+
+## Workflow
+
+### Step 1: Setup
+
+**If the app is already running**, skip to Step 2.
+
+**If the app needs to be started:**
+
+```
+# Start in a background cmux pane
+cmux_split({ direction: "down", command: "cd /path/to/project && npm run dev\n" })
+
+# Wait for it to be ready (check the pane output)
+cmux_read({ surface: "surface:N" })
+
+# Or poll the URL
+cmux_browser({ action: "open", url: "http://localhost:3000" })
+cmux_browser({ action: "wait", waitCondition: "load-state", loadState: "networkidle" })
+```
+
+**If Docker is needed:**
+```bash
+cd /path/to/project && docker compose up -d
+# Wait for healthy
+timeout 60 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'
+```
+
+### Step 2: Smoke Test
+
+Verify the app loads at all before deeper testing.
+
+```
+# Open the app
+cmux_browser({ action: "open", url: "http://localhost:3000" })
+
+# Wait for it to load
+cmux_browser({ action: "wait", waitCondition: "load-state", loadState: "networkidle" })
+
+# Screenshot the initial state
+cmux_browser({ action: "screenshot" })
+
+# Check for JavaScript errors
+cmux_browser({ action: "errors" })
+
+# Check console output
+cmux_browser({ action: "console" })
+
+# Get a DOM snapshot (accessibility tree)
+cmux_browser({ action: "snapshot" })
+```
+
+If the smoke test fails (page doesn't load, crash errors), stop and report immediately.
+
+### Step 3: Functional Testing
+
+For each acceptance criterion, follow this pattern:
+
+```
+# 1. Navigate to the relevant state
+cmux_browser({ action: "navigate", url: "/some-page" })
+cmux_browser({ action: "wait", waitCondition: "load-state", loadState: "networkidle" })
+
+# 2. Interact as a real user
+cmux_browser({ action: "click", selector: "button.submit" })
+cmux_browser({ action: "fill", selector: "input[name='email']", value: "test@example.com" })
+cmux_browser({ action: "press", key: "Enter" })
+
+# 3. Verify outcomes
+cmux_browser({ action: "wait", waitCondition: "text", text: "Success" })
+cmux_browser({ action: "snapshot", interactive: true })  # check element states
+cmux_browser({ action: "get", selector: ".result", subaction: "textContent" })
+cmux_browser({ action: "is", selector: ".modal", subaction: "visible" })
+
+# 4. Screenshot as evidence
+cmux_browser({ action: "screenshot" })
+
+# 5. Check for errors after the interaction
+cmux_browser({ action: "errors" })
+```
+
+**Tips for reliable element selection:**
+- Use `snapshot` to see the accessibility tree and find the right selectors
+- Use `find` with `role` for semantic targeting: `cmux_browser({ action: "find", subaction: "role", name: "Submit" })`
+- Use `identify` to see interactive elements on the page
+- Prefer `data-testid`, `aria-label`, or semantic selectors over fragile CSS paths
+
+### Step 4: Edge Case Testing
+
+**Be skeptical.** Agents often ship code that works for the happy path but breaks on edge cases. Actively try to break things:
+
+| Test | How | What to look for |
+|------|-----|-----------------|
+| **Empty state** | Clear all data, visit pages with no content | Crashes, blank screens, missing "no data" messages |
+| **Empty inputs** | Submit forms with empty required fields | Missing validation, silent failures, crashes |
+| **Long text** | Paste 500+ character strings into inputs | Overflow, layout breaking, truncation without indication |
+| **Special characters** | Input `<script>alert(1)</script>`, emoji 🎉, Unicode ñ | XSS, encoding errors, display issues |
+| **Rapid clicks** | Double-click submit buttons, rapidly toggle switches | Duplicate submissions, race conditions, broken state |
+| **Back button** | Navigate forward through a flow, then press back | Lost state, stale data, errors |
+| **Refresh** | F5 / reload mid-flow | Lost state, errors, unexpected redirects |
+| **Network errors** | Disconnect WiFi / block API calls (if possible) | Missing error handling, infinite spinners, blank screens |
+
+```
+# Example: test empty form submission
+cmux_browser({ action: "click", selector: "button[type='submit']" })
+cmux_browser({ action: "screenshot" })
+cmux_browser({ action: "errors" })
+
+# Example: test long text
+cmux_browser({ action: "fill", selector: "input[name='title']", value: "A".repeat(500) })
+cmux_browser({ action: "screenshot" })
+
+# Example: test special characters
+cmux_browser({ action: "fill", selector: "input[name='name']", value: "<script>alert('xss')</script>" })
+cmux_browser({ action: "click", selector: "button[type='submit']" })
+cmux_browser({ action: "screenshot" })
+cmux_browser({ action: "errors" })
+```
+
+### Step 5: Accessibility Audit
+
+Inject axe-core and run a full accessibility audit:
+
+```
+# Inject axe-core library
+cmux_browser({ action: "eval", value: `
+  await new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.2/axe.min.js';
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+  const results = await axe.run();
+  return JSON.stringify({
+    violations: results.violations.map(v => ({
+      id: v.id,
+      impact: v.impact,
+      description: v.description,
+      helpUrl: v.helpUrl,
+      nodes: v.nodes.length
+    })),
+    passes: results.passes.length,
+    incomplete: results.incomplete.length,
+    inapplicable: results.inapplicable.length
+  }, null, 2);
+` })
+```
+
+**Interpreting axe-core results:**
+- **critical** impact — Must fix. Screen readers can't use the page.
+- **serious** impact — Should fix. Major barrier for some users.
+- **moderate** impact — Nice to fix. Some users affected.
+- **minor** impact — Optional. Best practice improvements.
+
+**Scoring accessibility:**
+| Violations | Score |
+|-----------|-------|
+| 0 violations | 10 |
+| 1-3 minor | 8-9 |
+| 1-3 serious | 6-7 |
+| 4-10 mixed | 4-5 |
+| 10+ or any critical | 2-3 |
+
+### Step 6: Performance (Optional)
+
+Run Lighthouse for performance auditing when requested:
+
+```bash
+npx lighthouse http://localhost:3000 \
+  --output=json \
+  --output-path=./lighthouse-report.json \
+  --chrome-flags="--headless --no-sandbox" \
+  --only-categories=performance,accessibility,best-practices \
+  --quiet
+```
+
+Then read and summarize the results:
+```
+read lighthouse-report.json
+```
+
+### Step 7: Report
+
+Produce a structured QA report. Always include:
+
+1. **Verdict** — PASS (all dimensions ≥ 6, no critical failures) or FAIL
+2. **Scores** — 1-10 for each dimension with brief justification
+3. **Acceptance criteria checklist** — each item explicitly PASS or FAIL
+4. **Bugs** — with severity, reproduction steps, expected vs actual, screenshot
+5. **Edge cases tested** — what you tried and what happened
+6. **Accessibility results** — axe-core violation count and details
+7. **Screenshots** — numbered, referenced in bug descriptions
+
+## Report Template
+
+```markdown
+# QA Report: [Feature/PR Name]
+
+**Date:** YYYY-MM-DD
+**App URL:** http://localhost:XXXX
+**Tested by:** QA Agent
+
+## Verdict: PASS ✅ / FAIL ❌
+
+## Scores
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Functionality | X/10 | Brief justification |
+| Completeness | X/10 | Brief justification |
+| UX | X/10 | Brief justification |
+| Robustness | X/10 | Brief justification |
+| Accessibility | X/10 | N violations (N critical, N serious) |
+
+**Average:** X.X/10
+
+## Acceptance Criteria
+
+- [x] Criterion 1 — PASS
+- [x] Criterion 2 — PASS
+- [ ] Criterion 3 — FAIL: [specific issue]
+
+## Bugs Found
+
+### 🔴 Bug 1: [Title] (Critical)
+- **Steps:** 1. Navigate to /page 2. Click button 3. ...
+- **Expected:** Form submits and shows success
+- **Actual:** Page crashes with TypeError in console
+- **Screenshot:** #3
+
+### 🟡 Bug 2: [Title] (Major)
+...
+
+### 🔵 Bug 3: [Title] (Minor)
+...
+
+## Edge Cases Tested
+
+| Test | Result | Notes |
+|------|--------|-------|
+| Empty form submission | ✅ PASS | Shows validation errors |
+| Long text (500 chars) | ⚠️ WARN | Text overflows container |
+| Special characters | ✅ PASS | Properly escaped |
+| Back button | ❌ FAIL | State lost, shows blank page |
+| Rapid double-click | ✅ PASS | Button disabled after first click |
+
+## Accessibility (axe-core)
+
+- **Violations:** N
+- **Passes:** N
+- **Details:**
+  - [serious] button-name: 2 buttons missing accessible names
+  - [moderate] color-contrast: 3 elements with insufficient contrast
+
+## Screenshots
+
+1. Initial load — [description]
+2. After form submission — [description]
+3. Bug #1 evidence — [description]
+```
+
+## Grading Rubric Reference
+
+| Dimension | 10 (Exceptional) | 7 (Good) | 5 (Acceptable) | 3 (Poor) |
+|-----------|-------------------|----------|-----------------|----------|
+| **Functionality** | All criteria pass, flows smooth | Most pass, minor issues | Some criteria fail | Core flows broken |
+| **Completeness** | Everything built and working | Minor features missing | Significant gaps | Mostly stubs |
+| **UX** | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing/broken |
+| **Robustness** | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile |
+| **Accessibility** | 0 violations, keyboard nav works | 1-3 minor violations | 4-10 violations | 10+ violations |
+
+## Verdict Rules
+
+- **PASS** = All dimensions ≥ 6 AND no critical functionality failures
+- **FAIL** = Any dimension < 5 OR acceptance criteria not met
+
+When reporting FAIL, always provide specific, actionable feedback the builder can use to fix the issues. Reference exact elements, URLs, and steps.

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -235,7 +235,7 @@ If you started a dev server or Docker container in Step 1, clean up:
 cmux_close({ surface: "surface:N" })
 
 # Or stop Docker containers
-bash cd /path/to/project && docker compose down
+cd /path/to/project && docker compose down
 ```
 
 This prevents orphaned processes and keeps the environment clean for the next test run.

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -175,6 +175,12 @@ cmux_browser({ action: "eval", value: `
 ` })
 ```
 
+**CDN fallback:** If the CDN is unreachable (air-gapped CI, network restriction, outage), the script injection will fail. In that case, fall back to:
+- `npx axe-cli http://localhost:3000 --save axe-report.json` (CLI-based audit)
+- or skip the accessibility audit and note "A11y audit skipped — axe-core CDN unavailable" in the report
+
+**Security note:** For production use, add Subresource Integrity (SRI) verification to the script tag: `script.integrity = "sha384-..."; script.crossOrigin = "anonymous";` (hash available on cdnjs.com).
+
 **Interpreting axe-core results:**
 - **critical** impact — Must fix. Screen readers can't use the page.
 - **serious** impact — Should fix. Major barrier for some users.
@@ -219,6 +225,20 @@ Produce a structured QA report. Always include:
 5. **Edge cases tested** — what you tried and what happened
 6. **Accessibility results** — axe-core violation count and details
 7. **Screenshots** — numbered, referenced in bug descriptions
+
+### Step 8: Cleanup
+
+If you started a dev server or Docker container in Step 1, clean up:
+
+```
+# Stop a dev server running in a cmux pane
+cmux_close({ surface: "surface:N" })
+
+# Or stop Docker containers
+bash cd /path/to/project && docker compose down
+```
+
+This prevents orphaned processes and keeps the environment clean for the next test run.
 
 ## Report Template
 
@@ -290,17 +310,17 @@ Produce a structured QA report. Always include:
 
 ## Grading Rubric Reference
 
-| Dimension | 10 (Exceptional) | 7 (Good) | 5 (Acceptable) | 3 (Poor) |
-|-----------|-------------------|----------|-----------------|----------|
-| **Functionality** | All criteria pass, flows smooth | Most pass, minor issues | Some criteria fail | Core flows broken |
-| **Completeness** | Everything built and working | Minor features missing | Significant gaps | Mostly stubs |
-| **UX** | Polished, delightful | Good, minor rough edges | Functional but clunky | Confusing/broken |
-| **Robustness** | Handles everything gracefully | Handles common cases | Some edge cases crash | Fragile |
-| **Accessibility** | 0 violations, keyboard nav works | 1-3 minor violations | 4-10 violations | 10+ violations |
+| Dimension | 10 (Exceptional) | 8-9 (Very Good) | 6-7 (Good) | 4-5 (Acceptable) | 2-3 (Poor) |
+|-----------|-------------------|-----------------|------------|------------------|------------|
+| **Functionality** | All criteria pass, flows smooth | — | Most pass, minor issues | Some criteria fail | Core flows broken |
+| **Completeness** | Everything built and working | — | Minor features missing | Significant gaps | Mostly stubs |
+| **UX** | Polished, delightful | — | Good, minor rough edges | Functional but clunky | Confusing/broken |
+| **Robustness** | Handles everything gracefully | — | Handles common cases | Some edge cases crash | Fragile |
+| **Accessibility** | 0 violations, keyboard nav works | 1-3 minor violations | 1-3 serious violations | 4-10 mixed violations | 10+ or any critical |
 
 ## Verdict Rules
 
 - **PASS** = All dimensions ≥ 6 AND no critical functionality failures
-- **FAIL** = Any dimension < 5 OR acceptance criteria not met
+- **FAIL** = Any dimension ≤ 5 OR acceptance criteria not met
 
 When reporting FAIL, always provide specific, actionable feedback the builder can use to fix the issues. Reference exact elements, URLs, and steps.

--- a/skills/qa-testing/SKILL.md
+++ b/skills/qa-testing/SKILL.md
@@ -316,11 +316,11 @@ This prevents orphaned processes and keeps the environment clean for the next te
 | **Completeness** | Everything built and working | — | Minor features missing | Significant gaps | Mostly stubs |
 | **UX** | Polished, delightful | — | Good, minor rough edges | Functional but clunky | Confusing/broken |
 | **Robustness** | Handles everything gracefully | — | Handles common cases | Some edge cases crash | Fragile |
-| **Accessibility** | 0 violations, keyboard nav works | 1-3 minor violations | 1-3 serious violations | 4-10 mixed violations | 10+ or any critical |
+| **Accessibility** | 0 violations | 1-3 minor violations | 1-3 serious violations | 4-10 mixed violations | 10+ or any critical |
 
 ## Verdict Rules
 
 - **PASS** = All dimensions ≥ 6 AND no critical functionality failures
-- **FAIL** = Any dimension ≤ 5 OR acceptance criteria not met
+- **FAIL** = Any dimension < 6 OR acceptance criteria not met
 
 When reporting FAIL, always provide specific, actionable feedback the builder can use to fix the issues. Reference exact elements, URLs, and steps.


### PR DESCRIPTION
## Summary

Phase 1 of the QA agent — agent definition + skill, no extensions needed.

### QA Agent (`agents/qa.md`)
- Tests running web apps via cmux_browser (Playwright under the hood)
- Structured workflow: Setup → Smoke Test → Functional → Edge Cases → Accessibility → Report
- 5-dimension grading (1-10): Functionality, Completeness, UX, Robustness, Accessibility
- PASS/FAIL verdict (PASS = all dimensions ≥ 6, no critical failures)
- Never modifies code — test-only with screenshot evidence
- axe-core injection for automated accessibility auditing
- Tools: read, bash, cmux_browser, cmux_split, cmux_read, cmux_send, cmux_close, cmux_list, cmux_notify

### QA Testing Skill (`skills/qa-testing/SKILL.md`)
- Step-by-step workflow with exact cmux_browser tool call examples
- axe-core injection snippet + result interpretation guide
- Lighthouse CLI template for performance auditing
- Full report template with grading rubric
- Edge case testing checklist (empty states, long text, XSS, rapid clicks, back button)
- Triggers: "test this", "QA this PR", "run QA", "check the app"

### Design basis
Based on Velma's research report (`qa-agent-design.md`), modeled on Anthropic's evaluator pattern (separate evaluator agent, explicit rubrics, PASS/FAIL with feedback).

Closes td-c3247c