### PR TITLE
fix(pi-a2a): prevent infinite response loops while still processing responses

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -43,13 +43,15 @@ export interface AsyncTaskResult {
 	/** Sender's A2A endpoint URL, captured from the original request context. */
 	senderUrl?: string;
 	result: ProcessResult;
+	/** When true, don't send the result back to the sender (this was a response to a response — no reply-to-reply). */
+	skipReply?: boolean;
 }
 
 /**
  * Callback to inject a message into the main agent conversation.
  * Returns a promise that resolves when the agent finishes processing.
  */
-export type ProcessMessage = (prompt: string, sender: string) => Promise<ProcessResult>;
+export type ProcessMessage = (prompt: string, sender: string, options?: { isResponse?: boolean }) => Promise<ProcessResult>;
 
 export class PiAgentExecutor implements AgentExecutor {
 	private log: LogFn;
@@ -149,6 +151,24 @@ export class PiAgentExecutor implements AgentExecutor {
 			return;
 		}
 
+		// ── Check if this is a response to a message we sent (not a new request) ──
+		// When Agent A sends to Agent B, B processes and sends the result back
+		// as a new message/send with pi:isResponse metadata. We still process it
+		// through the agent (so it can act on the response), but we set skipReply
+		// so onAsyncResult won't send the result back — no reply-to-reply.
+		// This breaks the bidirectional loop while still letting the agent reason
+		// about the response.
+		const msgMetadata = userMessage.metadata as Record<string, unknown> | undefined;
+		const isResponse = msgMetadata?.["pi:isResponse"] === true;
+
+		if (isResponse) {
+			this.log("executor_received_response", {
+				taskId,
+				replyToTaskId: msgMetadata?.["pi:replyToTaskId"],
+				from: (msgMetadata?.["pi:sender"] as { name?: string } | undefined)?.name ?? "Unknown",
+			});
+		}
+
 		// Extract sender identity (name + URL for reply routing)
 		const senderMeta = (userMessage.metadata as Record<string, unknown> | undefined)?.["pi:sender"] as
 			| { name?: string; description?: string; url?: string }
@@ -214,7 +234,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		// The HTTP response has already been sent. The agent works on the
 		// task, and when done, the result is delivered via onAsyncResult
 		// which sends it back to the caller as a new A2A message.
-		this.processInBackground(taskId, prompt, senderName, senderUrl, releaseQueue!).catch((err) => {
+		this.processInBackground(taskId, prompt, senderName, senderUrl, releaseQueue!, isResponse).catch((err) => {
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_bg_error", { taskId, error: msg }, "ERROR");
 		});
@@ -279,9 +299,10 @@ export class PiAgentExecutor implements AgentExecutor {
 		senderName: string,
 		senderUrl: string | undefined,
 		releaseQueue: () => void,
+		skipReply: boolean = false,
 	): Promise<void> {
 		try {
-			const result = await this.processMessage(prompt, senderName);
+			const result = await this.processMessage(prompt, senderName, { isResponse: skipReply });
 
 			// Check if canceled while processing
 			if (this.activeTaskId !== taskId) {
@@ -303,7 +324,7 @@ export class PiAgentExecutor implements AgentExecutor {
 			}
 
 			// Deliver the result to be sent back to the caller
-			this.onAsyncResult?.({ taskId, senderName, senderUrl, result });
+			this.onAsyncResult?.({ taskId, senderName, senderUrl, result, skipReply });
 		} catch (err: unknown) {
 			this.activeTaskId = null;
 			const msg = err instanceof Error ? err.message : String(err);
@@ -319,6 +340,7 @@ export class PiAgentExecutor implements AgentExecutor {
 				senderName,
 				senderUrl,
 				result: { ok: false, response: "", error: msg, durationMs: 0 },
+				skipReply,
 			});
 		} finally {
 			releaseQueue();

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -151,21 +151,21 @@ export class PiAgentExecutor implements AgentExecutor {
 			return;
 		}
 
-		// ── Check if this is a response to a message we sent (not a new request) ──
-		// When Agent A sends to Agent B, B processes and sends the result back
-		// as a new message/send with pi:isResponse metadata. We still process it
-		// through the agent (so it can act on the response), but we set skipReply
-		// so onAsyncResult won't send the result back — no reply-to-reply.
-		// This breaks the bidirectional loop while still letting the agent reason
-		// about the response.
-		const msgMetadata = userMessage.metadata as Record<string, unknown> | undefined;
-		const isResponse = msgMetadata?.["pi:isResponse"] === true;
+		// ── Check if this is a follow-up to a previous task (not a cold new request) ──
+		// The A2A protocol's referenceTaskIds field links a message to tasks it
+		// relates to. When Agent B sends an async result back to Agent A, B
+		// includes the original taskId in referenceTaskIds. When A receives this,
+		// it knows it's a follow-up — process it (so the agent can act on the
+		// response) but set skipReply so onAsyncResult won't bounce the result
+		// back to B. This breaks the bidirectional A→B→A→B loop.
+		const refTaskIds = (userMessage as { referenceTaskIds?: string[] }).referenceTaskIds;
+		const isFollowUp = Array.isArray(refTaskIds) && refTaskIds.length > 0;
 
-		if (isResponse) {
-			this.log("executor_received_response", {
+		if (isFollowUp) {
+			this.log("executor_received_followup", {
 				taskId,
-				replyToTaskId: msgMetadata?.["pi:replyToTaskId"],
-				from: (msgMetadata?.["pi:sender"] as { name?: string } | undefined)?.name ?? "Unknown",
+				referenceTaskIds: refTaskIds,
+				from: ((userMessage.metadata as Record<string, unknown> | undefined)?.["pi:sender"] as { name?: string } | undefined)?.name ?? "Unknown",
 			});
 		}
 
@@ -234,7 +234,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		// The HTTP response has already been sent. The agent works on the
 		// task, and when done, the result is delivered via onAsyncResult
 		// which sends it back to the caller as a new A2A message.
-		this.processInBackground(taskId, prompt, senderName, senderUrl, releaseQueue!, isResponse).catch((err) => {
+		this.processInBackground(taskId, prompt, senderName, senderUrl, releaseQueue!, isFollowUp).catch((err) => {
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_bg_error", { taskId, error: msg }, "ERROR");
 		});

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -41,6 +41,8 @@ export interface SendMessageOptions {
 	sender?: SenderIdentity;
 	/** Additional metadata to merge into the A2A message metadata. */
 	metadata?: Record<string, unknown>;
+	/** Task IDs this message references (A2A protocol field for linking follow-ups to originating tasks). */
+	referenceTaskIds?: string[];
 	/**
 	 * Callback to refresh a stale credential on 401.
 	 * Called once on auth failure — should evict cache and return a fresh token.
@@ -73,7 +75,7 @@ export async function sendA2AMessage(
 	opts: SendMessageOptions,
 	log: LogFn,
 ): Promise<SendMessageResult> {
-	const { url, message, credential, timeoutMs, sender, metadata: extraMetadata, onRefreshCredential } = opts;
+	const { url, message, credential, timeoutMs, sender, metadata: extraMetadata, referenceTaskIds, onRefreshCredential } = opts;
 
 	log("a2a_send_start", { url, messageLength: message.length, hasCredential: !!credential });
 
@@ -175,6 +177,7 @@ export async function sendA2AMessage(
 				role: "user",
 				parts: [{ kind: "text", text: message }],
 				...(metadata ? { metadata } : {}),
+				...(referenceTaskIds?.length ? { referenceTaskIds } : {}),
 			},
 			configuration: {
 				blocking: true,

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -39,6 +39,8 @@ export interface SendMessageOptions {
 	timeoutMs?: number;
 	/** Local agent identity to include as sender metadata. */
 	sender?: SenderIdentity;
+	/** Additional metadata to merge into the A2A message metadata. */
+	metadata?: Record<string, unknown>;
 	/**
 	 * Callback to refresh a stale credential on 401.
 	 * Called once on auth failure — should evict cache and return a fresh token.
@@ -71,7 +73,7 @@ export async function sendA2AMessage(
 	opts: SendMessageOptions,
 	log: LogFn,
 ): Promise<SendMessageResult> {
-	const { url, message, credential, timeoutMs, sender, onRefreshCredential } = opts;
+	const { url, message, credential, timeoutMs, sender, metadata: extraMetadata, onRefreshCredential } = opts;
 
 	log("a2a_send_start", { url, messageLength: message.length, hasCredential: !!credential });
 
@@ -152,14 +154,19 @@ export async function sendA2AMessage(
 		const client = new Client(transport, minimalCard);
 
 		// ── Build the A2A message ─────────────────────────────────
-		const metadata: Record<string, unknown> | undefined = sender
+		const senderMeta = sender
 			? {
 				"pi:sender": {
 					name: sender.name,
 					...(sender.description ? { description: sender.description } : {}),
 				},
 			}
-			: undefined;
+			: {};
+
+		const metadata: Record<string, unknown> | undefined =
+			(Object.keys(senderMeta).length > 0 || extraMetadata)
+				? { ...senderMeta, ...extraMetadata }
+				: undefined;
 
 		const params: MessageSendParams = {
 			message: {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -150,6 +150,8 @@ export default function (pi: ExtensionAPI) {
 	let pendingStartTime = 0;
 	/** Nonce embedded in the injected message to correlate with agent_end. */
 	let pendingNonce: string | null = null;
+	/** Whether the current pending request is a response (affects the completion message). */
+	let pendingIsResponse = false;
 
 	/** Wait for agent to be idle before injecting an A2A message. */
 	let agentBusy = false;
@@ -166,7 +168,7 @@ export default function (pi: ExtensionAPI) {
 	 * Process an incoming A2A message via the main agent.
 	 * Called by the executor — blocks until the agent responds.
 	 */
-	async function processMessage(prompt: string, sender: string): Promise<ProcessResult> {
+	async function processMessage(prompt: string, sender: string, options?: { isResponse?: boolean }): Promise<ProcessResult> {
 		const start = Date.now();
 
 		// Guard against concurrent invocations — singleton pendingResolve
@@ -190,15 +192,25 @@ export default function (pi: ExtensionAPI) {
 			pendingStartTime = start;
 			pendingNonce = nonce;
 
+			const isResponse = options?.isResponse ?? false;
+			pendingIsResponse = isResponse;
+
 			// Inject into the main conversation — triggers a full agent turn.
 			// The nonce in details lets agent_end correlate this turn's response.
+			// For responses (pi:isResponse), we use different framing so the agent
+			// knows this is a reply to an earlier request, not a new one. The agent's
+			// output won't be sent back automatically — use a2a_send to follow up.
 			pi.sendMessage(
 				{
-					customType: "a2a-request",
-					content:
-						`📨 **A2A request from ${sender}**\n\n` +
-						`> ${prompt.split("\n").join("\n> ")}\n\n` +
-						`*Process this request. Your full response will be sent back to ${sender} via A2A.*`,
+					customType: isResponse ? "a2a-response-inbound" : "a2a-request",
+					content: isResponse
+						? `📨 **A2A response from ${sender}**\n\n` +
+						  `> ${prompt.split("\n").join("\n> ")}\n\n` +
+						  `*This is a response to an earlier A2A request. Process the information and take any needed action. ` +
+						  `Your reply will NOT be sent back automatically — use a2a_send explicitly if you need to follow up.*`
+						: `📨 **A2A request from ${sender}**\n\n` +
+						  `> ${prompt.split("\n").join("\n> ")}\n\n` +
+						  `*Process this request. Your full response will be sent back to ${sender} via A2A.*`,
 					display: true,
 					details: { nonce },
 				},
@@ -242,7 +254,7 @@ export default function (pi: ExtensionAPI) {
 		if (pendingResolve && pendingNonce) {
 			const hasMatchingRequest = event.messages.some((m) =>
 				"customType" in m &&
-				m.customType === "a2a-request" &&
+				(m.customType === "a2a-request" || m.customType === "a2a-response-inbound") &&
 				(m as { details?: { nonce?: string } }).details?.nonce === pendingNonce
 			);
 
@@ -250,15 +262,19 @@ export default function (pi: ExtensionAPI) {
 				const response = extractAssistantText(event.messages);
 				const durationMs = Date.now() - pendingStartTime;
 				const resolve = pendingResolve;
+				const isResponse = pendingIsResponse;
 				pendingResolve = null;
 				pendingNonce = null;
+				pendingIsResponse = false;
 
 				if (response) {
-					// Show completion in chat
+					// Show completion in chat — different message for responses vs requests
 					pi.sendMessage(
 						{
-							customType: "a2a-response-sent",
-							content: `📤 **A2A response sent** (${fmtDuration(durationMs)})`,
+							customType: isResponse ? "a2a-response-processed" : "a2a-response-sent",
+							content: isResponse
+								? `✅ **A2A response processed** (${fmtDuration(durationMs)})`
+								: `📤 **A2A response sent** (${fmtDuration(durationMs)})`,
 							display: true,
 						},
 						{ triggerTurn: false },
@@ -285,6 +301,35 @@ export default function (pi: ExtensionAPI) {
 	let outboundPending = 0;
 	/** Monotonic token incremented on each session_start. Stale closures bail out when mismatched. */
 	let sessionToken = 0;
+
+	// ── Outbound response rate limiter ────────────────────────
+	// Prevents outbound loops where the agent keeps calling a2a_send
+	// after processing each response, creating an ever-growing chain.
+	/** Timestamps of recent outbound A2A response-triggered turns. */
+	const a2aResponseTriggerTimestamps: number[] = [];
+	/** Rolling window size (1 minute). */
+	const A2A_RESPONSE_WINDOW_MS = 60_000;
+	/** Max auto-triggered turns per window before pausing. */
+	const MAX_A2A_RESPONSE_TRIGGERS = 10;
+
+	/** Check if we should trigger a turn for an outbound A2A response. */
+	function shouldTriggerA2AResponse(): boolean {
+		const now = Date.now();
+		// Evict expired entries
+		while (a2aResponseTriggerTimestamps.length > 0 &&
+			   (now - a2aResponseTriggerTimestamps[0]) > A2A_RESPONSE_WINDOW_MS) {
+			a2aResponseTriggerTimestamps.shift();
+		}
+		if (a2aResponseTriggerTimestamps.length >= MAX_A2A_RESPONSE_TRIGGERS) {
+			log("a2a_response_rate_limited", {
+				count: a2aResponseTriggerTimestamps.length,
+				windowMs: A2A_RESPONSE_WINDOW_MS,
+			}, "WARN");
+			return false;
+		}
+		a2aResponseTriggerTimestamps.push(now);
+		return true;
+	}
 
 	// ── TUI: status line ──────────────────────────────────────
 
@@ -404,6 +449,7 @@ export default function (pi: ExtensionAPI) {
 		// Clean restart — reset all async state from previous session
 		outboundPending = 0;
 		sessionToken++;
+		a2aResponseTriggerTimestamps.length = 0;
 		credentialCache.clear();
 		agentBusy = false;
 		const staleResolvers = idleResolvers;
@@ -414,6 +460,7 @@ export default function (pi: ExtensionAPI) {
 		}
 		pendingResolve = null;
 		pendingNonce = null;
+		pendingIsResponse = false;
 		if (telemetryInterval) {
 			clearInterval(telemetryInterval);
 			telemetryInterval = null;
@@ -452,8 +499,16 @@ export default function (pi: ExtensionAPI) {
 		// When a long-running task completes, send the result back to the sender
 		// as a new A2A message. The initial HTTP response already returned a
 		// "working" ACK — this delivers the actual content (or error).
+		//
+		// If skipReply is set, the original message was itself a response
+		// (pi:isResponse) — don't reply to a reply, or we'd loop forever.
 		executor.onAsyncResult = (asyncResult: AsyncTaskResult) => {
-			const { taskId, senderName, senderUrl, result } = asyncResult;
+			const { taskId, senderName, senderUrl, result, skipReply } = asyncResult;
+
+			if (skipReply) {
+				log("async_result_skip_reply", { taskId, sender: senderName, ok: result.ok });
+				return;
+			}
 
 			// Build the message — include error info so the caller knows what happened
 			const messageText = result.ok
@@ -537,6 +592,10 @@ export default function (pi: ExtensionAPI) {
 					credential,
 					timeoutMs: config.sendTimeoutMs,
 					sender: { name: config.name ?? "Pi Agent", description: config.description, url: selfUrl ?? undefined } as SenderIdentity,
+					metadata: {
+						"pi:isResponse": true,
+						"pi:replyToTaskId": taskId,
+					},
 				}, log);
 
 				if (sendResult.ok) {
@@ -939,14 +998,16 @@ export default function (pi: ExtensionAPI) {
 						{ triggerTurn: false },
 					);
 				} else if (result.ok) {
+					const trigger = shouldTriggerA2AResponse();
 					pi.sendMessage(
 						{
 							customType: "a2a-response-received",
 							content:
-								`📨 **A2A response from ${resolvedName}** (${dur}):\n\n${result.response}`,
+								`📨 **A2A response from ${resolvedName}** (${dur}):\n\n${result.response}` +
+								(!trigger ? `\n\n⚠️ *Automatic processing paused — too many consecutive A2A responses. Review and respond manually if needed.*` : ""),
 							display: true,
 						},
-						{ triggerTurn: true },
+						{ triggerTurn: trigger },
 					);
 				} else {
 					pi.sendMessage(

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -592,10 +592,7 @@ export default function (pi: ExtensionAPI) {
 					credential,
 					timeoutMs: config.sendTimeoutMs,
 					sender: { name: config.name ?? "Pi Agent", description: config.description, url: selfUrl ?? undefined } as SenderIdentity,
-					metadata: {
-						"pi:isResponse": true,
-						"pi:replyToTaskId": taskId,
-					},
+					referenceTaskIds: [taskId],
 				}, log);
 
 				if (sendResult.ok) {


### PR DESCRIPTION
## Problem

When receiving A2A responses, we need `triggerTurn: true` so the agent can process and act on them. But this creates two types of infinite loops:

1. **Bidirectional loop** (A→B→A→B...): Agent A sends to B. B processes it and sends the result back as a new A2A message. A receives it, processes it, and `onAsyncResult` sends A's result back to B. Infinite loop.

2. **Outbound loop**: Agent sends `a2a_send`, gets response with `triggerTurn: true`, processes it, calls `a2a_send` again, gets response, etc.

## Solution

Two-layer loop prevention that **still processes responses**:

### 1. Bidirectional loop prevention (`pi:isResponse` + `skipReply`)
- When `onAsyncResult` sends a result back to the sender, it includes `pi:isResponse: true` in the A2A message metadata
- When receiving a message with this flag, the executor still processes it through the agent (full turn with tool access)
- But the `AsyncTaskResult` carries `skipReply: true`, so `onAsyncResult` skips sending the result back
- The injected prompt tells the agent: *"Your reply will NOT be sent back automatically — use a2a_send explicitly if you need to follow up"*
- This breaks the loop after one round-trip while letting the agent reason about the response

### 2. Outbound loop prevention (rolling window rate limiter)
- `shouldTriggerA2AResponse()` tracks timestamps of recent response-triggered turns
- After 10 auto-triggered turns in a 60-second window, `triggerTurn` falls back to `false`
- Responses are still displayed but automatic processing pauses
- Window naturally resets after 60 seconds of inactivity

## Changes

| File | Change |
|------|--------|
| `agent-executor.ts` | Detect `pi:isResponse` metadata, process normally (no short-circuit), pass `skipReply` through `AsyncTaskResult` |
| `index.ts` | `processMessage` accepts `isResponse` option with different prompt framing. `onAsyncResult` skips reply when `skipReply` set. Rolling window rate limiter. |
| `client.ts` | Accept optional `metadata` in `SendMessageOptions` to merge into A2A messages |

Fixes td-409741