### PR TITLE
feat(pi-a2a): SQLite TaskStore + eliminate async result loop

### DIFF
--- a/extensions/pi-a2a/AGENTS.md
+++ b/extensions/pi-a2a/AGENTS.md
@@ -17,6 +17,7 @@ src/
 ├── logger.ts         # Structured logger via pi-logger event bus
 ├── agent-card.ts     # Agent Card builder from config, dynamic tool enrichment
 ├── agent-executor.ts # AgentExecutor — inline main-process delegation + TaskStore persistence
+├── supervisor.ts     # Loop control supervisor — cycle detection, hop limits, budget enforcement
 ├── task-store.ts     # SQLite-backed TaskStore (persistent tasks, WAL mode)
 ├── server.ts         # Self-contained HTTP server (node:http) + SDK RPC handler
 ├── client.ts         # Outbound A2A messaging via SDK Client
@@ -29,7 +30,8 @@ src/
 
 - **@a2a-js/sdk v0.3.10 integration** — Uses the SDK's `DefaultRequestHandler`, `JsonRpcTransportHandler`, `SQLiteTaskStore`, `InMemoryPushNotificationStore`, and `DefaultPushNotificationSender` for spec-compliant A2A protocol handling. The extension implements the `AgentExecutor` interface with pi-specific main-process delegation.
 - **Async-first task lifecycle** — The executor ACKs with "working" immediately (unblocking the HTTP response), then processes in the background. On completion, results are saved directly to the SQLite TaskStore (artifact + completed/failed status). Callers retrieve results via `tasks/get` polling or SSE `resubscribe`. No result messages are sent back — this eliminates bidirectional loops.
-- **Persistent SQLite TaskStore** — Tasks survive restarts. Schema: `a2a_tasks` with extracted `status`, `hop_count`, and `visited_agents` columns for efficient querying and future loop control. WAL mode for concurrent reads during processing. DB at `{agentDir}/db/a2a.db`.
+- **Persistent SQLite TaskStore** — Tasks survive restarts. Schema: `a2a_tasks` with extracted `status`, `hop_count`, and `visited_agents` columns for efficient querying and loop control. WAL mode for concurrent reads during processing. DB at `{agentDir}/db/a2a.db`.
+- **Loop control supervisor** — Prevents infinite A2A loops (A→B→A→B...) via spec-compliant metadata under `pi:` prefix. The supervisor runs before `execute()` and checks: (1) cycle detection — rejects if this agent already appears in `pi:visitedAgents`, (2) hop count — rejects if `pi:hopCount` exceeds `maxHops` (configurable, default 10). Metadata propagates on outbound messages so downstream agents inherit the chain. Pure-function design in `supervisor.ts` — testable and independent of the executor.
 - **Streaming support** — Capabilities declare `streaming: true`. The SDK's `sendMessageStream` returns an `AsyncGenerator`; the HTTP server detects this and responds with SSE (`text/event-stream`).
 - **Push notifications** — Capabilities declare `pushNotifications: true`. `InMemoryPushNotificationStore` and `DefaultPushNotificationSender` are wired into the `DefaultRequestHandler`, enabling clients to register webhook URLs for async task updates.
 - **Self-contained HTTP server** — Uses `node:http` directly. No dependency on pi-webserver, pi-kysely, or any other extension. Binds to `127.0.0.1` by default; optional API key auth for external access.
@@ -42,7 +44,7 @@ src/
 
 Settings key: `pi-a2a` in `~/.pi/agent/settings.json` or `.pi/settings.json`.
 
-Key fields: `port` (default 3100), `bind` (default "127.0.0.1"), `apiKey`, `publicUrl`, `name`, `description`, `version`, `organization`, `skills[]`, `hub` (url, apiKey, categories, tags, visibility, autoRegister), `staticAgents[]` (name, url, apiKey, description).
+Key fields: `port` (default 3100), `bind` (default "127.0.0.1"), `apiKey`, `publicUrl`, `name`, `description`, `version`, `organization`, `skills[]`, `maxHops` (default 10 — loop control hop limit), `hub` (url, apiKey, categories, tags, visibility, autoRegister), `staticAgents[]` (name, url, apiKey, description).
 
 ### Static Agents (no hub required)
 

--- a/extensions/pi-a2a/AGENTS.md
+++ b/extensions/pi-a2a/AGENTS.md
@@ -29,11 +29,12 @@ src/
 ## Key Design Decisions
 
 - **@a2a-js/sdk v0.3.10 integration** — Uses the SDK's `DefaultRequestHandler`, `JsonRpcTransportHandler`, `SQLiteTaskStore`, `InMemoryPushNotificationStore`, and `DefaultPushNotificationSender` for spec-compliant A2A protocol handling. The extension implements the `AgentExecutor` interface with pi-specific main-process delegation.
-- **Async-first task lifecycle** — The executor ACKs with "working" immediately (unblocking the HTTP response), then processes in the background. On completion, results are saved directly to the SQLite TaskStore (artifact + completed/failed status). Callers retrieve results via `tasks/get` polling or SSE `resubscribe`. No result messages are sent back — this eliminates bidirectional loops.
+- **Async-first task lifecycle** — Inbound: the executor ACKs with "working" immediately (unblocking the HTTP response), then processes in the background. On completion, results are saved directly to the SQLite TaskStore (artifact + completed/failed status). Outbound: `a2a_send` sends with `blocking: false` (fire-and-forget), gets back a taskId, then polls `tasks/get` every 5s until completed/failed/timeout. A sliding-window rate limiter (10 triggers/60s) prevents response injection storms. No result messages are sent back — this eliminates bidirectional loops.
 - **Persistent SQLite TaskStore** — Tasks survive restarts. Schema: `a2a_tasks` with extracted `status`, `hop_count`, and `visited_agents` columns for efficient querying and loop control. WAL mode for concurrent reads during processing. DB at `{agentDir}/db/a2a.db`.
 - **Loop control supervisor** — Prevents infinite A2A loops (A→B→A→B...) via spec-compliant metadata under `pi:` prefix. The supervisor runs before `execute()` and checks: (1) cycle detection — rejects if this agent already appears in `pi:visitedAgents`, (2) hop count — rejects if `pi:hopCount` exceeds `maxHops` (configurable, default 10). Metadata propagates on outbound messages so downstream agents inherit the chain. Pure-function design in `supervisor.ts` — testable and independent of the executor.
 - **Streaming support** — Capabilities declare `streaming: true`. The SDK's `sendMessageStream` returns an `AsyncGenerator`; the HTTP server detects this and responds with SSE (`text/event-stream`).
-- **Push notifications** — Capabilities declare `pushNotifications: true`. `InMemoryPushNotificationStore` and `DefaultPushNotificationSender` are wired into the `DefaultRequestHandler`, enabling clients to register webhook URLs for async task updates.
+- **Push notifications** — Capabilities declare `pushNotifications: true`. `SQLitePushNotificationStore` (persistent, shares DB with TaskStore) and `DefaultPushNotificationSender` are wired into the `DefaultRequestHandler`, enabling clients to register webhook URLs for async task updates. Push configs survive restarts.
+- **Task expiry** — Periodic cleanup (every 5 minutes) prunes tasks older than `taskTtlMs` (default 24 hours). Configurable via settings; set to 0 to disable.
 - **Self-contained HTTP server** — Uses `node:http` directly. No dependency on pi-webserver, pi-kysely, or any other extension. Binds to `127.0.0.1` by default; optional API key auth for external access.
 - **Dynamic agent card** — Starts with a basic card from config, then enriches it with registered extension tools after all extensions load. Uses a two-phase approach: `queueMicrotask` after `session_start` catches most tools, `agent_start` catches stragglers.
 - **Inline main-process delegation** — Incoming A2A messages are injected into the main pi conversation via `pi.sendMessage({ triggerTurn: true })`. Full TUI visibility — tool calls, file edits, thinking — all visible in the chat. Serial queue (max 1 concurrent), additional requests queued in arrival order.
@@ -44,7 +45,7 @@ src/
 
 Settings key: `pi-a2a` in `~/.pi/agent/settings.json` or `.pi/settings.json`.
 
-Key fields: `port` (default 3100), `bind` (default "127.0.0.1"), `apiKey`, `publicUrl`, `name`, `description`, `version`, `organization`, `skills[]`, `maxHops` (default 10 — loop control hop limit), `hub` (url, apiKey, categories, tags, visibility, autoRegister), `staticAgents[]` (name, url, apiKey, description).
+Key fields: `port` (default 3100), `bind` (default "127.0.0.1"), `apiKey`, `publicUrl`, `name`, `description`, `version`, `organization`, `skills[]`, `maxHops` (default 10 — loop control hop limit), `taskTtlMs` (default 86400000/24h — task expiry TTL, 0 to disable), `hub` (url, apiKey, categories, tags, visibility, autoRegister), `staticAgents[]` (name, url, apiKey, description).
 
 ### Static Agents (no hub required)
 

--- a/extensions/pi-a2a/AGENTS.md
+++ b/extensions/pi-a2a/AGENTS.md
@@ -16,8 +16,10 @@ src/
 ├── config.ts         # Settings.json loader via SettingsManager
 ├── logger.ts         # Structured logger via pi-logger event bus
 ├── agent-card.ts     # Agent Card builder from config, dynamic tool enrichment
-├── agent-executor.ts # AgentExecutor implementation — spawns pi subprocesses
+├── agent-executor.ts # AgentExecutor — inline main-process delegation + TaskStore persistence
+├── task-store.ts     # SQLite-backed TaskStore (persistent tasks, WAL mode)
 ├── server.ts         # Self-contained HTTP server (node:http) + SDK RPC handler
+├── client.ts         # Outbound A2A messaging via SDK Client
 ├── static-agents.ts  # Static agent registry — fetch/cache remote agent cards
 ├── subprocess.ts     # Isolated pi subprocess runner (pi --mode rpc)
 └── hub.ts            # A2A Hub registration client
@@ -25,13 +27,14 @@ src/
 
 ## Key Design Decisions
 
-- **@a2a-js/sdk v0.3.10 integration** — Uses the SDK's `DefaultRequestHandler`, `JsonRpcTransportHandler`, `InMemoryTaskStore`, `InMemoryPushNotificationStore`, and `DefaultPushNotificationSender` for spec-compliant A2A protocol handling. The extension implements the `AgentExecutor` interface with pi-specific subprocess logic.
-- **Full task lifecycle** — The executor follows the SDK's canonical pattern: publish initial Task (submitted) → status-update (working) → artifact-update → status-update (completed, final=true) → finished. This ensures `tasks/get` returns proper state and streaming/push notifications work.
+- **@a2a-js/sdk v0.3.10 integration** — Uses the SDK's `DefaultRequestHandler`, `JsonRpcTransportHandler`, `SQLiteTaskStore`, `InMemoryPushNotificationStore`, and `DefaultPushNotificationSender` for spec-compliant A2A protocol handling. The extension implements the `AgentExecutor` interface with pi-specific main-process delegation.
+- **Async-first task lifecycle** — The executor ACKs with "working" immediately (unblocking the HTTP response), then processes in the background. On completion, results are saved directly to the SQLite TaskStore (artifact + completed/failed status). Callers retrieve results via `tasks/get` polling or SSE `resubscribe`. No result messages are sent back — this eliminates bidirectional loops.
+- **Persistent SQLite TaskStore** — Tasks survive restarts. Schema: `a2a_tasks` with extracted `status`, `hop_count`, and `visited_agents` columns for efficient querying and future loop control. WAL mode for concurrent reads during processing. DB at `{agentDir}/db/a2a.db`.
 - **Streaming support** — Capabilities declare `streaming: true`. The SDK's `sendMessageStream` returns an `AsyncGenerator`; the HTTP server detects this and responds with SSE (`text/event-stream`).
 - **Push notifications** — Capabilities declare `pushNotifications: true`. `InMemoryPushNotificationStore` and `DefaultPushNotificationSender` are wired into the `DefaultRequestHandler`, enabling clients to register webhook URLs for async task updates.
 - **Self-contained HTTP server** — Uses `node:http` directly. No dependency on pi-webserver, pi-kysely, or any other extension. Binds to `127.0.0.1` by default; optional API key auth for external access.
 - **Dynamic agent card** — Starts with a basic card from config, then enriches it with registered extension tools after all extensions load. Uses a two-phase approach: `queueMicrotask` after `session_start` catches most tools, `agent_start` catches stragglers.
-- **Subprocess isolation** — Each `message/send` spawns a fresh `pi --mode rpc -ne` process. No shared state, no extension leakage. Cancellation kills the subprocess via `AbortController`.
+- **Inline main-process delegation** — Incoming A2A messages are injected into the main pi conversation via `pi.sendMessage({ triggerTurn: true })`. Full TUI visibility — tool calls, file edits, thinking — all visible in the chat. Serial queue (max 1 concurrent), additional requests queued in arrival order.
 - **Settings-driven** — All config via `pi-a2a` key in settings.json. No env vars.
 - **Static agent registry** — Manually configured remote agents in `staticAgents[]`. Agent cards are fetched from `/.well-known/agent-card.json` on session start and cached in memory. No hub required. Refresh via `/a2a agents refresh` command. Static agents are resolved first in `a2a_send`, before hub lookup.
 

--- a/extensions/pi-a2a/package-lock.json
+++ b/extensions/pi-a2a/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@a2a-js/sdk": "^0.3.10"
+        "@a2a-js/sdk": "^0.3.10",
+        "better-sqlite3": "^12.8.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
@@ -2058,6 +2060,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -2070,7 +2082,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2215,8 +2226,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
@@ -2228,6 +2238,20 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -2236,6 +2260,26 @@
       "peer": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bowser": {
@@ -2256,6 +2300,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -2287,6 +2355,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
@@ -2425,6 +2499,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -2438,6 +2536,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2479,7 +2586,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2548,6 +2654,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/extend": {
@@ -2688,6 +2803,12 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2730,6 +2851,12 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/gaxios": {
       "version": "7.1.3",
@@ -2825,6 +2952,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -2958,8 +3091,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -2970,6 +3102,18 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -3137,6 +3281,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -3153,6 +3309,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -3162,6 +3327,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3182,6 +3353,12 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -3190,6 +3367,18 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -3247,7 +3436,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3394,6 +3582,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -3483,10 +3698,38 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -3632,8 +3875,19 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3664,6 +3918,51 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -3723,6 +4022,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3841,6 +4149,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
@@ -3882,6 +4199,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thenify": {
@@ -3940,6 +4285,18 @@
       "license": "0BSD",
       "peer": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3981,8 +4338,13 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.0",
@@ -4110,8 +4472,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/extensions/pi-a2a/package.json
+++ b/extensions/pi-a2a/package.json
@@ -20,6 +20,7 @@
     "@mariozechner/pi-coding-agent": "*"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "typescript": "^5.9.3"
   },
   "files": [
@@ -34,6 +35,7 @@
     "directory": "extensions/pi-a2a"
   },
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.10"
+    "@a2a-js/sdk": "^0.3.10",
+    "better-sqlite3": "^12.8.0"
   }
 }

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -74,6 +74,8 @@ export class PiAgentExecutor implements AgentExecutor {
 	private queue: Promise<void> = Promise.resolve();
 	/** Cancel callbacks for queued (not yet active) tasks. */
 	private cancelCallbacks = new Map<string, () => void>();
+	/** Map taskId → contextId for protocol-correct cancel events. */
+	private taskContexts = new Map<string, string>();
 	/** Number of tasks waiting in the queue (not yet active). */
 	private _queueDepth = 0;
 	/** Last completed/failed task duration for telemetry reporting. */
@@ -129,6 +131,7 @@ export class PiAgentExecutor implements AgentExecutor {
 			this.log("executor_abort_queued", { taskId });
 		}
 		this.cancelCallbacks.clear();
+		this.taskContexts.clear();
 
 		if (this.activeTaskId) {
 			this.log("executor_abort_all", { taskId: this.activeTaskId });
@@ -155,10 +158,11 @@ export class PiAgentExecutor implements AgentExecutor {
 			} as Task);
 		}
 
-		// Register cancel callback so queued tasks can be canceled
+		// Register cancel callback and context mapping so queued tasks can be canceled
 		let canceled = false;
 		this._queueDepth++;
 		this.cancelCallbacks.set(taskId, () => { canceled = true; });
+		this.taskContexts.set(taskId, contextId);
 
 		// Wait for preceding tasks to finish
 		await myTurn;
@@ -301,16 +305,19 @@ export class PiAgentExecutor implements AgentExecutor {
 	}
 
 	async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+		const resolvedContextId = this.taskContexts.get(taskId) ?? taskId;
+
 		// Check queued tasks first
 		const queuedCancel = this.cancelCallbacks.get(taskId);
 		if (queuedCancel) {
 			queuedCancel();
 			this.cancelCallbacks.delete(taskId);
+			this.taskContexts.delete(taskId);
 			this.log("executor_cancel_queued", { taskId });
 			eventBus.publish({
 				kind: "status-update",
 				taskId,
-				contextId: taskId,
+				contextId: resolvedContextId,
 				status: { state: "canceled", timestamp: new Date().toISOString() },
 				final: true,
 			} as TaskStatusUpdateEvent);
@@ -321,12 +328,14 @@ export class PiAgentExecutor implements AgentExecutor {
 		// Active task — mark as canceled so result dispatch is skipped
 		if (this.activeTaskId === taskId) {
 			this.activeTaskId = null;
+			this.activeLoopMetadata = null;
+			this.taskContexts.delete(taskId);
 			this.log("executor_cancel", { taskId });
 
 			eventBus.publish({
 				kind: "status-update",
 				taskId,
-				contextId: taskId,
+				contextId: resolvedContextId,
 				status: { state: "canceled", timestamp: new Date().toISOString() },
 				final: true,
 			} as TaskStatusUpdateEvent);
@@ -374,6 +383,7 @@ export class PiAgentExecutor implements AgentExecutor {
 			// Check if canceled while processing
 			if (this.activeTaskId !== taskId) {
 				this.log("executor_canceled_during_run", { taskId });
+				this.activeLoopMetadata = null;
 				return;
 			}
 
@@ -393,6 +403,7 @@ export class PiAgentExecutor implements AgentExecutor {
 
 			// Update the task in the store — callers poll via tasks/get
 			await this.saveTaskResult(taskId, contextId, result, loopMetadata);
+			this.taskContexts.delete(taskId);
 		} catch (err: unknown) {
 			this.activeTaskId = null;
 			this.activeLoopMetadata = null;
@@ -410,6 +421,7 @@ export class PiAgentExecutor implements AgentExecutor {
 				error: msg,
 				durationMs: 0,
 			}, loopMetadata);
+			this.taskContexts.delete(taskId);
 		} finally {
 			releaseQueue();
 		}

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -6,13 +6,16 @@
  * TUI visibility — tool calls, file edits, thinking — all visible in
  * the chat, just like normal user messages.
  *
- * Task lifecycle (unchanged from the SDK's perspective):
+ * Task lifecycle:
  *   1. Publish initial Task (state: submitted) if new
- *   2. Publish status-update (state: working)
- *   3. Delegate to main agent process via processMessage callback
- *   4. Publish artifact-update with the response
- *   5. Publish final status-update (state: completed) with final=true
- *   6. Call eventBus.finished()
+ *   2. Publish status-update (state: working) + finish event bus → HTTP response
+ *   3. Delegate to main agent process via processMessage callback (background)
+ *   4. On completion: update task in TaskStore with artifact + completed/failed status
+ *   5. Callers retrieve results via tasks/get polling or SSE resubscribe
+ *
+ * This eliminates the old onAsyncResult→sendA2AMessage pattern that caused
+ * bidirectional infinite loops (A→B→A→B...). Results are now stored in the
+ * task store and retrieved through the A2A protocol's native task lifecycle.
  *
  * Concurrency: max 1 (blocks — the main agent handles one request at a
  * time). Additional requests are queued and processed in arrival order.
@@ -20,7 +23,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { AgentExecutor, ExecutionEventBus, RequestContext } from "@a2a-js/sdk/server";
+import type { AgentExecutor, ExecutionEventBus, RequestContext, TaskStore } from "@a2a-js/sdk/server";
 import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from "@a2a-js/sdk";
 import type { LogFn } from "./logger.ts";
 import type { TelemetrySnapshot } from "./types.ts";
@@ -36,15 +39,6 @@ export interface ProcessResult {
 	durationMs: number;
 }
 
-/** Callback payload when a long-running task completes in the background. */
-export interface AsyncTaskResult {
-	taskId: string;
-	senderName: string;
-	/** Sender's A2A endpoint URL, captured from the original request context. */
-	senderUrl?: string;
-	result: ProcessResult;
-}
-
 /**
  * Callback to inject a message into the main agent conversation.
  * Returns a promise that resolves when the agent finishes processing.
@@ -54,6 +48,7 @@ export type ProcessMessage = (prompt: string, sender: string) => Promise<Process
 export class PiAgentExecutor implements AgentExecutor {
 	private log: LogFn;
 	private processMessage: ProcessMessage;
+	private taskStore: TaskStore;
 	/**
 	 * Track the single active task for cancellation.
 	 * Note: cancellation only prevents result dispatch — the underlying
@@ -72,12 +67,11 @@ export class PiAgentExecutor implements AgentExecutor {
 	private lastTaskStatus?: "completed" | "failed";
 	/** Optional callback invoked after each task completes or fails. */
 	onTaskFinished?: () => void;
-	/** Optional callback to deliver async task results (for sending responses back to callers). */
-	onAsyncResult?: (result: AsyncTaskResult) => void;
 
-	constructor(log: LogFn, processMessage: ProcessMessage) {
+	constructor(log: LogFn, processMessage: ProcessMessage, taskStore: TaskStore) {
 		this.log = log;
 		this.processMessage = processMessage;
+		this.taskStore = taskStore;
 	}
 
 	/** Return a snapshot of current telemetry state for hub reporting. */
@@ -149,12 +143,11 @@ export class PiAgentExecutor implements AgentExecutor {
 			return;
 		}
 
-		// Extract sender identity (name + URL for reply routing)
+		// Extract sender identity for logging
 		const senderMeta = (userMessage.metadata as Record<string, unknown> | undefined)?.["pi:sender"] as
-			| { name?: string; description?: string; url?: string }
+			| { name?: string; description?: string }
 			| undefined;
 		const senderName = senderMeta?.name ?? "Unknown agent";
-		const senderUrl = senderMeta?.url;
 
 		// Extract text from all part types
 		const textSegments: string[] = [];
@@ -211,10 +204,10 @@ export class PiAgentExecutor implements AgentExecutor {
 		eventBus.finished();
 
 		// ── Process in the background ──────────────────────────────
-		// The HTTP response has already been sent. The agent works on the
-		// task, and when done, the result is delivered via onAsyncResult
-		// which sends it back to the caller as a new A2A message.
-		this.processInBackground(taskId, prompt, senderName, senderUrl, releaseQueue!).catch((err) => {
+		// The HTTP response has already been sent with "working" status.
+		// When the agent finishes, the result is saved to the TaskStore.
+		// Callers retrieve it via tasks/get polling or SSE resubscribe.
+		this.processInBackground(taskId, contextId, prompt, senderName, releaseQueue!).catch((err) => {
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_bg_error", { taskId, error: msg }, "ERROR");
 		});
@@ -270,14 +263,18 @@ export class PiAgentExecutor implements AgentExecutor {
 	}
 
 	/**
-	 * Process a task in the background after the ACK has been sent.
-	 * When the agent finishes, delivers the result via onAsyncResult callback.
+	 * Process a task in the background after the HTTP ACK has been sent.
+	 *
+	 * When the agent finishes, updates the task in the TaskStore with the
+	 * result artifact and final status (completed/failed). Callers retrieve
+	 * results via tasks/get polling or SSE resubscribe — no new A2A message
+	 * is sent back, eliminating bidirectional loops.
 	 */
 	private async processInBackground(
 		taskId: string,
+		contextId: string,
 		prompt: string,
 		senderName: string,
-		senderUrl: string | undefined,
 		releaseQueue: () => void,
 	): Promise<void> {
 		try {
@@ -302,8 +299,8 @@ export class PiAgentExecutor implements AgentExecutor {
 				this.log("executor_failed", { taskId, error: result.error ?? "Unknown", durationMs: result.durationMs }, "ERROR");
 			}
 
-			// Deliver the result to be sent back to the caller
-			this.onAsyncResult?.({ taskId, senderName, senderUrl, result });
+			// Update the task in the store — callers poll via tasks/get
+			await this.saveTaskResult(taskId, contextId, result);
 		} catch (err: unknown) {
 			this.activeTaskId = null;
 			const msg = err instanceof Error ? err.message : String(err);
@@ -313,15 +310,78 @@ export class PiAgentExecutor implements AgentExecutor {
 			this.lastTaskStatus = "failed";
 			this.onTaskFinished?.();
 
-			// Deliver error result
-			this.onAsyncResult?.({
-				taskId,
-				senderName,
-				senderUrl,
-				result: { ok: false, response: "", error: msg, durationMs: 0 },
+			// Save failure to the store so callers can see the error
+			await this.saveTaskResult(taskId, contextId, {
+				ok: false,
+				response: "",
+				error: msg,
+				durationMs: 0,
 			});
 		} finally {
 			releaseQueue();
+		}
+	}
+
+	/**
+	 * Save the completed/failed task result to the TaskStore.
+	 *
+	 * Loads the existing task (saved by the SDK during the "working" ACK phase),
+	 * updates it with the result artifact and final status, and saves it back.
+	 * If the task isn't found (shouldn't happen), constructs a minimal one.
+	 */
+	private async saveTaskResult(
+		taskId: string,
+		contextId: string,
+		result: ProcessResult,
+	): Promise<void> {
+		try {
+			const existing = await this.taskStore.load(taskId);
+			const now = new Date().toISOString();
+
+			const statusMessage = {
+				kind: "message" as const,
+				messageId: randomUUID(),
+				role: "agent" as const,
+				parts: [{
+					kind: "text" as const,
+					text: result.ok
+						? result.response
+						: `Error: ${result.error ?? "Unknown error"}`,
+				} as Part],
+			};
+
+			const updatedTask: Task = {
+				kind: "task",
+				id: taskId,
+				contextId,
+				// Preserve history from the existing task
+				...(existing?.history ? { history: existing.history } : {}),
+				// Preserve existing metadata
+				...(existing?.metadata ? { metadata: existing.metadata } : {}),
+				status: {
+					state: result.ok ? "completed" : "failed",
+					message: statusMessage,
+					timestamp: now,
+				},
+				// Add artifact with response on success
+				...(result.ok ? {
+					artifacts: [{
+						artifactId: randomUUID(),
+						name: "response",
+						parts: [{ kind: "text" as const, text: result.response } as Part],
+					}],
+				} : {}),
+			};
+
+			await this.taskStore.save(updatedTask);
+			this.log("task_result_saved", {
+				taskId,
+				state: result.ok ? "completed" : "failed",
+				hadExisting: !!existing,
+			});
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.log("task_result_save_error", { taskId, error: msg }, "ERROR");
 		}
 	}
 

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -27,6 +27,13 @@ import type { AgentExecutor, ExecutionEventBus, RequestContext, TaskStore } from
 import type { Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent, Part } from "@a2a-js/sdk";
 import type { LogFn } from "./logger.ts";
 import type { TelemetrySnapshot } from "./types.ts";
+import {
+	extractLoopMetadata,
+	injectLoopMetadata,
+	supervise,
+	type LoopMetadata,
+	type SupervisorConfig,
+} from "./supervisor.ts";
 
 /** Max concurrent tasks (1 for main-process delegation). */
 const MAX_CONCURRENT = 1;
@@ -49,12 +56,20 @@ export class PiAgentExecutor implements AgentExecutor {
 	private log: LogFn;
 	private processMessage: ProcessMessage;
 	private taskStore: TaskStore;
+	private supervisorConfig: SupervisorConfig;
 	/**
 	 * Track the single active task for cancellation.
 	 * Note: cancellation only prevents result dispatch — the underlying
 	 * agent turn cannot be interrupted mid-execution at this layer.
 	 */
 	private activeTaskId: string | null = null;
+	/**
+	 * Loop metadata for the currently active task (set by supervisor).
+	 * Used by the outbound client to propagate loop control on a2a_send
+	 * calls made during this task's processing. Null when no active task
+	 * or for tasks without loop metadata.
+	 */
+	private activeLoopMetadata: LoopMetadata | null = null;
 	/** Serializing queue — tasks run one at a time in arrival order. */
 	private queue: Promise<void> = Promise.resolve();
 	/** Cancel callbacks for queued (not yet active) tasks. */
@@ -68,10 +83,25 @@ export class PiAgentExecutor implements AgentExecutor {
 	/** Optional callback invoked after each task completes or fails. */
 	onTaskFinished?: () => void;
 
-	constructor(log: LogFn, processMessage: ProcessMessage, taskStore: TaskStore) {
+	constructor(
+		log: LogFn,
+		processMessage: ProcessMessage,
+		taskStore: TaskStore,
+		supervisorConfig: SupervisorConfig,
+	) {
 		this.log = log;
 		this.processMessage = processMessage;
 		this.taskStore = taskStore;
+		this.supervisorConfig = supervisorConfig;
+	}
+
+	/**
+	 * Get the loop metadata for the currently active inbound task.
+	 * Returns null if no task is active or the task had no loop metadata.
+	 * Used by the outbound client (a2a_send) to propagate loop control.
+	 */
+	getActiveLoopMetadata(): LoopMetadata | null {
+		return this.activeLoopMetadata;
 	}
 
 	/** Return a snapshot of current telemetry state for hub reporting. */
@@ -103,6 +133,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		if (this.activeTaskId) {
 			this.log("executor_abort_all", { taskId: this.activeTaskId });
 			this.activeTaskId = null;
+			this.activeLoopMetadata = null;
 		}
 	}
 
@@ -143,8 +174,61 @@ export class PiAgentExecutor implements AgentExecutor {
 			return;
 		}
 
+		// ── Supervisor: loop control check ──────────────────────────
+		// Extract loop metadata from the incoming message and run supervisor
+		// checks (cycle detection, hop count limit) BEFORE processing.
+		const messageMeta = userMessage.metadata as Record<string, unknown> | undefined;
+		const incomingLoop = extractLoopMetadata(messageMeta);
+		const supervisorResult = supervise(incomingLoop, this.supervisorConfig);
+
+		if (!supervisorResult.approved) {
+			this.log("supervisor_rejected", {
+				taskId,
+				reason: supervisorResult.reason,
+				hopCount: supervisorResult.metadata.hopCount,
+				visitedAgents: supervisorResult.metadata.visitedAgents,
+			}, "WARN");
+
+			// Publish failed status with clear rejection reason and finish
+			this.publishError(taskId, contextId, eventBus,
+				`Loop control: ${supervisorResult.reason}`);
+			eventBus.finished();
+
+			// Save the rejected task with metadata so it shows up in task store
+			const rejectedMeta = injectLoopMetadata(messageMeta, supervisorResult.metadata);
+			const rejectedTask: Task = {
+				kind: "task",
+				id: taskId,
+				contextId,
+				metadata: rejectedMeta,
+				status: {
+					state: "failed",
+					message: {
+						kind: "message",
+						messageId: randomUUID(),
+						role: "agent",
+						parts: [{ kind: "text", text: `Loop control: ${supervisorResult.reason}` } as Part],
+					},
+					timestamp: new Date().toISOString(),
+				},
+			};
+			await this.taskStore.save(rejectedTask);
+
+			releaseQueue!();
+			return;
+		}
+
+		// Supervisor approved — store the updated metadata for this task.
+		// This is used by a2a_send for outbound metadata propagation.
+		this.activeLoopMetadata = supervisorResult.metadata;
+		this.log("supervisor_approved", {
+			taskId,
+			hopCount: supervisorResult.metadata.hopCount,
+			visitedAgents: supervisorResult.metadata.visitedAgents,
+		});
+
 		// Extract sender identity for logging
-		const senderMeta = (userMessage.metadata as Record<string, unknown> | undefined)?.["pi:sender"] as
+		const senderMeta = messageMeta?.["pi:sender"] as
 			| { name?: string; description?: string }
 			| undefined;
 		const senderName = senderMeta?.name ?? "Unknown agent";
@@ -185,6 +269,8 @@ export class PiAgentExecutor implements AgentExecutor {
 		// This unblocks the HTTP response so the sender gets a Task with
 		// state: "working" right away instead of waiting for the agent to
 		// finish (which can take minutes and causes timeout).
+		// Include loop metadata so the caller can inspect it.
+		const ackMetadata = injectLoopMetadata(messageMeta, supervisorResult.metadata);
 		eventBus.publish({
 			kind: "status-update",
 			taskId,
@@ -199,6 +285,7 @@ export class PiAgentExecutor implements AgentExecutor {
 				},
 				timestamp: new Date().toISOString(),
 			},
+			metadata: ackMetadata,
 			final: true,
 		} as TaskStatusUpdateEvent);
 		eventBus.finished();
@@ -277,6 +364,10 @@ export class PiAgentExecutor implements AgentExecutor {
 		senderName: string,
 		releaseQueue: () => void,
 	): Promise<void> {
+		// Capture loop metadata before processing — it's cleared when the task
+		// finishes, but we need it for the saved task result.
+		const loopMetadata = this.activeLoopMetadata;
+
 		try {
 			const result = await this.processMessage(prompt, senderName);
 
@@ -287,6 +378,7 @@ export class PiAgentExecutor implements AgentExecutor {
 			}
 
 			this.activeTaskId = null;
+			this.activeLoopMetadata = null;
 
 			// Record telemetry
 			this.lastTaskDurationMs = result.durationMs;
@@ -300,9 +392,10 @@ export class PiAgentExecutor implements AgentExecutor {
 			}
 
 			// Update the task in the store — callers poll via tasks/get
-			await this.saveTaskResult(taskId, contextId, result);
+			await this.saveTaskResult(taskId, contextId, result, loopMetadata);
 		} catch (err: unknown) {
 			this.activeTaskId = null;
+			this.activeLoopMetadata = null;
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_error", { taskId, error: msg }, "ERROR");
 
@@ -316,7 +409,7 @@ export class PiAgentExecutor implements AgentExecutor {
 				response: "",
 				error: msg,
 				durationMs: 0,
-			});
+			}, loopMetadata);
 		} finally {
 			releaseQueue();
 		}
@@ -333,6 +426,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		taskId: string,
 		contextId: string,
 		result: ProcessResult,
+		loopMetadata?: LoopMetadata | null,
 	): Promise<void> {
 		try {
 			const existing = await this.taskStore.load(taskId);
@@ -350,14 +444,20 @@ export class PiAgentExecutor implements AgentExecutor {
 				} as Part],
 			};
 
+			// Merge existing metadata with loop-control metadata
+			const existingMeta = existing?.metadata as Record<string, unknown> | undefined;
+			const mergedMeta = loopMetadata
+				? injectLoopMetadata(existingMeta, loopMetadata)
+				: existingMeta;
+
 			const updatedTask: Task = {
 				kind: "task",
 				id: taskId,
 				contextId,
 				// Preserve history from the existing task
 				...(existing?.history ? { history: existing.history } : {}),
-				// Preserve existing metadata
-				...(existing?.metadata ? { metadata: existing.metadata } : {}),
+				// Include merged metadata (existing + loop control)
+				...(mergedMeta ? { metadata: mergedMeta } : {}),
 				status: {
 					state: result.ok ? "completed" : "failed",
 					message: statusMessage,

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -65,8 +65,34 @@ export interface SendMessageResult {
 	error?: string;
 	/** True when the remote agent returned HTTP 401 — credential may be stale. */
 	unauthorized?: boolean;
-	/** True when the remote agent ACKed with "working" — the real result will arrive later as a separate message. */
+	/** True when the remote agent ACKed with "working" — poll via getRemoteTask(). */
 	working?: boolean;
+	/** Task ID from the remote agent — use with getRemoteTask() to poll for completion. */
+	taskId?: string;
+}
+
+/** Options for polling a remote task's status. */
+export interface GetRemoteTaskOptions {
+	/** Remote agent's A2A endpoint URL. */
+	url: string;
+	/** Task ID to poll. */
+	taskId: string;
+	/** Bearer token for authenticating with the remote agent. */
+	credential?: string | null;
+	/** Callback to refresh a stale credential on 401. */
+	onRefreshCredential?: () => Promise<string | null>;
+}
+
+/** Result of polling a remote task. */
+export interface GetRemoteTaskResult {
+	/** Task state: submitted, working, completed, failed, canceled. */
+	state: string;
+	/** Extracted text if completed. */
+	response?: string;
+	/** Error message if failed. */
+	error?: string;
+	/** Raw task object for inspection. */
+	raw?: unknown;
 }
 
 /**
@@ -184,30 +210,42 @@ export async function sendA2AMessage(
 				...(metadata ? { metadata } : {}),
 			},
 			configuration: {
-				blocking: true,
+				blocking: false,
 			},
 		};
 
-		// ── Send via SDK ──────────────────────────────────────────
+		// ── Send via SDK (non-blocking) ───────────────────────────
+		// With blocking: false, the remote agent returns a Task immediately
+		// with submitted/working status. We return the taskId for polling.
 		const requestOpts = timeoutMs
 			? { signal: AbortSignal.timeout(timeoutMs) }
 			: undefined;
 
 		const result = await client.sendMessage(params, requestOpts);
 
-		// Detect "working" ACK — the remote agent accepted the task but hasn't finished yet.
-		// The actual result will arrive later as a separate A2A message.
+		// Extract task ID from the result
+		const taskId = (result as { id?: string }).id;
+
+		// Check if the remote returned a completed result immediately
+		// (possible if the task was trivial or already cached)
 		const status = (result as { status?: { state?: string } }).status;
-		if (status?.state === "working") {
-			log("a2a_send_working", { url });
-			return { ok: true, response: "", raw: result, working: true };
+		const state = status?.state;
+
+		if (state === "completed") {
+			const responseText = extractResponseText(result);
+			log("a2a_send_completed_immediately", { url, taskId, responseLength: responseText.length });
+			return { ok: true, response: responseText, raw: result, taskId: taskId ?? undefined };
 		}
 
-		// ── Extract response text ─────────────────────────────────
-		const responseText = extractResponseText(result);
-		log("a2a_send_success", { url, responseLength: responseText.length });
+		if (state === "failed") {
+			const errorText = extractResponseText(result);
+			log("a2a_send_failed_immediately", { url, taskId }, "ERROR");
+			return { ok: false, error: errorText, raw: result, taskId: taskId ?? undefined };
+		}
 
-		return { ok: true, response: responseText, raw: result };
+		// Task is submitted or working — return for polling
+		log("a2a_send_working", { url, taskId, state });
+		return { ok: true, response: "", raw: result, working: true, taskId: taskId ?? undefined };
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 
@@ -224,6 +262,83 @@ export async function sendA2AMessage(
 
 		log("a2a_send_error", { url, error: msg }, "ERROR");
 		return { ok: false, error: msg };
+	}
+}
+
+/**
+ * Poll a remote A2A task's status via the SDK Client's getTask method.
+ *
+ * Creates a short-lived Client per call (same pattern as sendA2AMessage).
+ * Returns the task state and extracted response/error text.
+ */
+export async function getRemoteTask(
+	opts: GetRemoteTaskOptions,
+	log: LogFn,
+): Promise<GetRemoteTaskResult> {
+	const { url, taskId, credential, onRefreshCredential } = opts;
+
+	try {
+		// Build auth-aware fetch (same pattern as sendA2AMessage)
+		let currentCredential = credential ?? null;
+		let retried = false;
+
+		const authHandler: AuthenticationHandler = {
+			async headers() {
+				const hdrs: Record<string, string> = {};
+				if (currentCredential) {
+					hdrs["Authorization"] = `Bearer ${currentCredential}`;
+				}
+				return hdrs;
+			},
+			async shouldRetryWithHeaders(_req, res) {
+				if (res.status === 401 && !retried && onRefreshCredential) {
+					retried = true;
+					const fresh = await onRefreshCredential();
+					if (fresh) {
+						currentCredential = fresh;
+						return { Authorization: `Bearer ${fresh}` };
+					}
+				}
+				return undefined;
+			},
+		};
+
+		const fetchImpl = createAuthenticatingFetchWithRetry(fetch, authHandler);
+		const transport = new JsonRpcTransport({ endpoint: url, fetchImpl });
+		const minimalCard: AgentCard = {
+			name: "remote-agent",
+			description: "",
+			url,
+			version: "1.0.0",
+			protocolVersion: "0.2.2",
+			capabilities: {},
+			defaultInputModes: ["text/plain"],
+			defaultOutputModes: ["text/plain"],
+			skills: [],
+		};
+		const client = new Client(transport, minimalCard);
+
+		const task = await client.getTask({ id: taskId });
+		const state = task.status?.state ?? "unknown";
+
+		if (state === "completed") {
+			const response = extractResponseText(task);
+			log("a2a_poll_completed", { url, taskId, responseLength: response.length });
+			return { state, response, raw: task };
+		}
+
+		if (state === "failed") {
+			const errorText = extractResponseText(task);
+			log("a2a_poll_failed", { url, taskId }, "WARN");
+			return { state, error: errorText, raw: task };
+		}
+
+		// Still working/submitted/canceled
+		return { state, raw: task };
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		log("a2a_poll_error", { url, taskId, error: msg }, "ERROR");
+		throw err;
 	}
 }
 

--- a/extensions/pi-a2a/src/client.ts
+++ b/extensions/pi-a2a/src/client.ts
@@ -17,6 +17,8 @@ import {
 } from "@a2a-js/sdk/client";
 import type { AgentCard, MessageSendParams, Task, Message, Part } from "@a2a-js/sdk";
 import type { LogFn } from "./logger.ts";
+import type { LoopMetadata } from "./supervisor.ts";
+import { injectLoopMetadata } from "./supervisor.ts";
 
 /** Sender identity to include in message metadata. */
 export interface SenderIdentity {
@@ -45,6 +47,12 @@ export interface SendMessageOptions {
 	 * If not provided, 401 is returned as-is.
 	 */
 	onRefreshCredential?: () => Promise<string | null>;
+	/**
+	 * Loop-control metadata to propagate on the outbound message.
+	 * When set, pi:hopCount, pi:visitedAgents, and pi:budgets are injected
+	 * into the message metadata for downstream loop prevention.
+	 */
+	loopMetadata?: LoopMetadata | null;
 }
 
 export interface SendMessageResult {
@@ -71,9 +79,9 @@ export async function sendA2AMessage(
 	opts: SendMessageOptions,
 	log: LogFn,
 ): Promise<SendMessageResult> {
-	const { url, message, credential, timeoutMs, sender, onRefreshCredential } = opts;
+	const { url, message, credential, timeoutMs, sender, onRefreshCredential, loopMetadata } = opts;
 
-	log("a2a_send_start", { url, messageLength: message.length, hasCredential: !!credential });
+	log("a2a_send_start", { url, messageLength: message.length, hasCredential: !!credential, hopCount: loopMetadata?.hopCount });
 
 	// Track auth state explicitly so we can set `unauthorized: true`
 	// without relying on SDK error message format (which is unstable
@@ -152,7 +160,8 @@ export async function sendA2AMessage(
 		const client = new Client(transport, minimalCard);
 
 		// ── Build the A2A message ─────────────────────────────────
-		const metadata: Record<string, unknown> | undefined = sender
+		// Start with sender identity, then layer in loop-control metadata
+		let metadata: Record<string, unknown> | undefined = sender
 			? {
 				"pi:sender": {
 					name: sender.name,
@@ -160,6 +169,11 @@ export async function sendA2AMessage(
 				},
 			}
 			: undefined;
+
+		// Inject loop-control metadata for downstream loop prevention
+		if (loopMetadata) {
+			metadata = injectLoopMetadata(metadata, loopMetadata);
+		}
 
 		const params: MessageSendParams = {
 			message: {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -45,7 +45,7 @@ import {
 import { SQLiteTaskStore } from "./task-store.ts";
 import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
-import { PiAgentExecutor, type ProcessResult, type AsyncTaskResult } from "./agent-executor.ts";
+import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
 import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification } from "./hub.ts";
 import { sendA2AMessage, type SenderIdentity } from "./client.ts";
@@ -65,43 +65,6 @@ function fmtDuration(ms: number): string {
 	const s = Math.round(ms / 1000);
 	if (s < 60) return `${s}s`;
 	return `${Math.floor(s / 60)}m ${s % 60}s`;
-}
-
-/**
- * Validate a reply URL for SSRF safety.
- *
- * Accepts https:// URLs unconditionally.
- * Accepts http:// only for localhost (127.0.0.1, [::1], localhost).
- * Rejects everything else: private/link-local IPs, non-http(s) schemes, invalid URLs.
- *
- * Returns the validated URL string, or null if rejected.
- */
-function validateReplyUrl(url: string): string | null {
-	let parsed: URL;
-	try {
-		parsed = new URL(url);
-	} catch {
-		return null;
-	}
-
-	// Only allow http(s) schemes
-	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-		return null;
-	}
-
-	// https is always allowed
-	if (parsed.protocol === "https:") {
-		return url;
-	}
-
-	// http: only allowed for localhost
-	const hostname = parsed.hostname;
-	if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") {
-		return url;
-	}
-
-	// Reject http to anything else (private IPs, link-local, public hosts)
-	return null;
 }
 
 /** Extract text content from the last assistant message. */
@@ -138,8 +101,6 @@ export default function (pi: ExtensionAPI) {
 	let staticRegistry: StaticAgentRegistry | null = null;
 	/** Active SQLite task store — closed on session restart/shutdown. */
 	let taskStore: SQLiteTaskStore | null = null;
-	/** This agent's own public A2A URL — included in pi:sender for reply routing. */
-	let selfUrl: string | null = null;
 
 	// ── Main-process message handling ─────────────────────────
 	//
@@ -257,11 +218,12 @@ export default function (pi: ExtensionAPI) {
 				pendingNonce = null;
 
 				if (response) {
-					// Show completion in chat
+					// Show completion in chat — result is saved to the task store,
+					// callers retrieve it via tasks/get polling
 					pi.sendMessage(
 						{
-							customType: "a2a-response-sent",
-							content: `📤 **A2A response sent** (${fmtDuration(durationMs)})`,
+							customType: "a2a-task-completed",
+							content: `✅ **A2A task completed** (${fmtDuration(durationMs)}) — result saved to task store`,
 							display: true,
 						},
 						{ triggerTurn: false },
@@ -439,11 +401,15 @@ export default function (pi: ExtensionAPI) {
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
 		const port = config.port ?? DEFAULT_PORT;
 		const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
-		selfUrl = publicUrl;
 		const agentCard = buildAgentCard(config, publicUrl);
 
-		// Set up executor with main-process callback
-		executor = new PiAgentExecutor(log, processMessage);
+		// Initialize persistent task store (must be created before executor)
+		const dbPath = join(getAgentDir(), "db", "a2a.db");
+		taskStore = new SQLiteTaskStore(dbPath, log);
+
+		// Set up executor — uses taskStore to persist results after background processing.
+		// No onAsyncResult callback — results go into the store, callers poll via tasks/get.
+		executor = new PiAgentExecutor(log, processMessage, taskStore);
 
 		// When the executor finishes an A2A task, refresh TUI status and
 		// send telemetry so the hub sees "idle" immediately — agent_end
@@ -455,110 +421,6 @@ export default function (pi: ExtensionAPI) {
 				sendTelemetry(config).catch(() => {});
 			}
 		};
-
-		// When a long-running task completes, send the result back to the sender
-		// as a new A2A message. The initial HTTP response already returned a
-		// "working" ACK — this delivers the actual content (or error).
-		executor.onAsyncResult = (asyncResult: AsyncTaskResult) => {
-			const { taskId, senderName, senderUrl, result } = asyncResult;
-
-			// Build the message — include error info so the caller knows what happened
-			const messageText = result.ok
-				? result.response
-				: `❌ Task failed: ${result.error ?? "Unknown error"}`;
-
-			// Resolve sender's URL and credential. Priority:
-			// 1. Match senderUrl against known agents (static registry + discovered hub agents)
-			// 2. Match senderName against known agents (static registry + discovered hub agents)
-			// 3. Fall back to validated senderUrl (SSRF-safe: https required, no private IPs)
-			(async () => {
-				let replyUrl: string | null = null;
-				let credential: string | null = null;
-				let agentId: string | null = null;
-				const senderLower = senderName.toLowerCase();
-
-				// If senderUrl is provided, try to match it against known agents first.
-				// This validates the URL is legitimate without trusting it blindly.
-				if (senderUrl) {
-					if (staticRegistry) {
-						const staticMatch = staticRegistry.findByUrl(senderUrl);
-						if (staticMatch) {
-							replyUrl = staticMatch.config.url;
-							credential = staticMatch.config.apiKey ?? null;
-						}
-					}
-					if (!replyUrl) {
-						const normalizedSender = senderUrl.replace(/\/+$/, "");
-						const hubMatch = discoveredAgents.find(
-							(a) => a.url.replace(/\/+$/, "") === normalizedSender,
-						);
-						if (hubMatch) {
-							replyUrl = hubMatch.url;
-							agentId = hubMatch.id;
-						}
-					}
-				}
-
-				// Fall back to name-based lookup in known agents
-				if (!replyUrl) {
-					if (staticRegistry) {
-						const staticMatch = staticRegistry.findByName(senderName);
-						if (staticMatch) {
-							replyUrl = staticMatch.config.url;
-							credential = staticMatch.config.apiKey ?? null;
-						}
-					}
-					if (!replyUrl) {
-						const hubMatch = discoveredAgents.find((a) => a.name.toLowerCase() === senderLower);
-						if (hubMatch) {
-							replyUrl = hubMatch.url;
-							agentId = hubMatch.id;
-						}
-					}
-				}
-
-				// Last resort: use senderUrl directly, but only after SSRF validation.
-				// Require https in production; allow http only for localhost/127.0.0.1.
-				if (!replyUrl && senderUrl) {
-					const validated = validateReplyUrl(senderUrl);
-					if (validated) {
-						replyUrl = validated;
-					} else {
-						log("async_result_url_rejected", { taskId, sender: senderName, senderUrl }, "WARN");
-					}
-				}
-
-				if (!replyUrl) {
-					log("async_result_no_sender", { taskId, sender: senderName }, "WARN");
-					return;
-				}
-
-				// Get credential for hub agents
-				if (!credential && agentId && config.hub?.apiKey) {
-					credential = await getCachedCredential(agentId, config.hub);
-				}
-
-				const sendResult = await sendA2AMessage({
-					url: replyUrl,
-					message: messageText,
-					credential,
-					timeoutMs: config.sendTimeoutMs,
-					sender: { name: config.name ?? "Pi Agent", description: config.description, url: selfUrl ?? undefined } as SenderIdentity,
-				}, log);
-
-				if (sendResult.ok) {
-					log("async_result_sent", { taskId, sender: senderName, ok: result.ok, responseLength: messageText.length });
-				} else {
-					log("async_result_send_failed", { taskId, sender: senderName, error: sendResult.error }, "ERROR");
-				}
-			})().catch((err: unknown) => {
-				const msg = err instanceof Error ? err.message : String(err);
-				log("async_result_send_error", { taskId, sender: senderName, error: msg }, "ERROR");
-			});
-		};
-
-		const dbPath = join(getAgentDir(), "db", "a2a.db");
-		taskStore = new SQLiteTaskStore(dbPath, log);
 		const pushNotificationStore = new InMemoryPushNotificationStore();
 		const pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
 

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -32,16 +32,17 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { join } from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import {
 	DefaultRequestHandler,
-	InMemoryTaskStore,
 	InMemoryPushNotificationStore,
 	DefaultPushNotificationSender,
 	JsonRpcTransportHandler,
 } from "@a2a-js/sdk/server";
+import { SQLiteTaskStore } from "./task-store.ts";
 import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult, type AsyncTaskResult } from "./agent-executor.ts";
@@ -135,6 +136,8 @@ export default function (pi: ExtensionAPI) {
 	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
 	let staticRegistry: StaticAgentRegistry | null = null;
+	/** Active SQLite task store — closed on session restart/shutdown. */
+	let taskStore: SQLiteTaskStore | null = null;
 	/** This agent's own public A2A URL — included in pi:sender for reply routing. */
 	let selfUrl: string | null = null;
 
@@ -424,6 +427,10 @@ export default function (pi: ExtensionAPI) {
 			executor.abortAll();
 			executor = null;
 		}
+		if (taskStore) {
+			taskStore.close();
+			taskStore = null;
+		}
 		if (isRunning()) {
 			await stopServer(log);
 		}
@@ -550,7 +557,8 @@ export default function (pi: ExtensionAPI) {
 			});
 		};
 
-		const taskStore = new InMemoryTaskStore();
+		const dbPath = join(getAgentDir(), "db", "a2a.db");
+		taskStore = new SQLiteTaskStore(dbPath, log);
 		const pushNotificationStore = new InMemoryPushNotificationStore();
 		const pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
 
@@ -673,6 +681,10 @@ export default function (pi: ExtensionAPI) {
 		if (executor) {
 			executor.abortAll();
 			executor = null;
+		}
+		if (taskStore) {
+			taskStore.close();
+			taskStore = null;
 		}
 		if (isRunning()) {
 			await stopServer(log);

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -38,23 +38,36 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import {
 	DefaultRequestHandler,
-	InMemoryPushNotificationStore,
 	DefaultPushNotificationSender,
 	JsonRpcTransportHandler,
 } from "@a2a-js/sdk/server";
-import { SQLiteTaskStore } from "./task-store.ts";
+import { SQLiteTaskStore, SQLitePushNotificationStore } from "./task-store.ts";
 import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
 import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification } from "./hub.ts";
-import { sendA2AMessage, type SenderIdentity } from "./client.ts";
+import { sendA2AMessage, getRemoteTask, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
 import { seedLoopMetadata, DEFAULT_MAX_HOPS } from "./supervisor.ts";
 import type { HubConfig, RemoteAgentSummary, TelemetrySnapshot } from "./types.ts";
 
 const DEFAULT_PORT = 3100;
+
+/** Sliding-window rate limiter for outbound response injection. */
+class RateLimiter {
+	private timestamps: number[] = [];
+	constructor(private maxCalls: number, private windowMs: number) {}
+	tryAcquire(): boolean {
+		const now = Date.now();
+		this.timestamps = this.timestamps.filter(t => now - t < this.windowMs);
+		if (this.timestamps.length >= this.maxCalls) return false;
+		this.timestamps.push(now);
+		return true;
+	}
+	reset(): void { this.timestamps = []; }
+}
 
 function txt(s: string) {
 	return { content: [{ type: "text" as const, text: s }], details: {} };
@@ -98,6 +111,7 @@ export default function (pi: ExtensionAPI) {
 		label: "A2A",
 	});
 	let telemetryInterval: ReturnType<typeof setInterval> | null = null;
+	let expiryInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
 	let staticRegistry: StaticAgentRegistry | null = null;
 	/** Active SQLite task store — closed on session restart/shutdown. */
@@ -106,6 +120,8 @@ export default function (pi: ExtensionAPI) {
 	let agentPublicUrl: string = "http://localhost:3100";
 	/** Configured max hops (set on session_start, used for seeding outbound metadata). */
 	let configuredMaxHops: number = DEFAULT_MAX_HOPS;
+	/** Rate limiter for outbound response injection — 10 triggers per 60s window. */
+	const responseLimiter = new RateLimiter(10, 60_000);
 
 	// ── Main-process message handling ─────────────────────────
 	//
@@ -374,6 +390,7 @@ export default function (pi: ExtensionAPI) {
 		// Clean restart — reset all async state from previous session
 		outboundPending = 0;
 		sessionToken++;
+		responseLimiter.reset();
 		credentialCache.clear();
 		agentBusy = false;
 		const staleResolvers = idleResolvers;
@@ -387,6 +404,10 @@ export default function (pi: ExtensionAPI) {
 		if (telemetryInterval) {
 			clearInterval(telemetryInterval);
 			telemetryInterval = null;
+		}
+		if (expiryInterval) {
+			clearInterval(expiryInterval);
+			expiryInterval = null;
 		}
 		hubAgentId = null;
 		staticRegistry = null;
@@ -433,8 +454,20 @@ export default function (pi: ExtensionAPI) {
 				sendTelemetry(config).catch(() => {});
 			}
 		};
-		const pushNotificationStore = new InMemoryPushNotificationStore();
+		const pushNotificationStore = new SQLitePushNotificationStore(taskStore.getDb(), log);
 		const pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
+
+		// Set up task expiry interval
+		const taskTtlMs = config.taskTtlMs ?? 86_400_000; // 24h default
+		if (taskTtlMs > 0) {
+			expiryInterval = setInterval(() => {
+				if (!taskStore) return;
+				const pruned = taskStore.pruneOlderThan(taskTtlMs);
+				if (pruned > 0) {
+					log("task_expiry_pruned", { pruned, taskTtlMs });
+				}
+			}, 300_000); // every 5 minutes
+		}
 
 		const requestHandler = new DefaultRequestHandler(
 			agentCard,
@@ -530,6 +563,12 @@ export default function (pi: ExtensionAPI) {
 		if (telemetryInterval) {
 			clearInterval(telemetryInterval);
 			telemetryInterval = null;
+		}
+
+		// Stop expiry interval
+		if (expiryInterval) {
+			clearInterval(expiryInterval);
+			expiryInterval = null;
 		}
 
 		// Send final "idle" telemetry report before shutting down
@@ -809,67 +848,114 @@ export default function (pi: ExtensionAPI) {
 			};
 
 			(async () => {
-				return await sendA2AMessage(sendOpts, log);
-			})().then((result) => {
-				// Bail out if session restarted while we were waiting
-				if (sessionToken !== myToken) return;
+				const result = await sendA2AMessage(sendOpts, log);
 
+				// Bail out if session restarted while we were waiting
+				if (sessionToken !== myToken) { outboundPending--; return; }
+
+				// ── Immediate completion (remote responded inline) ──────
+				if (result.ok && !result.working && result.response) {
+					outboundPending--;
+					updateStatusLine();
+					const dur = fmtDuration(Date.now() - sendStart);
+					if (!responseLimiter.tryAcquire()) {
+						log("rate_limit_response", { agent: resolvedName }, "WARN");
+						pi.sendMessage({ customType: "a2a-rate-limited", content: `⚠️ Rate limited — response from **${resolvedName}** suppressed (too many responses in 60s)`, display: true }, { triggerTurn: false });
+						return;
+					}
+					pi.sendMessage({ customType: "a2a-response-received", content: `📨 **A2A response from ${resolvedName}** (${dur}):\n\n${result.response}`, display: true }, { triggerTurn: true });
+					return;
+				}
+
+				// ── Send error ──────────────────────────────────────────
+				if (!result.ok) {
+					outboundPending--;
+					updateStatusLine();
+					const dur = fmtDuration(Date.now() - sendStart);
+					pi.sendMessage({ customType: "a2a-response-error", content: `❌ **A2A error from ${resolvedName}** (${dur}): ${result.error}`, display: true }, { triggerTurn: true });
+					return;
+				}
+
+				// ── Working — poll for completion ───────────────────────
+				const taskId = result.taskId;
+				if (!taskId) {
+					outboundPending--;
+					updateStatusLine();
+					pi.sendMessage({ customType: "a2a-response-error", content: `❌ **A2A error from ${resolvedName}**: No task ID returned for polling`, display: true }, { triggerTurn: true });
+					return;
+				}
+
+				log("a2a_poll_start", { agent: resolvedName, taskId });
+				const POLL_INTERVAL_MS = 5_000;
+				const maxPollMs = config.sendTimeoutMs ?? 600_000; // 10 min default
+				const pollDeadline = Date.now() + maxPollMs;
+				const pollOpts = {
+					url: resolvedUrl,
+					taskId,
+					credential,
+					onRefreshCredential: sendOpts.onRefreshCredential,
+				};
+
+				while (Date.now() < pollDeadline) {
+					if (sessionToken !== myToken) { outboundPending--; return; }
+					await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+					if (sessionToken !== myToken) { outboundPending--; return; }
+
+					try {
+						const poll = await getRemoteTask(pollOpts, log);
+
+						if (poll.state === "completed") {
+							outboundPending--;
+							updateStatusLine();
+							const dur = fmtDuration(Date.now() - sendStart);
+							if (!responseLimiter.tryAcquire()) {
+								log("rate_limit_response", { agent: resolvedName, taskId }, "WARN");
+								pi.sendMessage({ customType: "a2a-rate-limited", content: `⚠️ Rate limited — response from **${resolvedName}** suppressed`, display: true }, { triggerTurn: false });
+								return;
+							}
+							pi.sendMessage({ customType: "a2a-response-received", content: `📨 **A2A response from ${resolvedName}** (${dur}):\n\n${poll.response ?? "(no content)"}`, display: true }, { triggerTurn: true });
+							return;
+						}
+
+						if (poll.state === "failed") {
+							outboundPending--;
+							updateStatusLine();
+							const dur = fmtDuration(Date.now() - sendStart);
+							pi.sendMessage({ customType: "a2a-response-error", content: `❌ **A2A error from ${resolvedName}** (${dur}): ${poll.error ?? "Task failed"}`, display: true }, { triggerTurn: true });
+							return;
+						}
+
+						if (poll.state === "canceled") {
+							outboundPending--;
+							updateStatusLine();
+							const dur = fmtDuration(Date.now() - sendStart);
+							pi.sendMessage({ customType: "a2a-response-error", content: `🚫 **${resolvedName}** cancelled the task (${dur})`, display: true }, { triggerTurn: false });
+							return;
+						}
+
+						// Still working/submitted — continue polling
+					} catch (pollErr) {
+						const msg = pollErr instanceof Error ? pollErr.message : String(pollErr);
+						log("a2a_poll_network_error", { agent: resolvedName, taskId, error: msg }, "WARN");
+						// Continue polling — transient network errors are expected
+					}
+				}
+
+				// Poll timeout
 				outboundPending--;
 				updateStatusLine();
-
 				const dur = fmtDuration(Date.now() - sendStart);
-
-				if (result.ok && result.working) {
-					// ACK received — the remote agent is working on it.
-					// The actual result will arrive later as a separate inbound A2A message.
-					pi.sendMessage(
-						{
-							customType: "a2a-response-ack",
-							content:
-								`⏳ **${resolvedName}** acknowledged the request (${dur}) — working on it. Response will arrive when ready.`,
-							display: true,
-						},
-						{ triggerTurn: false },
-					);
-				} else if (result.ok) {
-					pi.sendMessage(
-						{
-							customType: "a2a-response-received",
-							content:
-								`📨 **A2A response from ${resolvedName}** (${dur}):\n\n${result.response}`,
-							display: true,
-						},
-						{ triggerTurn: true },
-					);
-				} else {
-					pi.sendMessage(
-						{
-							customType: "a2a-response-error",
-							content:
-								`❌ **A2A error from ${resolvedName}** (${dur}): ${result.error}`,
-							display: true,
-						},
-						{ triggerTurn: true },
-					);
-				}
-			}).catch((err: unknown) => {
+				pi.sendMessage({ customType: "a2a-response-error", content: `⏰ **${resolvedName}** did not complete within ${fmtDuration(maxPollMs)} (${dur}). Task ID: ${taskId}`, display: true }, { triggerTurn: false });
+			})().catch((err: unknown) => {
 				// Bail out if session restarted while we were waiting
-				if (sessionToken !== myToken) return;
+				if (sessionToken !== myToken) { outboundPending--; return; }
 
 				outboundPending--;
 				updateStatusLine();
 
 				const msg = err instanceof Error ? err.message : String(err);
 				const dur = fmtDuration(Date.now() - sendStart);
-				pi.sendMessage(
-					{
-						customType: "a2a-response-error",
-						content:
-							`❌ **A2A error from ${resolvedName}** (${dur}): ${msg}`,
-						display: true,
-					},
-					{ triggerTurn: true },
-				);
+				pi.sendMessage({ customType: "a2a-response-error", content: `❌ **A2A error from ${resolvedName}** (${dur}): ${msg}`, display: true }, { triggerTurn: true });
 			});
 
 			return txt(`📤 Message sent to **${agentName}** — waiting for response in the background. You'll see it when it arrives.`);

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -51,6 +51,7 @@ import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromH
 import { sendA2AMessage, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
+import { seedLoopMetadata, DEFAULT_MAX_HOPS } from "./supervisor.ts";
 import type { HubConfig, RemoteAgentSummary, TelemetrySnapshot } from "./types.ts";
 
 const DEFAULT_PORT = 3100;
@@ -101,6 +102,10 @@ export default function (pi: ExtensionAPI) {
 	let staticRegistry: StaticAgentRegistry | null = null;
 	/** Active SQLite task store — closed on session restart/shutdown. */
 	let taskStore: SQLiteTaskStore | null = null;
+	/** Agent's canonical public URL (set on session_start, used for loop metadata). */
+	let agentPublicUrl: string = "http://localhost:3100";
+	/** Configured max hops (set on session_start, used for seeding outbound metadata). */
+	let configuredMaxHops: number = DEFAULT_MAX_HOPS;
 
 	// ── Main-process message handling ─────────────────────────
 	//
@@ -401,6 +406,8 @@ export default function (pi: ExtensionAPI) {
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
 		const port = config.port ?? DEFAULT_PORT;
 		const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
+		agentPublicUrl = publicUrl;
+		configuredMaxHops = config.maxHops ?? DEFAULT_MAX_HOPS;
 		const agentCard = buildAgentCard(config, publicUrl);
 
 		// Initialize persistent task store (must be created before executor)
@@ -409,7 +416,12 @@ export default function (pi: ExtensionAPI) {
 
 		// Set up executor — uses taskStore to persist results after background processing.
 		// No onAsyncResult callback — results go into the store, callers poll via tasks/get.
-		executor = new PiAgentExecutor(log, processMessage, taskStore);
+		// Supervisor config provides agent identity and hop limit for loop control.
+		const maxHops = config.maxHops ?? DEFAULT_MAX_HOPS;
+		executor = new PiAgentExecutor(log, processMessage, taskStore, {
+			agentId: publicUrl,
+			defaultMaxHops: maxHops,
+		});
 
 		// When the executor finishes an A2A task, refresh TUI status and
 		// send telemetry so the hub sees "idle" immediately — agent_end
@@ -772,6 +784,12 @@ export default function (pi: ExtensionAPI) {
 			outboundPending++;
 			updateStatusLine();
 
+			// Resolve loop metadata: propagate from active inbound task, or seed fresh
+			const activeLoop = executor?.getActiveLoopMetadata() ?? null;
+			const outboundLoop = activeLoop
+				? activeLoop  // Propagate inbound chain (already incremented by supervisor)
+				: seedLoopMetadata(agentPublicUrl, configuredMaxHops);
+
 			const resolvedFromStatic = fromStatic;
 			const sendOpts = {
 				url: resolvedUrl,
@@ -779,6 +797,7 @@ export default function (pi: ExtensionAPI) {
 				credential,
 				timeoutMs: config.sendTimeoutMs,
 				sender: { name: config.name ?? "Pi Agent", description: config.description } as SenderIdentity,
+				loopMetadata: outboundLoop,
 				// SDK auth handler retries on 401 — provide a callback to refresh the credential
 				onRefreshCredential: (!resolvedFromStatic && resolvedAgentId && hubConfig)
 					? async () => {
@@ -1044,7 +1063,8 @@ export default function (pi: ExtensionAPI) {
 						`A2A server running on port ${port}\n` +
 						`Agent Card: ${publicUrl}/.well-known/agent-card.json\n` +
 						`Protocol: A2A v0.3.0 | Mode: inline (main process)${busy}\n` +
-						`Skills: ${skillCount} | Streaming: ✓ | Push Notifications: ✓`;
+						`Skills: ${skillCount} | Streaming: ✓ | Push Notifications: ✓\n` +
+						`Loop control: maxHops=${configuredMaxHops} | Agent ID: ${agentPublicUrl}`;
 
 					if (hubAgentId) {
 						const snap = buildTelemetrySnapshot();

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -491,6 +491,10 @@ export default function (pi: ExtensionAPI) {
 			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${port}`, "info");
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
+			// Clean up resources allocated before server start
+			if (expiryInterval) { clearInterval(expiryInterval); expiryInterval = null; }
+			executor = null;
+			taskStore.close(); taskStore = null;
 			ctx.ui.notify(`pi-a2a: Failed to start server — ${msg}`, "warning");
 			return;
 		}

--- a/extensions/pi-a2a/src/supervisor.ts
+++ b/extensions/pi-a2a/src/supervisor.ts
@@ -1,0 +1,188 @@
+/**
+ * pi-a2a — Loop control supervisor.
+ *
+ * Pure-function supervisor that inspects A2A message/task metadata for
+ * loop-control fields (under `pi:` prefix) and enforces safety policies:
+ *
+ *   1. Hop count — incremented at each agent, rejected if > maxHops
+ *   2. Cycle detection — reject if this agent already appears in visitedAgents
+ *   3. Budget limits — configurable maxHops (extensible to maxCalls, maxTokens)
+ *
+ * Metadata keys (spec-compliant transparent extensions — ignored by agents
+ * that don't understand them):
+ *   - `pi:hopCount` (number)  — incremented at each hop
+ *   - `pi:visitedAgents` (string[]) — agent identities (URLs) visited so far
+ *   - `pi:budgets` ({ maxHops?, maxCalls?, maxTokens? }) — configurable limits
+ *
+ * The supervisor is called in two places:
+ *   - Inbound: before AgentExecutor.execute() processes a task
+ *   - Outbound: to seed/propagate metadata on a2a_send messages
+ */
+
+// ── Types ───────────────────────────────────────────────────────
+
+/** Budget constraints carried in message metadata. */
+export interface LoopBudgets {
+	/** Maximum number of hops (agent transitions) allowed. */
+	maxHops?: number;
+	/** Maximum total calls (reserved for future use). */
+	maxCalls?: number;
+	/** Maximum total tokens (reserved for future use). */
+	maxTokens?: number;
+}
+
+/** Loop-control metadata extracted from A2A message/task metadata. */
+export interface LoopMetadata {
+	/** Current hop count (incremented at each agent). */
+	hopCount: number;
+	/** Agent identities (URLs) visited so far. */
+	visitedAgents: string[];
+	/** Budget constraints. */
+	budgets?: LoopBudgets;
+}
+
+/** Supervisor configuration. */
+export interface SupervisorConfig {
+	/** This agent's identity (canonical URL — uniquely identifies the agent). */
+	agentId: string;
+	/** Default max hops when not specified in message budgets. */
+	defaultMaxHops: number;
+}
+
+/** Result of a supervisor check. */
+export interface SupervisorResult {
+	/** Whether the task is approved for processing. */
+	approved: boolean;
+	/** Human-readable reason for rejection (only set when approved=false). */
+	reason?: string;
+	/** Updated metadata to carry forward (always set). */
+	metadata: LoopMetadata;
+}
+
+// ── Default ─────────────────────────────────────────────────────
+
+export const DEFAULT_MAX_HOPS = 10;
+
+// ── Extract / Inject ────────────────────────────────────────────
+
+/**
+ * Extract loop-control metadata from an A2A metadata record.
+ * Returns zero-state if no metadata or no pi: fields present.
+ */
+export function extractLoopMetadata(
+	metadata?: Record<string, unknown> | null,
+): LoopMetadata {
+	if (!metadata) return { hopCount: 0, visitedAgents: [] };
+
+	const hopCount =
+		typeof metadata["pi:hopCount"] === "number"
+			? (metadata["pi:hopCount"] as number)
+			: 0;
+
+	const visitedAgents = Array.isArray(metadata["pi:visitedAgents"])
+		? (metadata["pi:visitedAgents"] as string[]).filter((v) => typeof v === "string")
+		: [];
+
+	const rawBudgets = metadata["pi:budgets"];
+	let budgets: LoopBudgets | undefined;
+	if (rawBudgets && typeof rawBudgets === "object" && !Array.isArray(rawBudgets)) {
+		const b = rawBudgets as Record<string, unknown>;
+		budgets = {};
+		if (typeof b.maxHops === "number") budgets.maxHops = b.maxHops;
+		if (typeof b.maxCalls === "number") budgets.maxCalls = b.maxCalls;
+		if (typeof b.maxTokens === "number") budgets.maxTokens = b.maxTokens;
+		// Drop empty budgets object
+		if (budgets.maxHops === undefined && budgets.maxCalls === undefined && budgets.maxTokens === undefined) {
+			budgets = undefined;
+		}
+	}
+
+	return { hopCount, visitedAgents, budgets };
+}
+
+/**
+ * Inject loop-control metadata into an existing metadata record.
+ * Preserves all existing keys, overwriting only pi: loop-control fields.
+ */
+export function injectLoopMetadata(
+	existing: Record<string, unknown> | undefined,
+	loop: LoopMetadata,
+): Record<string, unknown> {
+	const result: Record<string, unknown> = { ...(existing ?? {}) };
+	result["pi:hopCount"] = loop.hopCount;
+	result["pi:visitedAgents"] = loop.visitedAgents;
+	if (loop.budgets) {
+		result["pi:budgets"] = loop.budgets;
+	}
+	return result;
+}
+
+// ── Supervisor ──────────────────────────────────────────────────
+
+/**
+ * Run supervisor checks on incoming loop metadata.
+ *
+ * Called before AgentExecutor processes a task. Returns approved=true
+ * with updated metadata (incremented hopCount, self added to visitedAgents)
+ * or approved=false with a rejection reason.
+ */
+export function supervise(
+	incoming: LoopMetadata,
+	config: SupervisorConfig,
+): SupervisorResult {
+	const maxHops = incoming.budgets?.maxHops ?? config.defaultMaxHops;
+
+	// ── 1. Cycle detection ──────────────────────────────────────
+	// Check BEFORE incrementing — if we've been visited before, it's a cycle
+	if (incoming.visitedAgents.includes(config.agentId)) {
+		const chain = [...incoming.visitedAgents, config.agentId].join(" → ");
+		return {
+			approved: false,
+			reason: `Cycle detected: agent "${config.agentId}" already visited. Chain: ${chain}`,
+			metadata: {
+				hopCount: incoming.hopCount + 1,
+				visitedAgents: [...incoming.visitedAgents, config.agentId],
+				budgets: incoming.budgets,
+			},
+		};
+	}
+
+	// ── 2. Hop count ────────────────────────────────────────────
+	const newHopCount = incoming.hopCount + 1;
+	if (newHopCount > maxHops) {
+		return {
+			approved: false,
+			reason: `Hop limit exceeded: ${newHopCount} > ${maxHops} (max). Chain: ${incoming.visitedAgents.join(" → ")}`,
+			metadata: {
+				hopCount: newHopCount,
+				visitedAgents: [...incoming.visitedAgents, config.agentId],
+				budgets: incoming.budgets,
+			},
+		};
+	}
+
+	// ── 3. Approved ─────────────────────────────────────────────
+	return {
+		approved: true,
+		metadata: {
+			hopCount: newHopCount,
+			visitedAgents: [...incoming.visitedAgents, config.agentId],
+			budgets: incoming.budgets,
+		},
+	};
+}
+
+/**
+ * Create seed metadata for an outbound message initiated by this agent
+ * (not a response to an inbound task — fresh chain).
+ */
+export function seedLoopMetadata(
+	agentId: string,
+	maxHops?: number,
+): LoopMetadata {
+	return {
+		hopCount: 0,
+		visitedAgents: [agentId],
+		budgets: maxHops !== undefined ? { maxHops } : undefined,
+	};
+}

--- a/extensions/pi-a2a/src/supervisor.ts
+++ b/extensions/pi-a2a/src/supervisor.ts
@@ -62,6 +62,8 @@ export interface SupervisorResult {
 // ── Default ─────────────────────────────────────────────────────
 
 export const DEFAULT_MAX_HOPS = 10;
+/** Cap on visitedAgents array length to bound memory from untrusted input. */
+const MAX_VISITED_AGENTS = 64;
 
 // ── Extract / Inject ────────────────────────────────────────────
 
@@ -80,7 +82,7 @@ export function extractLoopMetadata(
 			: 0;
 
 	const visitedAgents = Array.isArray(metadata["pi:visitedAgents"])
-		? (metadata["pi:visitedAgents"] as string[]).filter((v) => typeof v === "string")
+		? (metadata["pi:visitedAgents"] as string[]).filter((v) => typeof v === "string").slice(0, MAX_VISITED_AGENTS)
 		: [];
 
 	const rawBudgets = metadata["pi:budgets"];

--- a/extensions/pi-a2a/src/task-store.ts
+++ b/extensions/pi-a2a/src/task-store.ts
@@ -65,9 +65,8 @@ export class SQLiteTaskStore implements TaskStore {
 	private log: LogFn;
 
 	// Prepared statements (initialized after migrations)
-	private stmtSave!: Statement;
+	private stmtUpsert!: Statement;
 	private stmtLoad!: Statement;
-	private stmtExists!: Statement;
 
 	constructor(dbPath: string, log: LogFn) {
 		this.log = log;
@@ -103,24 +102,8 @@ export class SQLiteTaskStore implements TaskStore {
 
 		const now = new Date().toISOString();
 
-		// UPSERT: insert or replace on conflict
-		const exists = this.stmtExists.get(task.id) as { cnt: number } | undefined;
-		if (exists && exists.cnt > 0) {
-			this.stmtSave.run(
-				task.contextId,
-				status,
-				data,
-				hopCount,
-				visitedAgents,
-				now,
-				task.id,
-			);
-		} else {
-			this.db.prepare(
-				`INSERT INTO a2a_tasks (id, context_id, status, data, hop_count, visited_agents, created_at, updated_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-			).run(task.id, task.contextId, status, data, hopCount, visitedAgents, now, now);
-		}
+		// Atomic UPSERT — single statement, no race window
+		this.stmtUpsert.run(task.id, task.contextId, status, data, hopCount, visitedAgents, now, now);
 
 		this.log("task_store_save", { taskId: task.id, status });
 	}
@@ -260,18 +243,20 @@ export class SQLiteTaskStore implements TaskStore {
 	// ── Prepared Statements ───────────────────────────────────
 
 	private prepareStatements(): void {
-		this.stmtSave = this.db.prepare(
-			`UPDATE a2a_tasks
-			 SET context_id = ?, status = ?, data = ?, hop_count = ?, visited_agents = ?, updated_at = ?
-			 WHERE id = ?`,
+		this.stmtUpsert = this.db.prepare(
+			`INSERT INTO a2a_tasks (id, context_id, status, data, hop_count, visited_agents, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(id) DO UPDATE SET
+			   context_id = excluded.context_id,
+			   status = excluded.status,
+			   data = excluded.data,
+			   hop_count = excluded.hop_count,
+			   visited_agents = excluded.visited_agents,
+			   updated_at = excluded.updated_at`,
 		);
 
 		this.stmtLoad = this.db.prepare(
 			`SELECT data FROM a2a_tasks WHERE id = ?`,
-		);
-
-		this.stmtExists = this.db.prepare(
-			`SELECT COUNT(*) as cnt FROM a2a_tasks WHERE id = ?`,
 		);
 	}
 }

--- a/extensions/pi-a2a/src/task-store.ts
+++ b/extensions/pi-a2a/src/task-store.ts
@@ -1,0 +1,256 @@
+/**
+ * pi-a2a — SQLite-backed TaskStore.
+ *
+ * Implements the @a2a-js/sdk TaskStore interface using better-sqlite3.
+ * Tasks are serialized as JSON in a single column for SDK compatibility,
+ * with extracted columns for efficient querying and future loop-control
+ * metadata (hopCount, visitedAgents).
+ *
+ * Design:
+ *   - DB at {agentDir}/db/a2a.db, WAL mode for concurrent reads
+ *   - Migration table: a2a_migrations (version-based)
+ *   - Parameterized queries only — no string interpolation
+ *   - Sync operations (better-sqlite3 is sync) wrapped in async interface
+ *   - Extended columns beyond SDK interface for loop control (td-02cbd2)
+ */
+
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import Database from "better-sqlite3";
+import type { Database as DatabaseType, Statement } from "better-sqlite3";
+import type { TaskStore, ServerCallContext } from "@a2a-js/sdk/server";
+import type { Task } from "@a2a-js/sdk";
+import type { LogFn } from "./logger.ts";
+
+// ── Schema version ──────────────────────────────────────────────
+
+const CURRENT_VERSION = 1;
+
+const MIGRATIONS: Record<number, string[]> = {
+	1: [
+		`CREATE TABLE IF NOT EXISTS a2a_tasks (
+			id TEXT PRIMARY KEY NOT NULL,
+			context_id TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'submitted',
+			data TEXT NOT NULL,
+			hop_count INTEGER,
+			visited_agents TEXT,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+			updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_id ON a2a_tasks(context_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_status ON a2a_tasks(status)`,
+		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_updated_at ON a2a_tasks(updated_at)`,
+	],
+};
+
+// ── SQLiteTaskStore ─────────────────────────────────────────────
+
+export class SQLiteTaskStore implements TaskStore {
+	private db: DatabaseType;
+	private log: LogFn;
+
+	// Prepared statements (initialized after migrations)
+	private stmtSave!: Statement;
+	private stmtLoad!: Statement;
+	private stmtExists!: Statement;
+
+	constructor(dbPath: string, log: LogFn) {
+		this.log = log;
+
+		// Ensure parent directory exists
+		mkdirSync(dirname(dbPath), { recursive: true });
+
+		this.db = new Database(dbPath);
+		this.db.pragma("journal_mode = WAL");
+		this.db.pragma("foreign_keys = ON");
+		this.db.pragma("busy_timeout = 5000");
+
+		this.runMigrations();
+		this.prepareStatements();
+
+		log("task_store_init", { dbPath, version: CURRENT_VERSION });
+	}
+
+	// ── TaskStore interface ───────────────────────────────────
+
+	async save(task: Task, _context?: ServerCallContext): Promise<void> {
+		const data = JSON.stringify(task);
+		const status = task.status?.state ?? "submitted";
+
+		// Extract loop-control metadata for indexed querying (td-02cbd2)
+		const metadata = task.metadata as Record<string, unknown> | undefined;
+		const hopCount = typeof metadata?.["pi:hopCount"] === "number"
+			? metadata["pi:hopCount"] as number
+			: null;
+		const visitedAgents = Array.isArray(metadata?.["pi:visitedAgents"])
+			? JSON.stringify(metadata["pi:visitedAgents"])
+			: null;
+
+		const now = new Date().toISOString();
+
+		// UPSERT: insert or replace on conflict
+		const exists = this.stmtExists.get(task.id) as { cnt: number } | undefined;
+		if (exists && exists.cnt > 0) {
+			this.stmtSave.run(
+				task.contextId,
+				status,
+				data,
+				hopCount,
+				visitedAgents,
+				now,
+				task.id,
+			);
+		} else {
+			this.db.prepare(
+				`INSERT INTO a2a_tasks (id, context_id, status, data, hop_count, visited_agents, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(task.id, task.contextId, status, data, hopCount, visitedAgents, now, now);
+		}
+
+		this.log("task_store_save", { taskId: task.id, status });
+	}
+
+	async load(taskId: string, _context?: ServerCallContext): Promise<Task | undefined> {
+		const row = this.stmtLoad.get(taskId) as { data: string } | undefined;
+		if (!row) return undefined;
+
+		try {
+			return JSON.parse(row.data) as Task;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.log("task_store_load_error", { taskId, error: msg }, "ERROR");
+			return undefined;
+		}
+	}
+
+	// ── Extended methods (beyond SDK interface) ───────────────
+
+	/**
+	 * List tasks, optionally filtered by status. Ordered by updated_at desc.
+	 * Not part of the SDK TaskStore interface but useful for admin/debug.
+	 */
+	listTasks(opts?: { status?: string; limit?: number; offset?: number }): Task[] {
+		const limit = opts?.limit ?? 50;
+		const offset = opts?.offset ?? 0;
+
+		let sql: string;
+		let params: unknown[];
+
+		if (opts?.status) {
+			sql = `SELECT data FROM a2a_tasks WHERE status = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`;
+			params = [opts.status, limit, offset];
+		} else {
+			sql = `SELECT data FROM a2a_tasks ORDER BY updated_at DESC LIMIT ? OFFSET ?`;
+			params = [limit, offset];
+		}
+
+		const rows = this.db.prepare(sql).all(...params) as Array<{ data: string }>;
+		const tasks: Task[] = [];
+		for (const row of rows) {
+			try {
+				tasks.push(JSON.parse(row.data) as Task);
+			} catch {
+				// Skip corrupt rows
+			}
+		}
+		return tasks;
+	}
+
+	/**
+	 * Count tasks, optionally filtered by status.
+	 */
+	countTasks(status?: string): number {
+		if (status) {
+			const row = this.db.prepare(
+				`SELECT COUNT(*) as cnt FROM a2a_tasks WHERE status = ?`,
+			).get(status) as { cnt: number };
+			return row.cnt;
+		}
+		const row = this.db.prepare(
+			`SELECT COUNT(*) as cnt FROM a2a_tasks`,
+		).get() as { cnt: number };
+		return row.cnt;
+	}
+
+	/**
+	 * Delete tasks older than the given age in milliseconds.
+	 * Returns the number of deleted rows.
+	 */
+	pruneOlderThan(maxAgeMs: number): number {
+		const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+		const result = this.db.prepare(
+			`DELETE FROM a2a_tasks WHERE updated_at < ?`,
+		).run(cutoff);
+		if (result.changes > 0) {
+			this.log("task_store_prune", { deleted: result.changes, cutoff });
+		}
+		return result.changes;
+	}
+
+	/**
+	 * Close the database connection. Call on shutdown.
+	 */
+	close(): void {
+		try {
+			this.db.close();
+			this.log("task_store_closed");
+		} catch {
+			// Ignore close errors
+		}
+	}
+
+	// ── Migrations ────────────────────────────────────────────
+
+	private runMigrations(): void {
+		// Create migration tracking table
+		this.db.exec(`
+			CREATE TABLE IF NOT EXISTS a2a_migrations (
+				version INTEGER PRIMARY KEY NOT NULL,
+				applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+			)
+		`);
+
+		const currentVersion = (
+			this.db.prepare(`SELECT MAX(version) as v FROM a2a_migrations`).get() as { v: number | null }
+		).v ?? 0;
+
+		if (currentVersion >= CURRENT_VERSION) return;
+
+		const migrate = this.db.transaction(() => {
+			for (let v = currentVersion + 1; v <= CURRENT_VERSION; v++) {
+				const stmts = MIGRATIONS[v];
+				if (!stmts) {
+					throw new Error(`Missing migration for version ${v}`);
+				}
+				for (const sql of stmts) {
+					this.db.exec(sql);
+				}
+				this.db.prepare(
+					`INSERT INTO a2a_migrations (version) VALUES (?)`,
+				).run(v);
+				this.log("task_store_migration", { version: v });
+			}
+		});
+
+		migrate();
+	}
+
+	// ── Prepared Statements ───────────────────────────────────
+
+	private prepareStatements(): void {
+		this.stmtSave = this.db.prepare(
+			`UPDATE a2a_tasks
+			 SET context_id = ?, status = ?, data = ?, hop_count = ?, visited_agents = ?, updated_at = ?
+			 WHERE id = ?`,
+		);
+
+		this.stmtLoad = this.db.prepare(
+			`SELECT data FROM a2a_tasks WHERE id = ?`,
+		);
+
+		this.stmtExists = this.db.prepare(
+			`SELECT COUNT(*) as cnt FROM a2a_tasks WHERE id = ?`,
+		);
+	}
+}

--- a/extensions/pi-a2a/src/task-store.ts
+++ b/extensions/pi-a2a/src/task-store.ts
@@ -18,13 +18,14 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import Database from "better-sqlite3";
 import type { Database as DatabaseType, Statement } from "better-sqlite3";
-import type { TaskStore, ServerCallContext } from "@a2a-js/sdk/server";
-import type { Task } from "@a2a-js/sdk";
+import type { TaskStore, ServerCallContext, PushNotificationStore } from "@a2a-js/sdk/server";
+import type { Task, PushNotificationConfig } from "@a2a-js/sdk";
 import type { LogFn } from "./logger.ts";
+import { randomUUID } from "node:crypto";
 
 // ── Schema version ──────────────────────────────────────────────
 
-const CURRENT_VERSION = 1;
+const CURRENT_VERSION = 2;
 
 const MIGRATIONS: Record<number, string[]> = {
 	1: [
@@ -41,6 +42,19 @@ const MIGRATIONS: Record<number, string[]> = {
 		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_id ON a2a_tasks(context_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_status ON a2a_tasks(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_updated_at ON a2a_tasks(updated_at)`,
+	],
+	2: [
+		`CREATE TABLE IF NOT EXISTS a2a_push_configs (
+			task_id TEXT NOT NULL,
+			config_id TEXT NOT NULL,
+			url TEXT NOT NULL,
+			token TEXT,
+			auth_schemes TEXT,
+			auth_credentials TEXT,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+			PRIMARY KEY (task_id, config_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_a2a_push_configs_task_id ON a2a_push_configs(task_id)`,
 	],
 };
 
@@ -189,6 +203,13 @@ export class SQLiteTaskStore implements TaskStore {
 	}
 
 	/**
+	 * Get the underlying Database instance for sharing with other stores.
+	 */
+	getDb(): DatabaseType {
+		return this.db;
+	}
+
+	/**
 	 * Close the database connection. Call on shutdown.
 	 */
 	close(): void {
@@ -251,6 +272,138 @@ export class SQLiteTaskStore implements TaskStore {
 
 		this.stmtExists = this.db.prepare(
 			`SELECT COUNT(*) as cnt FROM a2a_tasks WHERE id = ?`,
+		);
+	}
+}
+
+// ── SQLitePushNotificationStore ─────────────────────────────
+
+export class SQLitePushNotificationStore implements PushNotificationStore {
+	private db: DatabaseType;
+	private log: LogFn;
+
+	// Prepared statements
+	private stmtSave!: Statement;
+	private stmtLoad!: Statement;
+	private stmtDelete!: Statement;
+	private stmtDeleteAll!: Statement;
+
+	constructor(db: DatabaseType, log: LogFn) {
+		this.db = db;
+		this.log = log;
+		this.prepareStatements();
+	}
+
+	async save(taskId: string, pushNotificationConfig: PushNotificationConfig): Promise<void> {
+		const configId = pushNotificationConfig.id ?? randomUUID();
+		const authSchemes = pushNotificationConfig.authentication?.schemes
+			? JSON.stringify(pushNotificationConfig.authentication.schemes)
+			: null;
+		const authCredentials = pushNotificationConfig.authentication?.credentials ?? null;
+
+		this.stmtSave.run(
+			taskId,
+			configId,
+			pushNotificationConfig.url,
+			pushNotificationConfig.token ?? null,
+			authSchemes,
+			authCredentials,
+		);
+
+		this.log("push_config_save", { taskId, configId });
+	}
+
+	async load(taskId: string): Promise<PushNotificationConfig[]> {
+		const rows = this.stmtLoad.all(taskId) as Array<{
+			config_id: string;
+			url: string;
+			token: string | null;
+			auth_schemes: string | null;
+			auth_credentials: string | null;
+		}>;
+
+		const configs: PushNotificationConfig[] = [];
+		for (const row of rows) {
+			const config: PushNotificationConfig = {
+				id: row.config_id,
+				url: row.url,
+			};
+			if (row.token) config.token = row.token;
+			if (row.auth_schemes) {
+				try {
+					const schemes = JSON.parse(row.auth_schemes) as string[];
+					config.authentication = { schemes };
+					if (row.auth_credentials) {
+						config.authentication.credentials = row.auth_credentials;
+					}
+				} catch {
+					// Skip invalid auth data
+				}
+			}
+			configs.push(config);
+		}
+
+		return configs;
+	}
+
+	async delete(taskId: string, configId?: string): Promise<void> {
+		if (configId) {
+			this.stmtDelete.run(taskId, configId);
+			this.log("push_config_delete", { taskId, configId });
+		} else {
+			this.stmtDeleteAll.run(taskId);
+			this.log("push_config_delete_all", { taskId });
+		}
+	}
+
+	/**
+	 * Clean up push notification configs for expired tasks.
+	 * Called after task pruning to maintain referential consistency.
+	 */
+	pruneForTasks(taskIds: string[]): number {
+		if (taskIds.length === 0) return 0;
+
+		const placeholders = taskIds.map(() => "?").join(",");
+		const result = this.db.prepare(
+			`DELETE FROM a2a_push_configs WHERE task_id NOT IN (${placeholders})`,
+		).run(...taskIds);
+
+		if (result.changes > 0) {
+			this.log("push_config_prune", { deleted: result.changes });
+		}
+		return result.changes;
+	}
+
+	/**
+	 * No-op close — we share the DB instance with SQLiteTaskStore.
+	 */
+	close(): void {
+		// No-op
+	}
+
+	private prepareStatements(): void {
+		this.stmtSave = this.db.prepare(
+			`INSERT INTO a2a_push_configs (task_id, config_id, url, token, auth_schemes, auth_credentials)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(task_id, config_id) DO UPDATE SET
+			   url = excluded.url,
+			   token = excluded.token,
+			   auth_schemes = excluded.auth_schemes,
+			   auth_credentials = excluded.auth_credentials`,
+		);
+
+		this.stmtLoad = this.db.prepare(
+			`SELECT config_id, url, token, auth_schemes, auth_credentials
+			 FROM a2a_push_configs
+			 WHERE task_id = ?`,
+		);
+
+		this.stmtDelete = this.db.prepare(
+			`DELETE FROM a2a_push_configs WHERE task_id = ? AND config_id = ?`,
+		);
+
+		this.stmtDeleteAll = this.db.prepare(
+			`DELETE FROM a2a_push_configs WHERE task_id = ?`,
 		);
 	}
 }

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -37,6 +37,9 @@ export interface A2AConfig {
 	maxHops?: number;
 	/** Manually configured remote agents (no hub required). */
 	staticAgents?: StaticAgentConfig[];
+	/** Task time-to-live in milliseconds. Tasks older than this are pruned periodically.
+	 *  Defaults to 86400000 (24 hours). Set to 0 to disable expiry. */
+	taskTtlMs?: number;
 }
 
 /** Configuration for a manually defined remote agent. */

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -32,6 +32,9 @@ export interface A2AConfig {
 	hub?: HubConfig;
 	/** Timeout in milliseconds for outbound a2a_send requests. No timeout by default. */
 	sendTimeoutMs?: number;
+	/** Default maximum hop count for loop control. Defaults to 10.
+	 *  Messages exceeding this many agent-to-agent hops are rejected. */
+	maxHops?: number;
 	/** Manually configured remote agents (no hub required). */
 	staticAgents?: StaticAgentConfig[];
 }


### PR DESCRIPTION
## Summary

Two commits implementing the first two tasks of the async-first architecture epic (td-a07540):

### 1. SQLite TaskStore (td-77bda8)
- New `src/task-store.ts`: `SQLiteTaskStore` implementing SDK's `TaskStore` interface
- DB at `{agentDir}/db/a2a.db`, WAL mode, migration tracking
- Schema: `a2a_tasks` with extracted columns for status, hop_count, visited_agents
- Utility methods: listTasks(), countTasks(), pruneOlderThan(), close()
- Wired into index.ts replacing InMemoryTaskStore

### 2. Eliminate onAsyncResult→sendA2AMessage loop (td-0bc998)
- **Core fix**: When background processing completes, save results directly to TaskStore instead of sending a NEW A2A message back to the sender
- Removes the bidirectional loop pattern (A→B→A→B...) at the protocol level
- Callers retrieve results via `tasks/get` polling or SSE `resubscribe`
- Removed: `AsyncTaskResult`, `onAsyncResult` callback, `validateReplyUrl()`, ~100 lines of reply routing logic
- Added: `saveTaskResult()` method, TaskStore as executor constructor dependency

### Architecture change
```
Before: ACK → background process → onAsyncResult → sendA2AMessage → LOOP!
After:  ACK → background process → TaskStore.save() → caller polls tasks/get
```

Resolves: td-77bda8, td-0bc998
Part of: td-a07540