### PR TITLE
feat(pi-web-dashboard): enhance prompt bar — textarea, shift+enter, auto-grow, stop button

### DIFF
--- a/extensions/pi-web-dashboard/dashboard.html
+++ b/extensions/pi-web-dashboard/dashboard.html
@@ -195,14 +195,37 @@
   .tool-error-text { color: var(--red); }
 
   /* ── Prompt bar ─────────────────────────────────────── */
-  .prompt-bar { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--border); }
-  .prompt-bar input { flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; color: var(--fg); font-size: 13px; font-family: inherit; outline: none; transition: border-color 0.15s; }
-  .prompt-bar input:focus { border-color: var(--accent); }
-  .prompt-bar input::placeholder { color: var(--fg3); }
-  .prompt-bar input:disabled { opacity: 0.5; }
+  .prompt-bar { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--border); align-items: flex-end; }
+  .prompt-bar textarea {
+    flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+    padding: 8px 12px; color: var(--fg); font-size: 13px; font-family: inherit;
+    outline: none; resize: none; line-height: 1.5; overflow-y: hidden;
+    min-height: calc(1.5em + 16px); max-height: calc(6 * 1.5em + 16px);
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .prompt-bar textarea:focus { border-color: var(--accent); }
+  .prompt-bar textarea::placeholder { color: var(--fg3); }
+  .prompt-bar textarea:disabled { opacity: 0.5; }
+  .prompt-bar textarea.agent-running {
+    border-color: var(--accent);
+    animation: promptPulse 1.5s ease-in-out infinite;
+  }
+  @keyframes promptPulse {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(124,111,240,0.3); }
+    50%       { box-shadow: 0 0 0 2px rgba(124,111,240,0); }
+  }
   .prompt-bar button { background: var(--accent); color: #fff; border: none; border-radius: 6px; padding: 8px 16px; font-size: 13px; font-weight: 600; cursor: pointer; transition: opacity 0.15s; white-space: nowrap; }
   .prompt-bar button:hover { opacity: 0.85; }
   .prompt-bar button:disabled { opacity: 0.4; cursor: not-allowed; }
+  .prompt-stop { background: var(--red) !important; display: none; }
+  .prompt-stop.visible { display: inline-block; }
+  .prompt-spinner {
+    width: 16px; height: 16px; flex-shrink: 0; align-self: center;
+    border: 2px solid var(--border); border-top-color: var(--accent);
+    border-radius: 50%; animation: promptSpin 0.7s linear infinite; display: none;
+  }
+  .prompt-spinner.visible { display: block; }
+  @keyframes promptSpin { to { transform: rotate(360deg); } }
 
   /* ── Events ─────────────────────────────────────────── */
   .events-wrap { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius); }
@@ -282,7 +305,9 @@
       <div class="chat-body" id="chat-body"></div>
       <div class="live-body" id="live-body" style="display:none"></div>
       <div class="prompt-bar">
-        <input type="text" id="prompt-input" placeholder="Send a prompt to the agent…" autocomplete="off" />
+        <textarea id="prompt-input" placeholder="Send a prompt to the agent…" autocomplete="off" rows="1"></textarea>
+        <span class="prompt-spinner" id="prompt-spinner"></span>
+        <button class="prompt-stop" id="prompt-stop">⬛ Stop</button>
         <button id="prompt-send">Send</button>
       </div>
     </div>
@@ -754,6 +779,8 @@ function renderChatMessages(messages) {
 function handleSSE(d) {
   switch (d.type) {
     case 'agent_start':
+      agentRunning = true;
+      updatePromptState();
       setLiveActive(true);
       liveBuffer = '';
       appendLiveDivider();
@@ -762,6 +789,8 @@ function handleSSE(d) {
       break;
 
     case 'agent_end':
+      agentRunning = false;
+      updatePromptState();
       flushLiveBuffer();
       setLiveActive(false);
       renderLive();
@@ -852,24 +881,43 @@ $('events-filters').addEventListener('click', (e) => {
 
 $('events-clear').addEventListener('click', () => { eventsEl.innerHTML = ''; });
 
-// ── Prompt ───────────────────────────────────────────────────────
+// ── Prompt ────────────────────────────────────────────────────────────────
 
 const promptInput = $('prompt-input');
 const promptSend = $('prompt-send');
+const promptStop = $('prompt-stop');
+const promptSpinner = $('prompt-spinner');
 let promptBusy = false;
+let agentRunning = false;
 
-function setPromptBusy(busy) {
-  promptBusy = busy;
-  promptInput.disabled = busy;
-  promptSend.disabled = busy;
-  promptSend.textContent = busy ? 'Sending…' : 'Send';
+// Auto-grow textarea: expands with content up to max 6 lines
+function autoGrowTextarea() {
+  promptInput.style.height = 'auto';
+  const lineH = parseFloat(getComputedStyle(promptInput).lineHeight) || 21;
+  const padV = 16; // 8px top + 8px bottom
+  const maxH = 6 * lineH + padV;
+  const newH = Math.min(promptInput.scrollHeight, maxH);
+  promptInput.style.height = newH + 'px';
+  promptInput.style.overflowY = promptInput.scrollHeight > maxH ? 'auto' : 'hidden';
+}
+
+function updatePromptState() {
+  const blocked = promptBusy || agentRunning;
+  promptInput.disabled = blocked;
+  promptInput.classList.toggle('agent-running', agentRunning && !promptBusy);
+  promptSpinner.classList.toggle('visible', promptBusy);
+  promptStop.classList.toggle('visible', agentRunning && !promptBusy);
+  promptSend.style.display = agentRunning ? 'none' : '';
+  promptSend.disabled = promptBusy;
+  promptSend.textContent = promptBusy ? 'Sending…' : 'Send';
 }
 
 async function sendPrompt() {
   const text = promptInput.value.trim();
-  if (!text || promptBusy) return;
+  if (!text || promptBusy || agentRunning) return;
 
-  setPromptBusy(true);
+  promptBusy = true;
+  updatePromptState();
   try {
     const res = await fetch('/api/dashboard/prompt', {
       method: 'POST',
@@ -878,6 +926,7 @@ async function sendPrompt() {
     });
     if (res.ok) {
       promptInput.value = '';
+      autoGrowTextarea();
     } else {
       const err = await res.json().catch(() => ({}));
       addEvent('error', 'Prompt error: ' + (err.error || res.statusText));
@@ -885,12 +934,23 @@ async function sendPrompt() {
   } catch (e) {
     addEvent('error', 'Failed to send: ' + e.message);
   }
-  setPromptBusy(false);
+  promptBusy = false;
+  updatePromptState();
 }
 
 promptSend.addEventListener('click', sendPrompt);
+promptInput.addEventListener('input', autoGrowTextarea);
 promptInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendPrompt(); }
+  // Shift+Enter: default textarea behaviour inserts a newline
+});
+
+promptStop.addEventListener('click', async () => {
+  try {
+    await fetch('/api/dashboard/stop', { method: 'POST' });
+  } catch (e) {
+    addEvent('error', 'Stop failed: ' + e.message);
+  }
 });
 
 // ── Chat view wiring ─────────────────────────────────────────────

--- a/extensions/pi-web-dashboard/dashboard.html
+++ b/extensions/pi-web-dashboard/dashboard.html
@@ -923,6 +923,7 @@ async function sendPrompt() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt: text }),
+      signal: AbortSignal.timeout(15_000),
     });
     if (res.ok) {
       promptInput.value = '';

--- a/extensions/pi-web-dashboard/dashboard.html
+++ b/extensions/pi-web-dashboard/dashboard.html
@@ -933,9 +933,10 @@ async function sendPrompt() {
     }
   } catch (e) {
     addEvent('error', 'Failed to send: ' + esc(e.message));
+  } finally {
+    promptBusy = false;
+    updatePromptState();
   }
-  promptBusy = false;
-  updatePromptState();
 }
 
 promptSend.addEventListener('click', sendPrompt);

--- a/extensions/pi-web-dashboard/dashboard.html
+++ b/extensions/pi-web-dashboard/dashboard.html
@@ -929,10 +929,10 @@ async function sendPrompt() {
       autoGrowTextarea();
     } else {
       const err = await res.json().catch(() => ({}));
-      addEvent('error', 'Prompt error: ' + (err.error || res.statusText));
+      addEvent('error', 'Prompt error: ' + esc(err.error || res.statusText));
     }
   } catch (e) {
-    addEvent('error', 'Failed to send: ' + e.message);
+    addEvent('error', 'Failed to send: ' + esc(e.message));
   }
   promptBusy = false;
   updatePromptState();
@@ -949,7 +949,7 @@ promptStop.addEventListener('click', async () => {
   try {
     await fetch('/api/dashboard/stop', { method: 'POST' });
   } catch (e) {
-    addEvent('error', 'Stop failed: ' + e.message);
+    addEvent('error', 'Stop failed: ' + esc(e.message));
   }
 });
 

--- a/extensions/pi-web-dashboard/src/index.ts
+++ b/extensions/pi-web-dashboard/src/index.ts
@@ -5,6 +5,7 @@
  *   Page: /dashboard         — Dashboard UI with live agent stream
  *   API:  /api/dashboard/events  — SSE stream of agent events
  *   API:  /api/dashboard/prompt  — POST a prompt to the agent
+ *   API:  /api/dashboard/stop    — POST to abort the running agent
  *   API:  /api/dashboard/config  — Agent config/status
  *
  * Subscribes to agent lifecycle events and streams them to SSE clients.
@@ -21,7 +22,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { mountDashboard, unmountDashboard, broadcast } from "./web.ts";
+import { mountDashboard, unmountDashboard, broadcast, setAbortFn } from "./web.ts";
 import { createLogger } from "./logger.ts";
 
 /** Max characters per text content block in SSE payloads. */
@@ -62,11 +63,13 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Stream agent events to SSE clients ────────────────────
 
-	pi.on("agent_start", async () => {
+	pi.on("agent_start", async (_event, ctx) => {
+		setAbortFn(() => ctx.abort());
 		broadcast({ type: "agent_start", time: new Date().toISOString() });
 	});
 
 	pi.on("agent_end", async () => {
+		setAbortFn(null);
 		broadcast({ type: "agent_end", time: new Date().toISOString() });
 	});
 

--- a/extensions/pi-web-dashboard/src/index.ts
+++ b/extensions/pi-web-dashboard/src/index.ts
@@ -51,13 +51,21 @@ function truncateInput(input: unknown, maxChars: number): string | undefined {
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
 
-	// Mount web routes when webserver is ready
-	const mount = () => { mountDashboard(pi); log("mount", {}); };
+	// Mount web routes when webserver is ready.
+	// Guard against double-mounting if both web:ready and session_start fire.
+	let mounted = false;
+	const mount = () => {
+		if (mounted) return;
+		mounted = true;
+		mountDashboard(pi);
+		log("mount", {});
+	};
 
 	pi.events.on("web:ready", mount);
 	pi.on("session_start", async () => mount());
 
 	pi.on("session_shutdown", async () => {
+		mounted = false;
 		unmountDashboard(pi);
 	});
 

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -60,10 +60,11 @@ function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
 	return new Promise((resolve, reject) => {
 		let body = "";
 		req.on("data", (chunk: Buffer) => {
-			body += chunk.toString();
-			if (body.length > maxBytes) {
+			if (body.length + chunk.length > maxBytes) {
 				reject(new Error("Body too large"));
 				req.destroy();
+			} else {
+				body += chunk.toString();
 			}
 		});
 		req.on("end", () => { resolve(body); });

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -59,16 +59,15 @@ function json(res: ServerResponse, status: number, data: unknown): void {
 function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
 	return new Promise((resolve, reject) => {
 		let body = "";
-		let oversized = false;
 		req.on("data", (chunk: Buffer) => {
 			body += chunk.toString();
-			if (body.length > maxBytes) { oversized = true; req.destroy(); }
+			if (body.length > maxBytes) {
+				reject(new Error("Body too large"));
+				req.destroy();
+			}
 		});
-		req.on("end", () => {
-			if (oversized) reject(new Error("Body too large"));
-			else resolve(body);
-		});
-		req.on("error", reject);
+		req.on("end", () => { resolve(body); });
+		req.on("error", (err) => { reject(err); });
 	});
 }
 

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -4,6 +4,7 @@
  * Page:  /dashboard              — Dashboard HTML
  * API:   /api/dashboard/events   — SSE stream
  * API:   /api/dashboard/prompt   — POST prompt
+ * API:   /api/dashboard/stop     — POST abort the running agent
  * API:   /api/dashboard/config   — GET status
  */
 
@@ -74,6 +75,13 @@ function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
 // ── Saved reference to pi for prompt submission ─────────────────
 
 let _pi: ExtensionAPI | null = null;
+
+/** Abort callback set while the agent is running; cleared on agent_end. */
+let _abortFn: (() => void) | null = null;
+
+export function setAbortFn(fn: (() => void) | null): void {
+	_abortFn = fn;
+}
 
 // ── Page handler ────────────────────────────────────────────────
 
@@ -156,6 +164,22 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: str
 			} else {
 				json(res, 400, { error: "Invalid JSON" });
 			}
+		}
+		return;
+	}
+
+	// POST /api/dashboard/stop
+	if (method === "POST" && p === "/stop") {
+		if (!_abortFn) {
+			json(res, 409, { error: "Agent is not running" });
+			return;
+		}
+		try {
+			_abortFn();
+			json(res, 202, { status: "stopping" });
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			json(res, 500, { error: `Abort failed: ${msg}` });
 		}
 		return;
 	}

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -59,6 +59,7 @@ function json(res: ServerResponse, status: number, data: unknown): void {
 function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
 	return new Promise((resolve, reject) => {
 		let body = "";
+		req.setTimeout(10_000, () => { reject(new Error("Request timeout")); req.destroy(); });
 		req.on("data", (chunk: Buffer) => {
 			if (body.length + chunk.length > maxBytes) {
 				reject(new Error("Body too large"));

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -162,6 +162,8 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: str
 		} catch (err: any) {
 			if (err.message === "Body too large") {
 				json(res, 413, { error: "Request body too large (max 1MB)" });
+			} else if (err.message === "Request timeout") {
+				json(res, 408, { error: "Request timed out" });
 			} else {
 				json(res, 400, { error: "Invalid JSON" });
 			}


### PR DESCRIPTION
## td-0253a0: Enhance prompt bar with shift+enter multi-line and streaming state

Part of epic td-2b6031 (Replace dashboard Live Session chat UI).

### Changes

**Frontend (dashboard.html)**
- Replace `<input type="text">` with `<textarea>` for multi-line support
- Auto-grow height as user types (min 1 line, max 6 lines) via `autoGrowTextarea()`
- **Shift+Enter** inserts a newline; **Enter** sends the prompt
- While prompt is being sent (`promptBusy`): textarea + send button disabled, spinner appears
- While agent is running (`agentRunning`): textarea disabled with pulsing accent-color border, **Stop** button shown in place of **Send**
- Focus ring uses `--accent` color (existing behaviour, preserved)
- `align-items: flex-end` on prompt-bar so buttons stay bottom-aligned with a growing textarea

**Backend (src/index.ts + src/web.ts)**
- New `POST /api/dashboard/stop` endpoint — calls `ctx.abort()` to interrupt the running agent
- `setAbortFn()`/`_abortFn` pattern: abort callback registered from `agent_start` event ctx, cleared on `agent_end`
- Returns 409 if agent is not running, 202 on success

### Testing
- `npm run typecheck` passes with no errors