### PR TITLE
feat(pi-a2a): add hub_tasks tool — full CRUD for A2A Hub pipeline tasks

### DIFF
--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -11,6 +11,45 @@
  */
 
 import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot } from "./types.ts";
+
+export type PipelineState = "queued" | "planning" | "building" | "reviewing" | "pr_ready" | "blocked" | "approved" | "cancelled";
+export type TaskPriority = "low" | "normal" | "high" | "critical";
+
+export interface HubTask {
+	id: string;
+	title: string;
+	description: string | null;
+	project: string;
+	repo: string | null;
+	state: PipelineState;
+	priority: TaskPriority;
+	assignedAgentId: string | null;
+	createdBy: string;
+	externalTaskId: string | null;
+	branch: string | null;
+	prUrl: string | null;
+	prNumber: number | null;
+	blockedReason: string | null;
+	reviewRound: number;
+	maxReviewRounds: number;
+	metadata: Record<string, unknown>;
+	createdAt: string;
+	updatedAt: string;
+	startedAt: string | null;
+	completedAt: string | null;
+}
+
+export interface HubTaskTransition {
+	id: string;
+	taskId: string;
+	fromState: PipelineState | null;
+	toState: PipelineState;
+	actorAgentId: string | null;
+	actorUserId: string | null;
+	note: string | null;
+	metadata: Record<string, unknown>;
+	createdAt: string;
+}
 import type { LogFn } from "./logger.ts";
 
 interface HubRpcResponse {
@@ -481,4 +520,163 @@ export async function reportTelemetryToHub(
 		return { telemetryUpdatedAt: result.telemetryUpdatedAt as string };
 	}
 	return null;
+}
+
+// ── Pipeline Tasks ───────────────────────────────────────────
+
+function asTask(r: Record<string, unknown>): HubTask {
+	return r as unknown as HubTask;
+}
+
+function asTaskList(r: Record<string, unknown>): { tasks: HubTask[]; total: number; page: number; limit: number } {
+	return {
+		tasks: (r.tasks as unknown[]).map((t) => t as HubTask),
+		total: r.total as number,
+		page: r.page as number,
+		limit: r.limit as number,
+	};
+}
+
+export async function createHubTask(
+	params: {
+		title: string;
+		project: string;
+		description?: string;
+		repo?: string;
+		priority?: TaskPriority;
+		assignedAgentId?: string;
+		metadata?: Record<string, unknown>;
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<HubTask | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.create", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_create");
+	return result ? asTask(result) : null;
+}
+
+export async function getHubTask(
+	taskId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<HubTask | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.get", { taskId }, hubConfig.apiKey, log, "tasks_get");
+	return result ? asTask(result) : null;
+}
+
+export async function listHubTasks(
+	params: {
+		project?: string;
+		state?: PipelineState;
+		assignedAgentId?: string;
+		priority?: TaskPriority;
+		page?: number;
+		limit?: number;
+		includeTerminal?: boolean;
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ tasks: HubTask[]; total: number; page: number; limit: number } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.list", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_list");
+	return result ? asTaskList(result) : null;
+}
+
+export async function updateHubTask(
+	params: {
+		taskId: string;
+		title?: string;
+		description?: string;
+		priority?: TaskPriority;
+		assignedAgentId?: string | null;
+		metadata?: Record<string, unknown>;
+		externalTaskId?: string;
+		branch?: string;
+		prUrl?: string;
+		prNumber?: number;
+		blockedReason?: string;
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<HubTask | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.update", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_update");
+	return result ? asTask(result) : null;
+}
+
+export async function transitionHubTask(
+	params: {
+		taskId: string;
+		toState: PipelineState;
+		note?: string;
+		metadata?: Record<string, unknown>;
+		actorAgentId?: string;
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<HubTask | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.transition", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_transition");
+	return result ? asTask(result) : null;
+}
+
+export async function deleteHubTask(
+	taskId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ deleted: boolean; taskId: string } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.delete", { taskId }, hubConfig.apiKey, log, "tasks_delete");
+	return result ? { deleted: result.deleted as boolean, taskId: result.taskId as string } : null;
+}
+
+export async function getHubTaskHistory(
+	taskId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+	limit = 50,
+): Promise<{ taskId: string; transitions: HubTaskTransition[] } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.history", { taskId, limit }, hubConfig.apiKey, log, "tasks_history");
+	if (!result) return null;
+	return {
+		taskId: result.taskId as string,
+		transitions: (result.transitions as unknown[]).map((t) => t as HubTaskTransition),
+	};
+}
+
+export async function getHubTaskBoard(
+	params: { project?: string; assignedAgentId?: string },
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ board: Record<PipelineState, HubTask[]>; total: number; projects: string[] } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.board", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_board");
+	if (!result) return null;
+	return {
+		board: result.board as Record<PipelineState, HubTask[]>,
+		total: result.total as number,
+		projects: result.projects as string[],
+	};
+}
+
+export async function reportHubTaskStatus(
+	params: {
+		hubTaskId: string;
+		toState: PipelineState;
+		note?: string;
+		externalTaskId?: string;
+		branch?: string;
+		prUrl?: string;
+		prNumber?: number;
+		blockedReason?: string;
+		metadata?: Record<string, unknown>;
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<HubTask | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "tasks.reportStatus", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_report_status");
+	return result ? asTask(result) : null;
 }

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -531,9 +531,9 @@ function asTask(r: Record<string, unknown>): HubTask {
 function asTaskList(r: Record<string, unknown>): { tasks: HubTask[]; total: number; page: number; limit: number } {
 	return {
 		tasks: ((r.tasks as unknown[]) ?? []).map((t) => t as HubTask),
-		total: r.total as number,
-		page: r.page as number,
-		limit: r.limit as number,
+		total: (r.total as number) ?? 0,
+		page: (r.page as number) ?? 1,
+		limit: (r.limit as number) ?? 0,
 	};
 }
 
@@ -655,7 +655,7 @@ export async function getHubTaskBoard(
 	const result = await hubRpc(rpcUrl, "tasks.board", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_board");
 	if (!result) return null;
 	return {
-		board: result.board as Record<PipelineState, HubTask[]>,
+		board: (result.board as Record<PipelineState, HubTask[]>) ?? {},
 		total: result.total as number,
 		projects: (result.projects as string[]) ?? [],
 	};

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -656,7 +656,7 @@ export async function getHubTaskBoard(
 	if (!result) return null;
 	return {
 		board: (result.board as Record<PipelineState, HubTask[]>) ?? {},
-		total: result.total as number,
+		total: (result.total as number) ?? 0,
 		projects: (result.projects as string[]) ?? [],
 	};
 }

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -530,7 +530,7 @@ function asTask(r: Record<string, unknown>): HubTask {
 
 function asTaskList(r: Record<string, unknown>): { tasks: HubTask[]; total: number; page: number; limit: number } {
 	return {
-		tasks: (r.tasks as unknown[]).map((t) => t as HubTask),
+		tasks: ((r.tasks as unknown[]) ?? []).map((t) => t as HubTask),
 		total: r.total as number,
 		page: r.page as number,
 		limit: r.limit as number,
@@ -642,7 +642,7 @@ export async function getHubTaskHistory(
 	if (!result) return null;
 	return {
 		taskId: result.taskId as string,
-		transitions: (result.transitions as unknown[]).map((t) => t as HubTaskTransition),
+		transitions: ((result.transitions as unknown[]) ?? []).map((t) => t as HubTaskTransition),
 	};
 }
 
@@ -657,7 +657,7 @@ export async function getHubTaskBoard(
 	return {
 		board: result.board as Record<PipelineState, HubTask[]>,
 		total: result.total as number,
-		projects: result.projects as string[],
+		projects: (result.projects as string[]) ?? [],
 	};
 }
 

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -1971,7 +1971,7 @@ export default function (pi: ExtensionAPI) {
 							const ext = t.externalTaskId ? ` [${t.externalTaskId}]` : "";
 							const agent = t.assignedAgentId ? ` → agent:${t.assignedAgentId.slice(0, 8)}…` : "";
 							const pr = t.prUrl ? ` PR#${t.prNumber}` : "";
-							lines.push(`- **${t.id.slice(0, 8)}…** ${t.title} [${t.priority}]${ext}${agent}${pr}`);
+							lines.push(`- **${t.id?.slice(0, 8) ?? '?'}…** ${t.title} [${t.priority}]${ext}${agent}${pr}`);
 							lines.push(`  id: ${t.id} | project: ${t.project}`);
 						}
 						lines.push("");
@@ -1995,7 +1995,7 @@ export default function (pi: ExtensionAPI) {
 					for (const t of result.tasks) {
 						const ext = t.externalTaskId ? ` [${t.externalTaskId}]` : "";
 						const agent = t.assignedAgentId ? ` → agent:${t.assignedAgentId.slice(0, 8)}…` : "";
-						lines.push(`- **${t.id.slice(0, 8)}…** \`${t.state}\` [${t.priority}] ${t.title}${ext}${agent}`);
+						lines.push(`- **${t.id?.slice(0, 8) ?? '?'}…** \`${t.state}\` [${t.priority}] ${t.title}${ext}${agent}`);
 						lines.push(`  id: ${t.id} | project: ${t.project}`);
 					}
 					if (result.limit > 0 && result.total > result.page * result.limit) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2036,7 +2036,7 @@ export default function (pi: ExtensionAPI) {
 						description: params.description,
 						repo: params.repo,
 						priority: params.priority as TaskPriority | undefined,
-						assignedAgentId: params.assignedAgentId,
+						assignedAgentId: params.assignedAgentId === "" ? undefined : params.assignedAgentId,
 					}, hubConfig, log);
 					if (!task) return txt("❌ Failed to create task.");
 					return txt(`✅ Created\n**ID:** ${task.id}\n**Title:** ${task.title}\n**Project:** ${task.project} | **State:** ${task.state} | **Priority:** ${task.priority}`);

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -1998,7 +1998,7 @@ export default function (pi: ExtensionAPI) {
 						lines.push(`- **${t.id.slice(0, 8)}…** \`${t.state}\` [${t.priority}] ${t.title}${ext}${agent}`);
 						lines.push(`  id: ${t.id} | project: ${t.project}`);
 					}
-					if (result.total > result.page * result.limit) {
+					if (result.limit > 0 && result.total > result.page * result.limit) {
 						lines.push(`\n_${result.total - result.page * result.limit} more — use page param to paginate_`);
 					}
 					return txt(lines.join("\n"));

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -49,7 +49,7 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification } from "./hub.ts";
+import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
 import { sendA2AMessage, getRemoteTask, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
@@ -1873,6 +1873,249 @@ export default function (pi: ExtensionAPI) {
 				"Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a discover [query] | /a2a agents [refresh|name]",
 				"info",
 			);
+		},
+	});
+
+	// ── Hub Tasks (Pipeline CRUD) ───────────────────────────────────────────
+
+	pi.registerTool({
+		name: "hub_tasks",
+		label: "Hub Tasks",
+		description:
+			"Manage pipeline tasks on the A2A Hub. Full CRUD for the Hub's build pipeline.\n" +
+			"Actions:\n" +
+			"  board      — Kanban board grouped by pipeline state\n" +
+			"  list       — List tasks (filters: project, state, priority, assignedAgentId, page, limit, includeTerminal)\n" +
+			"  get        — Get a single task by taskId\n" +
+			"  create     — Create a task (title + project required; optional: description, repo, priority, assignedAgentId)\n" +
+			"  update     — Update task fields (taskId required; any of: title, description, priority, assignedAgentId, externalTaskId, branch, prUrl, prNumber, blockedReason)\n" +
+			"  transition — Move through pipeline (taskId + toState; optional note). States: queued→planning→building→reviewing→pr_ready→approved | blocked | cancelled\n" +
+			"  delete     — Delete a task (taskId required)\n" +
+			"  history    — State transition log for a task (taskId required)\n" +
+			"  report     — Agent self-reports pipeline status (hubTaskId + toState; optional: externalTaskId, branch, prUrl, prNumber, blockedReason)",
+		parameters: Type.Object({
+			action: Type.Union([
+				Type.Literal("board"),
+				Type.Literal("list"),
+				Type.Literal("get"),
+				Type.Literal("create"),
+				Type.Literal("update"),
+				Type.Literal("transition"),
+				Type.Literal("delete"),
+				Type.Literal("history"),
+				Type.Literal("report"),
+			], { description: "Action to perform" }),
+			// Task identity
+			taskId: Type.Optional(Type.String({ description: "Hub task ID (required for get/update/transition/delete/history)" })),
+			hubTaskId: Type.Optional(Type.String({ description: "Hub task ID (for report action)" })),
+			// Create / update fields
+			title: Type.Optional(Type.String({ description: "Task title" })),
+			description: Type.Optional(Type.String({ description: "Task description" })),
+			project: Type.Optional(Type.String({ description: "Project name e.g. 'aivena', 'e9n.dev'" })),
+			repo: Type.Optional(Type.String({ description: "Git repo URL" })),
+			priority: Type.Optional(Type.Union([
+				Type.Literal("low"), Type.Literal("normal"), Type.Literal("high"), Type.Literal("critical"),
+			], { description: "Task priority (default: normal)" })),
+			assignedAgentId: Type.Optional(Type.String({ description: "Agent ID to assign. Pass empty string to unassign." })),
+			// Transition / report
+			toState: Type.Optional(Type.Union([
+				Type.Literal("queued"), Type.Literal("planning"), Type.Literal("building"),
+				Type.Literal("reviewing"), Type.Literal("pr_ready"), Type.Literal("blocked"),
+				Type.Literal("approved"), Type.Literal("cancelled"),
+			], { description: "Target pipeline state" })),
+			note: Type.Optional(Type.String({ description: "Transition note (e.g. review feedback)" })),
+			// External references
+			externalTaskId: Type.Optional(Type.String({ description: "td task ID on agent side e.g. td-abc123" })),
+			branch: Type.Optional(Type.String({ description: "Git branch name" })),
+			prUrl: Type.Optional(Type.String({ description: "Pull request URL" })),
+			prNumber: Type.Optional(Type.Number({ description: "Pull request number" })),
+			blockedReason: Type.Optional(Type.String({ description: "Reason for blocking" })),
+			// List filters
+			state: Type.Optional(Type.Union([
+				Type.Literal("queued"), Type.Literal("planning"), Type.Literal("building"),
+				Type.Literal("reviewing"), Type.Literal("pr_ready"), Type.Literal("blocked"),
+				Type.Literal("approved"), Type.Literal("cancelled"),
+			], { description: "Filter by state (for list)" })),
+			page: Type.Optional(Type.Number({ description: "Page number for list (default: 1)" })),
+			limit: Type.Optional(Type.Number({ description: "Results per page for list/history (default: 20/50)" })),
+			includeTerminal: Type.Optional(Type.Boolean({ description: "Include approved/cancelled in list (default: false)" })),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			switch (params.action) {
+
+				case "board": {
+					const board = await getHubTaskBoard(
+						{ project: params.project, assignedAgentId: params.assignedAgentId },
+						hubConfig, log,
+					);
+					if (!board) return txt("❌ Failed to fetch board — check hub connection.");
+					const STAGES: PipelineState[] = ["queued", "planning", "building", "reviewing", "pr_ready", "blocked"];
+					const EMOJI: Record<string, string> = {
+						queued: "📋", planning: "📐", building: "🔨",
+						reviewing: "👀", pr_ready: "🚀", blocked: "🚧",
+					};
+					const lines = [`# Hub Pipeline Board (${board.total} active tasks)\n`];
+					if (board.projects.length) lines.push(`Projects: ${board.projects.join(", ")}\n`);
+					for (const stage of STAGES) {
+						const tasks: HubTask[] = (board.board[stage] as unknown as HubTask[]) ?? [];
+						lines.push(`## ${EMOJI[stage]} ${stage.replace("_", " ")} (${tasks.length})`);
+						if (tasks.length === 0) { lines.push("_none_\n"); continue; }
+						for (const t of tasks) {
+							const ext = t.externalTaskId ? ` [${t.externalTaskId}]` : "";
+							const agent = t.assignedAgentId ? ` → agent:${t.assignedAgentId.slice(0, 8)}…` : "";
+							const pr = t.prUrl ? ` PR#${t.prNumber}` : "";
+							lines.push(`- **${t.id.slice(0, 8)}…** ${t.title} [${t.priority}]${ext}${agent}${pr}`);
+							lines.push(`  id: ${t.id} | project: ${t.project}`);
+						}
+						lines.push("");
+					}
+					return txt(lines.join("\n"));
+				}
+
+				case "list": {
+					const result = await listHubTasks({
+						project: params.project,
+						state: params.state as PipelineState | undefined,
+						priority: params.priority as TaskPriority | undefined,
+						assignedAgentId: params.assignedAgentId,
+						page: params.page,
+						limit: params.limit,
+						includeTerminal: params.includeTerminal,
+					}, hubConfig, log);
+					if (!result) return txt("❌ Failed to list tasks.");
+					if (result.tasks.length === 0) return txt("No tasks found.");
+					const lines = [`# Hub Tasks (${result.total} total, page ${result.page})\n`];
+					for (const t of result.tasks) {
+						const ext = t.externalTaskId ? ` [${t.externalTaskId}]` : "";
+						const agent = t.assignedAgentId ? ` → agent:${t.assignedAgentId.slice(0, 8)}…` : "";
+						lines.push(`- **${t.id.slice(0, 8)}…** \`${t.state}\` [${t.priority}] ${t.title}${ext}${agent}`);
+						lines.push(`  id: ${t.id} | project: ${t.project}`);
+					}
+					if (result.total > result.page * result.limit) {
+						lines.push(`\n_${result.total - result.page * result.limit} more — use page param to paginate_`);
+					}
+					return txt(lines.join("\n"));
+				}
+
+				case "get": {
+					if (!params.taskId) return txt("❌ taskId required.");
+					const task = await getHubTask(params.taskId, hubConfig, log);
+					if (!task) return txt(`❌ Task not found: ${params.taskId}`);
+					const lines = [
+						`# Task: ${task.title}`,
+						`**ID:** ${task.id}`,
+						`**State:** ${task.state} | **Priority:** ${task.priority} | **Project:** ${task.project}`,
+						task.description ? `**Description:** ${task.description}` : "",
+						task.assignedAgentId ? `**Assigned:** ${task.assignedAgentId}` : "",
+						task.externalTaskId ? `**External Task:** ${task.externalTaskId}` : "",
+						task.branch ? `**Branch:** ${task.branch}` : "",
+						task.prUrl ? `**PR:** [#${task.prNumber}](${task.prUrl})` : "",
+						task.blockedReason ? `**Blocked:** ${task.blockedReason}` : "",
+						task.repo ? `**Repo:** ${task.repo}` : "",
+						`**Review:** ${task.reviewRound}/${task.maxReviewRounds} rounds`,
+						`**Created:** ${task.createdAt} | **Updated:** ${task.updatedAt}`,
+						task.startedAt ? `**Started:** ${task.startedAt}` : "",
+						task.completedAt ? `**Completed:** ${task.completedAt}` : "",
+					].filter(Boolean);
+					return txt(lines.join("\n"));
+				}
+
+				case "create": {
+					if (!params.title) return txt("❌ title required.");
+					if (!params.project) return txt("❌ project required.");
+					const task = await createHubTask({
+						title: params.title,
+						project: params.project,
+						description: params.description,
+						repo: params.repo,
+						priority: params.priority as TaskPriority | undefined,
+						assignedAgentId: params.assignedAgentId,
+					}, hubConfig, log);
+					if (!task) return txt("❌ Failed to create task.");
+					return txt(`✅ Created\n**ID:** ${task.id}\n**Title:** ${task.title}\n**Project:** ${task.project} | **State:** ${task.state} | **Priority:** ${task.priority}`);
+				}
+
+				case "update": {
+					if (!params.taskId) return txt("❌ taskId required.");
+					const task = await updateHubTask({
+						taskId: params.taskId,
+						title: params.title,
+						description: params.description,
+						priority: params.priority as TaskPriority | undefined,
+						assignedAgentId: params.assignedAgentId === "" ? null : params.assignedAgentId,
+						externalTaskId: params.externalTaskId,
+						branch: params.branch,
+						prUrl: params.prUrl,
+						prNumber: params.prNumber,
+						blockedReason: params.blockedReason,
+					}, hubConfig, log);
+					if (!task) return txt(`❌ Failed to update: ${params.taskId}`);
+					return txt(`✅ Updated\n**ID:** ${task.id}\n**Title:** ${task.title} | **State:** ${task.state} | **Priority:** ${task.priority}${task.externalTaskId ? `\n**External:** ${task.externalTaskId}` : ""}${task.branch ? `\n**Branch:** ${task.branch}` : ""}`);
+				}
+
+				case "transition": {
+					if (!params.taskId) return txt("❌ taskId required.");
+					if (!params.toState) return txt("❌ toState required.");
+					const task = await transitionHubTask({
+						taskId: params.taskId,
+						toState: params.toState as PipelineState,
+						note: params.note,
+					}, hubConfig, log);
+					if (!task) return txt(`❌ Failed to transition: ${params.taskId}`);
+					return txt(`✅ Transitioned → **${task.state}**\n**ID:** ${task.id}\n**Title:** ${task.title}${params.note ? `\n**Note:** ${params.note}` : ""}`);
+				}
+
+				case "delete": {
+					if (!params.taskId) return txt("❌ taskId required.");
+					const result = await deleteHubTask(params.taskId, hubConfig, log);
+					if (!result?.deleted) return txt(`❌ Failed to delete: ${params.taskId}`);
+					return txt(`✅ Deleted: ${params.taskId}`);
+				}
+
+				case "history": {
+					if (!params.taskId) return txt("❌ taskId required.");
+					const result = await getHubTaskHistory(params.taskId, hubConfig, log, params.limit ?? 50);
+					if (!result) return txt(`❌ Failed to fetch history: ${params.taskId}`);
+					if (result.transitions.length === 0) return txt("No transitions recorded.");
+					const lines = [`# History: ${params.taskId}\n`];
+					for (const t of result.transitions) {
+						const from = t.fromState ?? "(created)";
+						const actor = t.actorAgentId
+							? `agent:${t.actorAgentId.slice(0, 8)}…`
+							: t.actorUserId ? `user:${t.actorUserId.slice(0, 8)}…` : "unknown";
+						const note = t.note ? ` — ${t.note}` : "";
+						lines.push(`- ${t.createdAt.slice(0, 19)} | ${from} → **${t.toState}** by ${actor}${note}`);
+					}
+					return txt(lines.join("\n"));
+				}
+
+				case "report": {
+					if (!params.hubTaskId) return txt("❌ hubTaskId required.");
+					if (!params.toState) return txt("❌ toState required.");
+					const task = await reportHubTaskStatus({
+						hubTaskId: params.hubTaskId,
+						toState: params.toState as PipelineState,
+						note: params.note,
+						externalTaskId: params.externalTaskId,
+						branch: params.branch,
+						prUrl: params.prUrl,
+						prNumber: params.prNumber,
+						blockedReason: params.blockedReason,
+					}, hubConfig, log);
+					if (!task) return txt(`❌ Failed to report status: ${params.hubTaskId}`);
+					return txt(`✅ Status reported → **${task.state}**\n**ID:** ${task.id}\n**Title:** ${task.title}${task.branch ? `\n**Branch:** ${task.branch}` : ""}${task.prUrl ? `\n**PR:** ${task.prUrl}` : ""}`);
+				}
+
+				default:
+					return txt("Unknown action. Use: board, list, get, create, update, transition, delete, history, report");
+			}
 		},
 	});
 }


### PR DESCRIPTION
Adds a hub_tasks tool to pi-a2a with 9 actions:
- board      — Kanban board grouped by pipeline state
- list       — List tasks with filters (project, state, priority, page)
- get        — Get a single task by ID
- create     — Create a task (title + project required)
- update     — Update task fields (title, description, priority, assignedAgentId, externalTaskId, branch, prUrl, prNumber, blockedReason)
- transition — Move task through pipeline states with optional note
- delete     — Delete a task
- history    — State transition log for a task
- report     — Agent self-reports pipeline status (links externalTaskId/branch/PR)

Task functions added to hub.ts:
- createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask
- deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus
- HubTask, HubTaskTransition, PipelineState, TaskPriority types exported

Uses existing pi-a2a.hub config (url + apiKey) — no new setup needed.

Closes td-e7173b
