### PR TITLE
fix(pi-a2a): auto-retry send when remote task is in terminal state

### DIFF
--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -1366,10 +1366,25 @@ export default function (pi: ExtensionAPI) {
 
 			(async () => {
 				try {
-					const result = await sendA2AMessage(sendOpts, log);
+					let result = await sendA2AMessage(sendOpts, log);
 
 					// Bail out if session restarted while we were waiting
 					if (sessionToken !== myToken) return;
+
+					// ── Auto-retry on terminal task error ──────────────────
+					// When the remote task is already completed/failed/cancelled,
+					// the hub rejects follow-up messages with JSON-RPC -32600
+					// ("Task ... is in a terminal state and cannot be modified").
+					// Recover automatically by starting a fresh task (same contextId,
+					// no stale taskId) so the user doesn't need newConversation=true.
+					if (!result.ok && result.error && /terminal state/i.test(result.error) && resolvedTaskId) {
+						log("a2a_terminal_task_retry", { agent: agentName, oldTaskId: resolvedTaskId });
+						// Clear the stale taskId from the context store immediately
+						conversationContexts.set(agentKey, { contextId: resolvedContextId! });
+						// Retry as a new task (keep contextId for conversation continuity)
+						result = await sendA2AMessage({ ...sendOpts, taskId: undefined }, log);
+						if (sessionToken !== myToken) return;
+					}
 
 					// Store conversation context for follow-up messages
 					if (result.ok) {


### PR DESCRIPTION
## Problem

When `a2a_send` is called with a stored `taskId` and the remote task is already in a terminal state (completed/failed/cancelled), the hub rejects the follow-up with:

```
JSON-RPC error: Task ed401f7a-... is in a terminal state (completed) and cannot be modified. (Code: -32600)
```

This surfaces as a red `❌ A2A error` to the user, even though the intent was just to send a new message to the same agent.

## Root cause

`conversationContexts` stores the last `{ contextId, taskId }` per agent and automatically reuses it on follow-up sends. The stale `taskId` is sent to the hub, which rejects it.

## Fix

After the initial `sendA2AMessage` call, detect the terminal-state error pattern (`/terminal state/i`) and automatically retry without the stale `taskId` (same `contextId` for continuity). The stale `taskId` is cleared from `conversationContexts` before the retry.

The retry is fully transparent to the caller — no need for `newConversation=true`.

## Test

1. Send a message to any A2A agent → wait for it to complete
2. Send a follow-up to the same agent (same `contextId`/`taskId` auto-reused)
3. Before fix: `❌ A2A error: Task ... is in a terminal state`
4. After fix: seamless new task, conversation continues

Reported by Fury. Hub task: `976337bb`