### PR TITLE
feat(pi-prism): hub_tasks API widgets + peer dep bump to 0.65.2

### DIFF
--- a/extensions/pi-prism/AGENTS.md
+++ b/extensions/pi-prism/AGENTS.md
@@ -1,0 +1,28 @@
+---
+name: pi-prism
+description: Configurable widget sidebar overlay for pi — operational dashboard in the TUI
+---
+
+## Overview
+
+TUI sidebar extension that renders a right-anchored overlay with configurable widgets.
+No database of its own — queries other extensions' tables via pi-kysely event bus (read-only).
+
+**Stack:** TypeScript · pi-tui overlay API · pi-kysely event bus
+
+## Architecture
+
+- `src/index.ts` — Extension entry point. Registers `/prism` command, `Ctrl+Shift+P` shortcut, auto-opens on session start.
+- `src/settings.ts` — Loads `pi-prism` settings from `.pi/settings.json` (widget list, autoOpen).
+- `src/helpers.ts` — Shared utilities: DB query helper (via kysely event bus), CLI exec, format helpers (money, date, time, progress bars).
+- `src/sidebar.ts` — `WidgetSidebar` class — the main TUI overlay component. Handles rendering, scrolling, refresh, keyboard input.
+- `src/widgets/index.ts` — Widget interface, registry, and default widget list.
+- `src/widgets/*.ts` — Individual widget implementations (one file per widget).
+
+## Key Patterns
+
+- **Read-only DB access** — requests `kysely:grant` with `select` only. Never writes data.
+- **Graceful degradation** — each widget catches errors silently. Missing data shows "no data" message.
+- **No direct extension imports** — all data access via pi-kysely event bus queries.
+- **Overlay API** — uses `ctx.ui.custom()` with `overlay: true` and `overlayOptions` for right-anchored sidebar.
+- **Cached rendering** — sidebar caches rendered output and only re-renders on state changes (version counter pattern).

--- a/extensions/pi-prism/CHANGELOG.md
+++ b/extensions/pi-prism/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] - 2026-02-22
+
+### Added
+
+- Initial release — configurable widget sidebar overlay for pi.
+- 14 built-in widgets: active-task, task-queue, git-status, today-calendar, week-calendar, recent-ops, system-health, accounts, budget-bars, recent-txns, reminders, recent-contacts, session-stats, clock.
+- Settings: configurable widget list and auto-open behavior.
+- `/prism` command and `Ctrl+Shift+P` shortcut to toggle sidebar.
+- Auto-refresh every 60s with manual refresh via `r`.
+- Keyboard navigation: `j/k` scroll, `q/Esc` close.

--- a/extensions/pi-prism/README.md
+++ b/extensions/pi-prism/README.md
@@ -1,0 +1,62 @@
+# @e9n/pi-prism
+
+Configurable widget sidebar overlay for [pi](https://github.com/espennilsen/pi) — an operational dashboard in the TUI.
+
+## Features
+
+- **Right-anchored overlay** — 34% width sidebar with scrollable widget stack
+- **14 built-in widgets** — tasks, calendar, git, finance, CRM, system health, and more
+- **Configurable** — choose and order widgets via settings
+- **Auto-refresh** — widgets update every 60s, manual refresh with `r`
+- **Keyboard-driven** — `j/k` scroll, `q/Esc` close, `r` refresh
+
+## Settings
+
+Add to `~/.pi/agent/settings.json` or `.pi/settings.json`:
+
+```json
+{
+  "pi-prism": {
+    "widgets": ["active-task", "today-calendar", "git-status", "accounts"],
+    "autoOpen": true
+  }
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `widgets` | `["active-task", "today-calendar", "recent-ops", "accounts"]` | Widget IDs to display (order matters) |
+| `autoOpen` | `true` | Auto-open sidebar on session start |
+
+## Usage
+
+- **Command:** `/prism` — toggle the sidebar
+- **Shortcut:** `Ctrl+Shift+P` — toggle the sidebar
+- Auto-opens on session start (configurable)
+
+## Available Widgets
+
+| ID | Icon | Description |
+|----|------|-------------|
+| `active-task` | 🎯 | Current td task status |
+| `task-queue` | 📋 | Open td tasks (top 6) |
+| `git-status` | 🔀 | Branch, staged/modified/untracked counts |
+| `today-calendar` | 📅 | Today's calendar events |
+| `week-calendar` | 🗓️ | This week's calendar events |
+| `recent-ops` | ⚡ | Last 8 tool calls with status |
+| `system-health` | 🟢 | DB, memory, git, tasks health checks |
+| `accounts` | 💳 | Finance account balances |
+| `budget-bars` | 📊 | Monthly budget progress bars |
+| `recent-txns` | 💸 | Last 5 transactions |
+| `reminders` | 🔔 | Upcoming CRM reminders (14 days) |
+| `recent-contacts` | 👥 | Recently contacted people |
+| `session-stats` | ⏱ | Session uptime, model, daily cost |
+| `clock` | 🕐 | Big digit clock with date |
+
+## Requirements
+
+Widgets that query the database require [pi-kysely](https://www.npmjs.com/package/@e9n/pi-kysely) to be loaded. Widgets gracefully degrade if their data source is unavailable.
+
+## License
+
+MIT

--- a/extensions/pi-prism/package-lock.json
+++ b/extensions/pi-prism/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@mariozechner/pi-coding-agent": "^0.65.2",
+				"@mariozechner/pi-tui": "^0.65.2",
+				"@sinclair/typebox": "^0.34.49",
 				"typescript": "^5.9.3"
 			},
 			"peerDependencies": {
@@ -21,8 +24,8 @@
 			"version": "0.73.0",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
 			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"json-schema-to-ts": "^3.1.1"
 			},
@@ -42,8 +45,8 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
 			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -57,8 +60,8 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
 			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-js": "^5.2.0",
 				"@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -73,8 +76,8 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -86,8 +89,8 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -100,8 +103,8 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -114,8 +117,8 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
 			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -129,8 +132,8 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
 			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			}
@@ -139,8 +142,8 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
 			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-sdk/types": "^3.222.0",
 				"@smithy/util-utf8": "^2.0.0",
@@ -151,8 +154,8 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
 			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -164,8 +167,8 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
 			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -178,8 +181,8 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
 			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
@@ -189,125 +192,58 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.995.0.tgz",
-			"integrity": "sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==",
+			"version": "3.1025.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1025.0.tgz",
+			"integrity": "sha512-+ATojo49AZAd9IPHTYiRgv5kiPZcZkgkznENl7lK+Hg0W4RCs48bMjlJDVgN9QKPk3VfQUUPq1KjAtX98ggBtw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/credential-provider-node": "^3.972.10",
-				"@aws-sdk/eventstream-handler-node": "^3.972.5",
-				"@aws-sdk/middleware-eventstream": "^3.972.3",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/middleware-websocket": "^3.972.6",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/token-providers": "3.995.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.995.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.10",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/eventstream-serde-browser": "^4.2.8",
-				"@smithy/eventstream-serde-config-resolver": "^4.3.8",
-				"@smithy/eventstream-serde-node": "^4.2.8",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-stream": "^4.5.12",
-				"@smithy/util-utf8": "^4.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.993.0.tgz",
-			"integrity": "sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.993.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.9",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-node": "^3.972.29",
+				"@aws-sdk/eventstream-handler-node": "^3.972.12",
+				"@aws-sdk/middleware-eventstream": "^3.972.8",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/middleware-websocket": "^3.972.14",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/token-providers": "3.1025.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.12",
+				"@smithy/eventstream-serde-node": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-stream": "^4.5.21",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -315,24 +251,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.973.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
-			"integrity": "sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==",
+			"version": "3.973.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+			"integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/xml-builder": "^3.972.5",
-				"@smithy/core": "^3.23.2",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/signature-v4": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/xml-builder": "^3.972.16",
+				"@smithy/core": "^3.23.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -340,16 +276,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.9.tgz",
-			"integrity": "sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+			"integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -357,21 +293,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
-			"integrity": "sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==",
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+			"integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-stream": "^4.5.12",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.21",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -379,25 +315,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.9.tgz",
-			"integrity": "sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+			"integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/credential-provider-env": "^3.972.9",
-				"@aws-sdk/credential-provider-http": "^3.972.11",
-				"@aws-sdk/credential-provider-login": "^3.972.9",
-				"@aws-sdk/credential-provider-process": "^3.972.9",
-				"@aws-sdk/credential-provider-sso": "^3.972.9",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.9",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/credential-provider-imds": "^4.2.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/credential-provider-env": "^3.972.24",
+				"@aws-sdk/credential-provider-http": "^3.972.26",
+				"@aws-sdk/credential-provider-login": "^3.972.28",
+				"@aws-sdk/credential-provider-process": "^3.972.24",
+				"@aws-sdk/credential-provider-sso": "^3.972.28",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.28",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -405,19 +341,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
-			"integrity": "sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+			"integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -425,23 +361,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.10.tgz",
-			"integrity": "sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==",
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+			"integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.9",
-				"@aws-sdk/credential-provider-http": "^3.972.11",
-				"@aws-sdk/credential-provider-ini": "^3.972.9",
-				"@aws-sdk/credential-provider-process": "^3.972.9",
-				"@aws-sdk/credential-provider-sso": "^3.972.9",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.9",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/credential-provider-imds": "^4.2.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/credential-provider-env": "^3.972.24",
+				"@aws-sdk/credential-provider-http": "^3.972.26",
+				"@aws-sdk/credential-provider-ini": "^3.972.28",
+				"@aws-sdk/credential-provider-process": "^3.972.24",
+				"@aws-sdk/credential-provider-sso": "^3.972.28",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.28",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -449,17 +385,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
-			"integrity": "sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+			"integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -467,19 +403,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.9.tgz",
-			"integrity": "sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+			"integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.993.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/token-providers": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/token-providers": "3.1021.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -487,18 +423,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.993.0.tgz",
-			"integrity": "sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==",
+			"version": "3.1021.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+			"integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -506,18 +442,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
-			"integrity": "sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+			"integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.993.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -525,15 +461,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.5.tgz",
-			"integrity": "sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==",
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+			"integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/eventstream-codec": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -541,15 +477,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.3.tgz",
-			"integrity": "sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+			"integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -557,15 +493,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
-			"integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+			"integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -573,14 +509,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
-			"integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+			"integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -588,16 +524,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
-			"integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+			"integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/types": "^3.973.6",
 				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -605,35 +541,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
-			"integrity": "sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==",
+			"version": "3.972.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+			"integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.993.0",
-				"@smithy/core": "^3.23.2",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@smithy/core": "^3.23.13",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-retry": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -641,23 +561,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.6",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.6.tgz",
-			"integrity": "sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==",
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+			"integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-format-url": "^3.972.3",
-				"@smithy/eventstream-codec": "^4.2.8",
-				"@smithy/eventstream-serde-browser": "^4.2.8",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/signature-v4": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-format-url": "^3.972.8",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -665,66 +585,49 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
-			"integrity": "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==",
+			"version": "3.996.18",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+			"integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.993.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.9",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.993.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
-			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.14",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.13",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.28",
+				"@smithy/middleware-retry": "^4.4.46",
+				"@smithy/middleware-serde": "^4.2.16",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.1",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.8",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.44",
+				"@smithy/util-defaults-mode-node": "^4.2.48",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.13",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -732,16 +635,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
-			"integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+			"integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -749,68 +652,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.995.0.tgz",
-			"integrity": "sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==",
+			"version": "3.1025.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1025.0.tgz",
+			"integrity": "sha512-sbEnN8VbDFCmf1NbGHpWDQ9llwOYkPeEs8NLZ2+uYO7l97s+x6X58XTnM6XG/DBe9LZm5ddObvsK1CVlW2N4hg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/nested-clients": "3.995.0",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.995.0.tgz",
-			"integrity": "sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@aws-crypto/sha256-browser": "5.2.0",
-				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.11",
-				"@aws-sdk/middleware-host-header": "^3.972.3",
-				"@aws-sdk/middleware-logger": "^3.972.3",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/region-config-resolver": "^3.972.3",
-				"@aws-sdk/types": "^3.973.1",
-				"@aws-sdk/util-endpoints": "3.995.0",
-				"@aws-sdk/util-user-agent-browser": "^3.972.3",
-				"@aws-sdk/util-user-agent-node": "^3.972.10",
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/core": "^3.23.2",
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/hash-node": "^4.2.8",
-				"@smithy/invalid-dependency": "^4.2.8",
-				"@smithy/middleware-content-length": "^4.2.8",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-retry": "^4.4.33",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-body-length-node": "^4.2.1",
-				"@smithy/util-defaults-mode-browser": "^4.3.32",
-				"@smithy/util-defaults-mode-node": "^4.2.35",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/util-utf8": "^4.2.0",
+				"@aws-sdk/core": "^3.973.26",
+				"@aws-sdk/nested-clients": "^3.996.18",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -818,13 +671,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-			"integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -832,16 +685,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.995.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
-			"integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
+			"version": "3.996.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+			"integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-endpoints": "^3.2.8",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-endpoints": "^3.3.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -849,15 +702,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
-			"integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+			"integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/querystring-builder": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -865,11 +718,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-locate-window": {
-			"version": "3.965.4",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
-			"integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -878,29 +731,30 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
-			"integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+			"integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
-			"integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
+			"version": "3.973.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+			"integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.11",
-				"@aws-sdk/types": "^3.973.1",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
+				"@aws-sdk/middleware-user-agent": "^3.972.28",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -916,14 +770,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.5",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
-			"integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"fast-xml-parser": "5.3.6",
+				"@smithy/types": "^4.13.1",
+				"fast-xml-parser": "5.5.8",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -931,21 +785,21 @@
 			}
 		},
 		"node_modules/@aws/lambda-invoke-store": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-			"integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -954,19 +808,19 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
 			"integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.42.0.tgz",
-			"integrity": "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.48.0.tgz",
+			"integrity": "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"google-auth-library": "^10.3.0",
 				"p-retry": "^4.6.2",
@@ -985,116 +839,13 @@
 				}
 			}
 		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/@mariozechner/clipboard": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
 			"integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			},
@@ -1118,12 +869,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1132,12 +883,12 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
 			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1149,12 +900,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1166,12 +917,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1183,12 +934,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1200,12 +951,12 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1217,12 +968,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1234,12 +985,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1251,12 +1002,12 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1268,12 +1019,12 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -1282,8 +1033,8 @@
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
 			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"std-env": "^3.10.0",
 				"yoctocolors": "^2.1.2"
@@ -1293,34 +1044,34 @@
 			}
 		},
 		"node_modules/@mariozechner/pi-agent-core": {
-			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.54.0.tgz",
-			"integrity": "sha512-LsPoudpOJLj7JjSpjlAdLM5uA2iy8nP+4nA6Si1ASD3tMqXdjHzNaKNloGSODKJO+3O3yhwPMSbuk78CCnZteQ==",
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.65.2.tgz",
+			"integrity": "sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@mariozechner/pi-ai": "^0.54.0"
+				"@mariozechner/pi-ai": "^0.65.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@mariozechner/pi-ai": {
-			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.54.0.tgz",
-			"integrity": "sha512-XHhMIbFFHCa4mbiYdttfhVg6r3VmFD5tAiW4tjnmf33FhLUCRd76bGMQRc4kLWXPKCi/U4nqAErvaGiZUY4B8A==",
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.65.2.tgz",
+			"integrity": "sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@anthropic-ai/sdk": "^0.73.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
 				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "1.10.0",
+				"@mistralai/mistralai": "1.14.1",
 				"@sinclair/typebox": "^0.34.41",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"chalk": "^5.6.2",
-				"openai": "6.10.0",
+				"openai": "6.26.0",
 				"partial-json": "^0.1.7",
 				"proxy-agent": "^6.5.0",
 				"undici": "^7.19.1",
@@ -1334,122 +1085,137 @@
 			}
 		},
 		"node_modules/@mariozechner/pi-coding-agent": {
-			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.54.0.tgz",
-			"integrity": "sha512-CO8uLmigLzzep2i5/f05dchyywDYDsqykLxpaMXbwDa/dDzsBRbuWoGQBOAsiGbcCMya6AT5nAggFFo4Aqy/+g==",
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.65.2.tgz",
+			"integrity": "sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@mariozechner/jiti": "^2.6.2",
-				"@mariozechner/pi-agent-core": "^0.54.0",
-				"@mariozechner/pi-ai": "^0.54.0",
-				"@mariozechner/pi-tui": "^0.54.0",
+				"@mariozechner/pi-agent-core": "^0.65.2",
+				"@mariozechner/pi-ai": "^0.65.2",
+				"@mariozechner/pi-tui": "^0.65.2",
 				"@silvia-odwyer/photon-node": "^0.3.4",
+				"ajv": "^8.17.1",
 				"chalk": "^5.5.0",
 				"cli-highlight": "^2.1.11",
 				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
 				"file-type": "^21.1.1",
 				"glob": "^13.0.1",
 				"hosted-git-info": "^9.0.2",
 				"ignore": "^7.0.5",
 				"marked": "^15.0.12",
-				"minimatch": "^10.1.1",
+				"minimatch": "^10.2.3",
 				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
 				"yaml": "^2.8.2"
 			},
 			"bin": {
 				"pi": "dist/cli.js"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=20.6.0"
 			},
 			"optionalDependencies": {
 				"@mariozechner/clipboard": "^0.3.2"
 			}
 		},
-		"node_modules/@mariozechner/pi-tui": {
-			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.54.0.tgz",
-			"integrity": "sha512-bvFlUohdxDvKcFeQM2xsd5twCGKWxVaYSlHCFljIW0KqMC4vU+/Ts4A1i9iDnm6Xe/MlueKvC0V09YeC8fLIHA==",
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.65.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.65.2.tgz",
+			"integrity": "sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",
 				"chalk": "^5.5.0",
 				"get-east-asian-width": "^1.3.0",
-				"koffi": "^2.9.0",
 				"marked": "^15.0.12",
 				"mime-types": "^3.0.1"
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
 			}
 		},
 		"node_modules/@mistralai/mistralai": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.10.0.tgz",
-			"integrity": "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==",
-			"peer": true,
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+			"integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+			"dev": true,
 			"dependencies": {
-				"zod": "^3.20.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
 				"zod-to-json-schema": "^3.24.1"
-			}
-		},
-		"node_modules/@mistralai/mistralai/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
 			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
 			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/codegen": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
 			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
 			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
 			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.1",
 				"@protobufjs/inquire": "^1.1.0"
@@ -1459,77 +1225,63 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
 			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
 			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
 			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/utf8": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
 			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-			"license": "Apache-2.0",
-			"peer": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.34.48",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@smithy/abort-controller": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-			"integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-			"integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+			"version": "4.4.14",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
+			"integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-config-provider": "^4.2.0",
-				"@smithy/util-endpoints": "^3.2.8",
-				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.3.4",
+				"@smithy/util-middleware": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1537,21 +1289,21 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.2",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
-			"integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
+			"version": "3.23.14",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+			"integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-body-length-browser": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-stream": "^4.5.12",
-				"@smithy/util-utf8": "^4.2.0",
-				"@smithy/uuid": "^1.1.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-stream": "^4.5.22",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1559,16 +1311,16 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-			"integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
+			"integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1576,15 +1328,15 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
-			"integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
+			"integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-hex-encoding": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1592,14 +1344,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
-			"integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
+			"integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/eventstream-serde-universal": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1607,13 +1359,13 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
-			"integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
+			"version": "4.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
+			"integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1621,14 +1373,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
-			"integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
+			"integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/eventstream-serde-universal": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1636,14 +1388,14 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
-			"integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
+			"integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/eventstream-codec": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1651,16 +1403,16 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.9",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-			"integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+			"version": "5.3.16",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+			"integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/querystring-builder": "^4.2.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/querystring-builder": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-base64": "^4.3.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1668,15 +1420,15 @@
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-			"integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+			"integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1684,13 +1436,13 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-			"integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+			"integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1698,11 +1450,11 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-			"integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -1711,14 +1463,14 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-			"integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+			"integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1726,19 +1478,19 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.16",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
-			"integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
+			"version": "4.4.29",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+			"integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.23.2",
-				"@smithy/middleware-serde": "^4.2.9",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
-				"@smithy/url-parser": "^4.2.8",
-				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/core": "^3.23.14",
+				"@smithy/middleware-serde": "^4.2.17",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-middleware": "^4.2.13",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1746,20 +1498,21 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.4.33",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
-			"integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.0.tgz",
+			"integrity": "sha512-/NzISn4grj/BRFVua/xnQwF+7fakYZgimpw2dfmlPgcqecBMKxpB9g5mLYRrmBD5OrPoODokw4Vi1hrSR4zRyw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/service-error-classification": "^4.2.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-retry": "^4.2.8",
-				"@smithy/uuid": "^1.1.0",
+				"@smithy/core": "^3.23.14",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/service-error-classification": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-retry": "^4.3.0",
+				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1767,14 +1520,15 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.9",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-			"integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+			"integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/core": "^3.23.14",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1782,13 +1536,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-			"integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+			"integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1796,15 +1550,15 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-			"integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+			"version": "4.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+			"integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/shared-ini-file-loader": "^4.4.3",
-				"@smithy/types": "^4.12.0",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1812,16 +1566,15 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.4.10",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
-			"integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+			"integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/abort-controller": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/querystring-builder": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/querystring-builder": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1829,13 +1582,13 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-			"integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+			"integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1843,13 +1596,13 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-			"integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+			"integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1857,14 +1610,14 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-			"integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+			"integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-uri-escape": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1872,13 +1625,13 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-			"integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+			"integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1886,26 +1639,26 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-			"integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+			"integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0"
+				"@smithy/types": "^4.14.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-			"integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+			"integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1913,19 +1666,19 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-			"integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+			"integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.0",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-middleware": "^4.2.8",
-				"@smithy/util-uri-escape": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1933,18 +1686,18 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.11.5",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
-			"integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
+			"version": "4.12.9",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+			"integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/core": "^3.23.2",
-				"@smithy/middleware-endpoint": "^4.4.16",
-				"@smithy/middleware-stack": "^4.2.8",
-				"@smithy/protocol-http": "^5.3.8",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-stream": "^4.5.12",
+				"@smithy/core": "^3.23.14",
+				"@smithy/middleware-endpoint": "^4.4.29",
+				"@smithy/middleware-stack": "^4.2.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-stream": "^4.5.22",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1952,11 +1705,11 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-			"integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+			"integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -1965,14 +1718,14 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-			"integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+			"integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/querystring-parser": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1980,14 +1733,14 @@
 			}
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1995,11 +1748,11 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-			"integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2008,11 +1761,11 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-			"integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2021,13 +1774,13 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-			"integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.0",
+				"@smithy/is-array-buffer": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2035,11 +1788,11 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-			"integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2048,15 +1801,15 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.32",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
-			"integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
+			"version": "4.3.45",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+			"integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2064,18 +1817,18 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.35",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
-			"integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
+			"version": "4.2.49",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
+			"integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/config-resolver": "^4.4.6",
-				"@smithy/credential-provider-imds": "^4.2.8",
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/property-provider": "^4.2.8",
-				"@smithy/smithy-client": "^4.11.5",
-				"@smithy/types": "^4.12.0",
+				"@smithy/config-resolver": "^4.4.14",
+				"@smithy/credential-provider-imds": "^4.2.13",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2083,14 +1836,14 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "3.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-			"integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
+			"integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2098,11 +1851,11 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2111,13 +1864,13 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-			"integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+			"integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/types": "^4.12.0",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2125,14 +1878,14 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-			"integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.0.tgz",
+			"integrity": "sha512-tSOPQNT/4KfbvqeMovWC3g23KSYy8czHd3tlN+tOYVNIDLSfxIsrPJihYi5TpNcoV789KWtgChUVedh2y6dDPg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.2.8",
-				"@smithy/types": "^4.12.0",
+				"@smithy/service-error-classification": "^4.2.13",
+				"@smithy/types": "^4.14.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2140,19 +1893,19 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.5.12",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
-			"integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
+			"version": "4.5.22",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+			"integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.9",
-				"@smithy/node-http-handler": "^4.4.10",
-				"@smithy/types": "^4.12.0",
-				"@smithy/util-base64": "^4.3.0",
-				"@smithy/util-buffer-from": "^4.2.0",
-				"@smithy/util-hex-encoding": "^4.2.0",
-				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/fetch-http-handler": "^5.3.16",
+				"@smithy/node-http-handler": "^4.5.2",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2160,11 +1913,11 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2173,13 +1926,13 @@
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-buffer-from": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2187,11 +1940,11 @@
 			}
 		},
 		"node_modules/@smithy/uuid": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-			"integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -2203,8 +1956,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
 			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.3",
 				"token-types": "^6.1.1"
@@ -2221,29 +1974,29 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
 			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/mime-types": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
 			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-			"integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+			"integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
@@ -2252,15 +2005,26 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
 			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 14"
 			}
@@ -2269,8 +2033,8 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -2286,8 +2050,8 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -2304,8 +2068,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2314,8 +2078,8 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -2330,15 +2094,15 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
 			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -2347,19 +2111,20 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-			"integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2374,15 +2139,14 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-			"integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -2391,8 +2155,8 @@
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
 			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -2401,35 +2165,45 @@
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
 			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-			"integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "20 || >=22"
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/chalk": {
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
 			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -2441,8 +2215,8 @@
 			"version": "2.1.11",
 			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
 			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"highlight.js": "^10.7.1",
@@ -2463,8 +2237,8 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -2480,8 +2254,8 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
 			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -2492,8 +2266,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -2505,30 +2279,15 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/cross-spawn": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
 			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -2537,8 +2296,8 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -2555,8 +2314,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
 			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ast-types": "^0.13.4",
 				"escodegen": "^2.1.0",
@@ -2570,25 +2329,18 @@
 			"version": "8.0.3",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
 			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
 			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -2597,15 +2349,25 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true
+			"dependencies": {
+				"once": "^1.4.0"
+			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2614,8 +2376,8 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
 			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"esprima": "^4.0.1",
 				"estraverse": "^5.2.0",
@@ -2636,8 +2398,8 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -2650,8 +2412,8 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -2660,8 +2422,8 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2670,20 +2432,42 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
 			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2694,13 +2478,13 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
-		"node_modules/fast-xml-parser": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-			"integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2708,18 +2492,46 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"strnum": "^2.1.2"
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
 			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2731,7 +2543,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"node-domexception": "^1.0.0",
 				"web-streams-polyfill": "^3.0.3"
@@ -2744,8 +2555,8 @@
 			"version": "21.3.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
 			"integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@tokenizer/inflate": "^0.4.1",
 				"strtok3": "^10.3.4",
@@ -2759,42 +2570,12 @@
 				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
 			}
 		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/foreground-child/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"license": "ISC",
-			"peer": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
 			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fetch-blob": "^3.1.2"
 			},
@@ -2803,16 +2584,15 @@
 			}
 		},
 		"node_modules/gaxios": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-			"integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^7.0.1",
-				"node-fetch": "^3.3.2",
-				"rimraf": "^5.0.1"
+				"node-fetch": "^3.3.2"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2822,8 +2602,8 @@
 			"version": "8.1.2",
 			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
 			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"gaxios": "^7.0.0",
 				"google-logging-utils": "^1.0.0",
@@ -2837,8 +2617,8 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
@@ -2847,10 +2627,26 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
 			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -2860,8 +2656,8 @@
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
 			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"basic-ftp": "^5.0.2",
 				"data-uri-to-buffer": "^6.0.2",
@@ -2875,8 +2671,8 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
 			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 14"
 			}
@@ -2885,8 +2681,8 @@
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
 			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"minimatch": "^10.2.2",
 				"minipass": "^7.1.3",
@@ -2900,18 +2696,17 @@
 			}
 		},
 		"node_modules/google-auth-library": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-			"integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
-				"gaxios": "^7.0.0",
-				"gcp-metadata": "^8.0.0",
-				"google-logging-utils": "^1.0.0",
-				"gtoken": "^8.0.0",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
 				"jws": "^4.0.0"
 			},
 			"engines": {
@@ -2922,8 +2717,8 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
 			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -2932,29 +2727,15 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/gtoken": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-			"integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"gaxios": "^7.0.0",
-				"jws": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2963,8 +2744,8 @@
 			"version": "10.7.3",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
 			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -2973,8 +2754,8 @@
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
 			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"lru-cache": "^11.1.0"
 			},
@@ -2986,8 +2767,8 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
 			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.0",
 				"debug": "^4.3.4"
@@ -3000,8 +2781,8 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
 			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "4"
@@ -3014,6 +2795,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3028,15 +2810,14 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3045,8 +2826,8 @@
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
 			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -3055,41 +2836,18 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
@@ -3098,8 +2856,8 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
 			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"ts-algebra": "^2.0.0"
@@ -3112,15 +2870,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
 			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
@@ -3131,20 +2889,21 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
 			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"jwa": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/koffi": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
-			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+			"version": "2.15.5",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.5.tgz",
+			"integrity": "sha512-4/35/oOpnH9tzrpWAC3ObjAERBSe0Q0Dh2NP1eBBPRGpohEj4vFw2+7tej9W9MTExvk0vtF0PjMqIGG4rf6feQ==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
+			"optional": true,
 			"funding": {
 				"url": "https://liberapay.com/Koromix"
 			}
@@ -3153,15 +2912,15 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"license": "Apache-2.0",
-			"peer": true
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/lru-cache": {
 			"version": "11.2.6",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
 			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -3170,8 +2929,8 @@
 			"version": "15.0.12",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
 			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -3183,8 +2942,8 @@
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
 			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -3193,8 +2952,8 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -3207,13 +2966,13 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-			"integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -3226,8 +2985,8 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -3236,15 +2995,15 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
 			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"any-promise": "^1.0.0",
 				"object-assign": "^4.0.1",
@@ -3252,11 +3011,11 @@
 			}
 		},
 		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.0.tgz",
+			"integrity": "sha512-z9sZrk6wyf8/NDKKqe+Tyl58XtgkYrV4kgt1O8xrzYvpl1LvPacPo0imMLHfpStk3kgCIq1ksJ2bmJn9hue2lQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4.0"
 			}
@@ -3266,6 +3025,7 @@
 			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
 			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
 			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3277,7 +3037,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.5.0"
 			}
@@ -3286,8 +3045,8 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
 			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
 				"fetch-blob": "^3.1.4",
@@ -3305,18 +3064,28 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
 		"node_modules/openai": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
-			"integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"openai": "bin/cli"
 			},
@@ -3337,8 +3106,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
 			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
@@ -3351,8 +3120,8 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
 			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@tootallnate/quickjs-emscripten": "^0.23.0",
 				"agent-base": "^7.1.2",
@@ -3371,8 +3140,8 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
 			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"degenerator": "^5.0.0",
 				"netmask": "^2.0.2"
@@ -3381,26 +3150,19 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"license": "BlueOak-1.0.0",
-			"peer": true
-		},
 		"node_modules/parse5": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
 			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/parse5-htmlparser2-tree-adapter": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
 			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"parse5": "^6.0.1"
 			}
@@ -3409,32 +3171,38 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/partial-json": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
 			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
-		"node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+		"node_modules/path-expression-matcher": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.3.0.tgz",
+			"integrity": "sha512-tkolHg8cWjEFA8+TqYGk0w6aNEZVcb7pVxW8KXZpU+ebaBr3s1ogbLssjK1cL74TtEuKl/qy6cb90RnwTFt3kw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/path-scurry": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
 			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"lru-cache": "^11.0.0",
 				"minipass": "^7.1.2"
@@ -3446,12 +3214,19 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/proper-lockfile": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
 			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"retry": "^0.12.0",
@@ -3462,8 +3237,8 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3472,9 +3247,9 @@
 			"version": "7.5.4",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
 			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -3497,8 +3272,8 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
 			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "^4.3.4",
@@ -3517,8 +3292,8 @@
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
 			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -3527,15 +3302,26 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3544,8 +3330,8 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3554,94 +3340,17 @@
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
 			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"glob": "^10.3.7"
-			},
-			"bin": {
-				"rimraf": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC",
-			"peer": true
-		},
-		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-			"integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^5.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/path-scurry": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-			"license": "BlueOak-1.0.0",
-			"peer": true,
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3656,45 +3365,21 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
+			"license": "MIT"
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"license": "ISC",
-			"peer": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/smart-buffer": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
@@ -3704,8 +3389,8 @@
 			"version": "2.8.7",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
 			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ip-address": "^10.0.1",
 				"smart-buffer": "^4.2.0"
@@ -3719,8 +3404,8 @@
 			"version": "8.0.5",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
 			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "^4.3.4",
@@ -3734,9 +3419,9 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3745,31 +3430,15 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -3783,22 +3452,8 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -3807,24 +3462,24 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/strtok3": {
 			"version": "10.3.4",
 			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
 			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
 			},
@@ -3840,8 +3495,8 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -3853,8 +3508,8 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
 			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"any-promise": "^1.0.0"
 			}
@@ -3863,8 +3518,8 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
 			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"thenify": ">= 3.1.0 < 4"
 			},
@@ -3876,8 +3531,8 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
 			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@borewit/text-codec": "^0.2.1",
 				"@tokenizer/token": "^0.3.0",
@@ -3895,15 +3550,15 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
 			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"peer": true
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
@@ -3923,8 +3578,8 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
 			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -3933,11 +3588,11 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+			"integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=20.18.1"
 			}
@@ -3946,31 +3601,15 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
 			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-			"license": "MIT",
-			"peer": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
 			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
 			"engines": {
 				"node": ">= 8"
 			}
@@ -3979,8 +3618,8 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -3993,31 +3632,19 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -4038,8 +3665,8 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -4048,8 +3675,8 @@
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
 			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -4064,8 +3691,8 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
 			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -4083,18 +3710,29 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		},
 		"node_modules/yoctocolors": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
 			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -4106,20 +3744,20 @@
 			"version": "4.3.6",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zod-to-json-schema": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"peerDependencies": {
-				"zod": "^3.25 || ^4"
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/extensions/pi-prism/package-lock.json
+++ b/extensions/pi-prism/package-lock.json
@@ -1,0 +1,4126 @@
+{
+	"name": "@e9n/pi-prism",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@e9n/pi-prism",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"typescript": "^5.9.3"
+			},
+			"peerDependencies": {
+				"@mariozechner/pi-coding-agent": "*",
+				"@mariozechner/pi-tui": "*",
+				"@sinclair/typebox": "*"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.995.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.995.0.tgz",
+			"integrity": "sha512-nI7tT11L9s34AKr95GHmxs6k2+3ie+rEOew2cXOwsMC9k/5aifrZwh0JjAkBop4FqbmS8n0ZjCKDjBZFY/0YxQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/credential-provider-node": "^3.972.10",
+				"@aws-sdk/eventstream-handler-node": "^3.972.5",
+				"@aws-sdk/middleware-eventstream": "^3.972.3",
+				"@aws-sdk/middleware-host-header": "^3.972.3",
+				"@aws-sdk/middleware-logger": "^3.972.3",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
+				"@aws-sdk/middleware-user-agent": "^3.972.11",
+				"@aws-sdk/middleware-websocket": "^3.972.6",
+				"@aws-sdk/region-config-resolver": "^3.972.3",
+				"@aws-sdk/token-providers": "3.995.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/util-endpoints": "3.995.0",
+				"@aws-sdk/util-user-agent-browser": "^3.972.3",
+				"@aws-sdk/util-user-agent-node": "^3.972.10",
+				"@smithy/config-resolver": "^4.4.6",
+				"@smithy/core": "^3.23.2",
+				"@smithy/eventstream-serde-browser": "^4.2.8",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.8",
+				"@smithy/eventstream-serde-node": "^4.2.8",
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/hash-node": "^4.2.8",
+				"@smithy/invalid-dependency": "^4.2.8",
+				"@smithy/middleware-content-length": "^4.2.8",
+				"@smithy/middleware-endpoint": "^4.4.16",
+				"@smithy/middleware-retry": "^4.4.33",
+				"@smithy/middleware-serde": "^4.2.9",
+				"@smithy/middleware-stack": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/node-http-handler": "^4.4.10",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.32",
+				"@smithy/util-defaults-mode-node": "^4.2.35",
+				"@smithy/util-endpoints": "^3.2.8",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-retry": "^4.2.8",
+				"@smithy/util-stream": "^4.5.12",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso": {
+			"version": "3.993.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.993.0.tgz",
+			"integrity": "sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/middleware-host-header": "^3.972.3",
+				"@aws-sdk/middleware-logger": "^3.972.3",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
+				"@aws-sdk/middleware-user-agent": "^3.972.11",
+				"@aws-sdk/region-config-resolver": "^3.972.3",
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/util-endpoints": "3.993.0",
+				"@aws-sdk/util-user-agent-browser": "^3.972.3",
+				"@aws-sdk/util-user-agent-node": "^3.972.9",
+				"@smithy/config-resolver": "^4.4.6",
+				"@smithy/core": "^3.23.2",
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/hash-node": "^4.2.8",
+				"@smithy/invalid-dependency": "^4.2.8",
+				"@smithy/middleware-content-length": "^4.2.8",
+				"@smithy/middleware-endpoint": "^4.4.16",
+				"@smithy/middleware-retry": "^4.4.33",
+				"@smithy/middleware-serde": "^4.2.9",
+				"@smithy/middleware-stack": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/node-http-handler": "^4.4.10",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.32",
+				"@smithy/util-defaults-mode-node": "^4.2.35",
+				"@smithy/util-endpoints": "^3.2.8",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-retry": "^4.2.8",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.993.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-endpoints": "^3.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.973.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.11.tgz",
+			"integrity": "sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/xml-builder": "^3.972.5",
+				"@smithy/core": "^3.23.2",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/signature-v4": "^5.3.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.9.tgz",
+			"integrity": "sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.11.tgz",
+			"integrity": "sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/node-http-handler": "^4.4.10",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-stream": "^4.5.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.9.tgz",
+			"integrity": "sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/credential-provider-env": "^3.972.9",
+				"@aws-sdk/credential-provider-http": "^3.972.11",
+				"@aws-sdk/credential-provider-login": "^3.972.9",
+				"@aws-sdk/credential-provider-process": "^3.972.9",
+				"@aws-sdk/credential-provider-sso": "^3.972.9",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.9",
+				"@aws-sdk/nested-clients": "3.993.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/credential-provider-imds": "^4.2.8",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.9.tgz",
+			"integrity": "sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/nested-clients": "3.993.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.10.tgz",
+			"integrity": "sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.9",
+				"@aws-sdk/credential-provider-http": "^3.972.11",
+				"@aws-sdk/credential-provider-ini": "^3.972.9",
+				"@aws-sdk/credential-provider-process": "^3.972.9",
+				"@aws-sdk/credential-provider-sso": "^3.972.9",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.9",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/credential-provider-imds": "^4.2.8",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.9.tgz",
+			"integrity": "sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.9.tgz",
+			"integrity": "sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.993.0",
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/token-providers": "3.993.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.993.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.993.0.tgz",
+			"integrity": "sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/nested-clients": "3.993.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.9.tgz",
+			"integrity": "sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/nested-clients": "3.993.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.5.tgz",
+			"integrity": "sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/eventstream-codec": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.3.tgz",
+			"integrity": "sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
+			"integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
+			"integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
+			"integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.11.tgz",
+			"integrity": "sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/util-endpoints": "3.993.0",
+				"@smithy/core": "^3.23.2",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.993.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-endpoints": "^3.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.6.tgz",
+			"integrity": "sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/util-format-url": "^3.972.3",
+				"@smithy/eventstream-codec": "^4.2.8",
+				"@smithy/eventstream-serde-browser": "^4.2.8",
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/signature-v4": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.993.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.993.0.tgz",
+			"integrity": "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/middleware-host-header": "^3.972.3",
+				"@aws-sdk/middleware-logger": "^3.972.3",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
+				"@aws-sdk/middleware-user-agent": "^3.972.11",
+				"@aws-sdk/region-config-resolver": "^3.972.3",
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/util-endpoints": "3.993.0",
+				"@aws-sdk/util-user-agent-browser": "^3.972.3",
+				"@aws-sdk/util-user-agent-node": "^3.972.9",
+				"@smithy/config-resolver": "^4.4.6",
+				"@smithy/core": "^3.23.2",
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/hash-node": "^4.2.8",
+				"@smithy/invalid-dependency": "^4.2.8",
+				"@smithy/middleware-content-length": "^4.2.8",
+				"@smithy/middleware-endpoint": "^4.4.16",
+				"@smithy/middleware-retry": "^4.4.33",
+				"@smithy/middleware-serde": "^4.2.9",
+				"@smithy/middleware-stack": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/node-http-handler": "^4.4.10",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.32",
+				"@smithy/util-defaults-mode-node": "^4.2.35",
+				"@smithy/util-endpoints": "^3.2.8",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-retry": "^4.2.8",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.993.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.993.0.tgz",
+			"integrity": "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-endpoints": "^3.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
+			"integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/config-resolver": "^4.4.6",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.995.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.995.0.tgz",
+			"integrity": "sha512-lYSadNdZZ513qCKoj/KlJ+PgCycL3n8ZNS37qLVFC0t7TbHzoxvGquu9aD2n9OCERAn43OMhQ7dXjYDYdjAXzA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/nested-clients": "3.995.0",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.995.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.995.0.tgz",
+			"integrity": "sha512-7gq9gismVhESiRsSt0eYe1y1b6jS20LqLk+e/YSyPmGi9yHdndHQLIq73RbEJnK/QPpkQGFqq70M1mI46M1HGw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.11",
+				"@aws-sdk/middleware-host-header": "^3.972.3",
+				"@aws-sdk/middleware-logger": "^3.972.3",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.3",
+				"@aws-sdk/middleware-user-agent": "^3.972.11",
+				"@aws-sdk/region-config-resolver": "^3.972.3",
+				"@aws-sdk/types": "^3.973.1",
+				"@aws-sdk/util-endpoints": "3.995.0",
+				"@aws-sdk/util-user-agent-browser": "^3.972.3",
+				"@aws-sdk/util-user-agent-node": "^3.972.10",
+				"@smithy/config-resolver": "^4.4.6",
+				"@smithy/core": "^3.23.2",
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/hash-node": "^4.2.8",
+				"@smithy/invalid-dependency": "^4.2.8",
+				"@smithy/middleware-content-length": "^4.2.8",
+				"@smithy/middleware-endpoint": "^4.4.16",
+				"@smithy/middleware-retry": "^4.4.33",
+				"@smithy/middleware-serde": "^4.2.9",
+				"@smithy/middleware-stack": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/node-http-handler": "^4.4.10",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-body-length-node": "^4.2.1",
+				"@smithy/util-defaults-mode-browser": "^4.3.32",
+				"@smithy/util-defaults-mode-node": "^4.2.35",
+				"@smithy/util-endpoints": "^3.2.8",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-retry": "^4.2.8",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.973.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
+			"integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.995.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.995.0.tgz",
+			"integrity": "sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-endpoints": "^3.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.3.tgz",
+			"integrity": "sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/querystring-builder": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.4",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
+			"integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
+			"integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/types": "^4.12.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.10.tgz",
+			"integrity": "sha512-LVXzICPlsheET+sE6tkcS47Q5HkSTrANIlqL1iFxGAY/wRQ236DX/PCAK56qMh9QJoXAfXfoRW0B0Og4R+X7Nw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.11",
+				"@aws-sdk/types": "^3.973.1",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
+			"integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"fast-xml-parser": "5.3.6",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+			"integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
+			"integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.42.0.tgz",
+			"integrity": "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+			"integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+				"@mariozechner/clipboard-darwin-universal": "0.3.2",
+				"@mariozechner/clipboard-darwin-x64": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+			"integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+			"integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+			"integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+			"integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+			"integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+			"integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+			"integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/jiti": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"std-env": "^3.10.0",
+				"yoctocolors": "^2.1.2"
+			},
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.54.0.tgz",
+			"integrity": "sha512-LsPoudpOJLj7JjSpjlAdLM5uA2iy8nP+4nA6Si1ASD3tMqXdjHzNaKNloGSODKJO+3O3yhwPMSbuk78CCnZteQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.54.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.54.0.tgz",
+			"integrity": "sha512-XHhMIbFFHCa4mbiYdttfhVg6r3VmFD5tAiW4tjnmf33FhLUCRd76bGMQRc4kLWXPKCi/U4nqAErvaGiZUY4B8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.73.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "1.10.0",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "6.10.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.54.0.tgz",
+			"integrity": "sha512-CO8uLmigLzzep2i5/f05dchyywDYDsqykLxpaMXbwDa/dDzsBRbuWoGQBOAsiGbcCMya6AT5nAggFFo4Aqy/+g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.54.0",
+				"@mariozechner/pi-ai": "^0.54.0",
+				"@mariozechner/pi-tui": "^0.54.0",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.1.1",
+				"proper-lockfile": "^4.1.2",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.54.0",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.54.0.tgz",
+			"integrity": "sha512-bvFlUohdxDvKcFeQM2xsd5twCGKWxVaYSlHCFljIW0KqMC4vU+/Ts4A1i9iDnm6Xe/MlueKvC0V09YeC8fLIHA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"koffi": "^2.9.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.10.0.tgz",
+			"integrity": "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==",
+			"peer": true,
+			"dependencies": {
+				"zod": "^3.20.0",
+				"zod-to-json-schema": "^3.24.1"
+			}
+		},
+		"node_modules/@mistralai/mistralai/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@smithy/abort-controller": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
+			"integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "4.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
+			"integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-config-provider": "^4.2.0",
+				"@smithy/util-endpoints": "^3.2.8",
+				"@smithy/util-middleware": "^4.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.23.2",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
+			"integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/middleware-serde": "^4.2.9",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-body-length-browser": "^4.2.0",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-stream": "^4.5.12",
+				"@smithy/util-utf8": "^4.2.0",
+				"@smithy/uuid": "^1.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
+			"integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.8.tgz",
+			"integrity": "sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.8.tgz",
+			"integrity": "sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.8.tgz",
+			"integrity": "sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.8.tgz",
+			"integrity": "sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.8.tgz",
+			"integrity": "sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-codec": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.9",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
+			"integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/querystring-builder": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-base64": "^4.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
+			"integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
+			"integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+			"integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
+			"integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
+			"integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.2",
+				"@smithy/middleware-serde": "^4.2.9",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"@smithy/url-parser": "^4.2.8",
+				"@smithy/util-middleware": "^4.2.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.4.33",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
+			"integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/service-error-classification": "^4.2.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-retry": "^4.2.8",
+				"@smithy/uuid": "^1.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
+			"integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
+			"integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
+			"integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/shared-ini-file-loader": "^4.4.3",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
+			"integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/abort-controller": "^4.2.8",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/querystring-builder": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
+			"integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+			"integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+			"integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-uri-escape": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
+			"integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
+			"integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
+			"integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.8",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+			"integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.0",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/util-middleware": "^4.2.8",
+				"@smithy/util-uri-escape": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.11.5",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
+			"integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.2",
+				"@smithy/middleware-endpoint": "^4.4.16",
+				"@smithy/middleware-stack": "^4.2.8",
+				"@smithy/protocol-http": "^5.3.8",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-stream": "^4.5.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+			"integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
+			"integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/querystring-parser": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+			"integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+			"integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+			"integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+			"integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+			"integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.32",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
+			"integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.35",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
+			"integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.6",
+				"@smithy/credential-provider-imds": "^4.2.8",
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/property-provider": "^4.2.8",
+				"@smithy/smithy-client": "^4.11.5",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
+			"integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+			"integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+			"integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
+			"integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/service-error-classification": "^4.2.8",
+				"@smithy/types": "^4.12.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "4.5.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
+			"integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^5.3.9",
+				"@smithy/node-http-handler": "^4.4.10",
+				"@smithy/types": "^4.12.0",
+				"@smithy/util-base64": "^4.3.0",
+				"@smithy/util-buffer-from": "^4.2.0",
+				"@smithy/util-hex-encoding": "^4.2.0",
+				"@smithy/util-utf8": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+			"integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+			"integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+			"integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/node": {
+			"version": "25.3.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+			"integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+			"integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+			"integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+			"integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/diff": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+			"integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"strnum": "^2.1.2"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
+			"integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+			"integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2",
+				"rimraf": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+			"integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.0.0",
+				"gcp-metadata": "^8.0.0",
+				"google-logging-utils": "^1.0.0",
+				"gtoken": "^8.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/gtoken": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+			"integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/koffi": {
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
+			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://liberapay.com/Koromix"
+			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/lru-cache": {
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+			"integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
+			"integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+			"integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25 || ^4"
+			}
+		}
+	}
+}

--- a/extensions/pi-prism/package-lock.json
+++ b/extensions/pi-prism/package-lock.json
@@ -8,16 +8,21 @@
 			"name": "@e9n/pi-prism",
 			"version": "0.1.0",
 			"license": "MIT",
+			"dependencies": {
+				"luxon": "^3.7.2"
+			},
 			"devDependencies": {
 				"@mariozechner/pi-coding-agent": "^0.65.2",
 				"@mariozechner/pi-tui": "^0.65.2",
 				"@sinclair/typebox": "^0.34.49",
+				"@types/luxon": "^3.7.1",
+				"luxon": "^3.6.1",
 				"typescript": "^5.9.3"
 			},
 			"peerDependencies": {
-				"@mariozechner/pi-coding-agent": "*",
-				"@mariozechner/pi-tui": "*",
-				"@sinclair/typebox": "*"
+				"@mariozechner/pi-coding-agent": ">=0.65.2",
+				"@mariozechner/pi-tui": ">=0.65.2",
+				"@sinclair/typebox": ">=0.34.0"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -1984,6 +1989,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/luxon": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+			"integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/mime-types": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -2923,6 +2935,16 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
+			}
+		},
+		"node_modules/luxon": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/marked": {

--- a/extensions/pi-prism/package.json
+++ b/extensions/pi-prism/package.json
@@ -26,10 +26,15 @@
 		"@mariozechner/pi-tui": ">=0.65.2",
 		"@sinclair/typebox": ">=0.34.0"
 	},
+	"dependencies": {
+		"luxon": "^3.7.2"
+	},
 	"devDependencies": {
 		"@mariozechner/pi-coding-agent": "^0.65.2",
 		"@mariozechner/pi-tui": "^0.65.2",
 		"@sinclair/typebox": "^0.34.49",
+		"@types/luxon": "^3.7.1",
+		"luxon": "^3.6.1",
 		"typescript": "^5.9.3"
 	},
 	"files": [

--- a/extensions/pi-prism/package.json
+++ b/extensions/pi-prism/package.json
@@ -22,11 +22,14 @@
 	"author": "Espen Nilsen <hi@e9n.dev>",
 	"license": "MIT",
 	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*",
-		"@mariozechner/pi-tui": "*",
-		"@sinclair/typebox": "*"
+		"@mariozechner/pi-coding-agent": ">=0.65.2",
+		"@mariozechner/pi-tui": ">=0.65.2",
+		"@sinclair/typebox": ">=0.34.0"
 	},
 	"devDependencies": {
+		"@mariozechner/pi-coding-agent": "^0.65.2",
+		"@mariozechner/pi-tui": "^0.65.2",
+		"@sinclair/typebox": "^0.34.49",
 		"typescript": "^5.9.3"
 	},
 	"files": [

--- a/extensions/pi-prism/package.json
+++ b/extensions/pi-prism/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@e9n/pi-prism",
+	"version": "0.1.0",
+	"description": "Configurable widget sidebar overlay for pi — operational dashboard in the TUI",
+	"type": "module",
+	"keywords": [
+		"pi-package"
+	],
+	"pi": {
+		"extensions": [
+			"./src/index.ts"
+		]
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/espennilsen/pi.git",
+		"directory": "extensions/pi-prism"
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit"
+	},
+	"author": "Espen Nilsen <hi@e9n.dev>",
+	"license": "MIT",
+	"peerDependencies": {
+		"@mariozechner/pi-coding-agent": "*",
+		"@mariozechner/pi-tui": "*",
+		"@sinclair/typebox": "*"
+	},
+	"devDependencies": {
+		"typescript": "^5.9.3"
+	},
+	"files": [
+		"CHANGELOG.md",
+		"README.md",
+		"package.json",
+		"src"
+	]
+}

--- a/extensions/pi-prism/src/helpers.ts
+++ b/extensions/pi-prism/src/helpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared helpers for pi-prism widgets.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface QueryResult {
+	rows: Record<string, unknown>[];
+}
+
+export type Q = (sql: string, params?: unknown[]) => Promise<QueryResult>;
+
+// ── DB Query Helper ──────────────────────────────────────────
+
+const ACTOR = "pi-prism";
+
+export function createQuery(events: ExtensionAPI["events"]): Q {
+	return (sql: string, params: unknown[] = []): Promise<QueryResult> =>
+		new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => reject(new Error("timeout")), 5000);
+			events.emit("kysely:query", {
+				actor: ACTOR,
+				input: { sql, params },
+				reply: (r: QueryResult) => {
+					clearTimeout(timeout);
+					resolve(r);
+				},
+				ack: (a: { ok: boolean; error?: string }) => {
+					if (!a.ok) {
+						clearTimeout(timeout);
+						reject(new Error(a.error));
+					}
+				},
+			});
+		});
+}
+
+// ── CLI Exec Helper ──────────────────────────────────────────
+
+export async function execCmd(cmd: string, cwd: string): Promise<string> {
+	const { exec } = await import("node:child_process");
+	const { promisify } = await import("node:util");
+	try {
+		const { stdout } = await promisify(exec)(cmd, { cwd, timeout: 5000 });
+		return stdout.trim();
+	} catch {
+		return "";
+	}
+}
+
+// ── Format Helpers ───────────────────────────────────────────
+
+export function pad(s: string, width: number): string {
+	const vis = visibleWidth(s);
+	if (vis >= width) return truncateToWidth(s, width);
+	return s + " ".repeat(width - vis);
+}
+
+export function fmtMoney(amount: number, cur = "NOK"): string {
+	const abs = Math.abs(amount);
+	return `${amount < 0 ? "-" : ""}${abs.toLocaleString("nb-NO", { maximumFractionDigits: 0 })} ${cur}`;
+}
+
+export function fmtDate(iso: string): string {
+	if (!iso) return "";
+	try {
+		return new Date(iso).toLocaleDateString("en-GB", { day: "numeric", month: "short", timeZone: "Europe/Oslo" });
+	} catch {
+		return iso.slice(0, 10);
+	}
+}
+
+export function fmtTime(iso: string): string {
+	if (!iso) return "     ";
+	try {
+		return new Date(iso).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Oslo" });
+	} catch {
+		return iso.slice(11, 16);
+	}
+}
+
+export function fmtAgo(ts: number): string {
+	const d = Date.now() - ts;
+	if (d < 60000) return "just now";
+	if (d < 3600000) return `${Math.floor(d / 60000)}m ago`;
+	return `${Math.floor(d / 3600000)}h ago`;
+}
+
+export function bar(ratio: number, width: number): string {
+	const r = Math.max(0, Math.min(1, ratio));
+	const f = Math.round(r * width);
+	return "█".repeat(f) + "░".repeat(width - f);
+}

--- a/extensions/pi-prism/src/helpers.ts
+++ b/extensions/pi-prism/src/helpers.ts
@@ -4,6 +4,7 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { DateTime } from "luxon";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -89,6 +90,18 @@ export async function execCmd(cmd: string, cwd: string): Promise<string> {
 	} catch {
 		return "";
 	}
+}
+
+// ── Luxon Date Helpers (DST-safe) ────────────────────────────
+
+/** Today's date in ISO format (YYYY-MM-DD), using Oslo timezone. */
+export function todayIso(): string {
+	return DateTime.now().setZone("Europe/Oslo").toISODate()!;
+}
+
+/** Date N days from now in ISO format (YYYY-MM-DD), using Oslo timezone. Handles DST correctly. */
+export function daysAheadIso(days: number): string {
+	return DateTime.now().setZone("Europe/Oslo").plus({ days }).toISODate()!;
 }
 
 // ── Format Helpers ───────────────────────────────────────────

--- a/extensions/pi-prism/src/helpers.ts
+++ b/extensions/pi-prism/src/helpers.ts
@@ -38,6 +38,46 @@ export function createQuery(events: ExtensionAPI["events"]): Q {
 		});
 }
 
+// ── Hub JSON-RPC Helper ──────────────────────────────────────
+
+export interface HubTask {
+	id: string;
+	title: string;
+	state: string;
+	priority: string;
+	project: string;
+	branch: string | null;
+	prUrl: string | null;
+	prNumber: number | null;
+	externalTaskId: string | null;
+	assignedAgentId: string | null;
+}
+
+/**
+ * Fire a JSON-RPC call to the A2A Hub pipeline API.
+ * Returns the result object, or null on error/timeout.
+ */
+export async function hubRpc(
+	rpcUrl: string,
+	apiKey: string,
+	method: string,
+	params: Record<string, unknown>,
+): Promise<Record<string, unknown> | null> {
+	try {
+		const res = await fetch(rpcUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", "X-API-Key": apiKey },
+			body: JSON.stringify({ jsonrpc: "2.0", method, params, id: 1 }),
+			signal: AbortSignal.timeout(8_000),
+		});
+		if (!res.ok) return null;
+		const data = (await res.json()) as { result?: Record<string, unknown>; error?: unknown };
+		return data.result ?? null;
+	} catch {
+		return null;
+	}
+}
+
 // ── CLI Exec Helper ──────────────────────────────────────────
 
 export async function execCmd(cmd: string, cwd: string): Promise<string> {

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -1,0 +1,122 @@
+/**
+ * pi-prism — Configurable widget sidebar overlay for pi.
+ *
+ * Right-anchored overlay (34% width) with a stack of user-chosen widgets.
+ * Auto-opens on session start; toggle with /prism or Ctrl+Shift+P.
+ *
+ * Configure via .pi/settings.json:
+ *   { "pi-prism": { "widgets": ["active-task", "today-calendar", "git-status", ...] } }
+ *
+ * Available widgets:
+ *   active-task, task-queue, git-status, today-calendar, week-calendar,
+ *   recent-ops, system-health, accounts, budget-bars, recent-txns,
+ *   reminders, recent-contacts, session-stats, clock
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { OverlayHandle, TUI } from "@mariozechner/pi-tui";
+import { Key } from "@mariozechner/pi-tui";
+import { resolveSettings, type PrismSettings } from "./settings.ts";
+import { WidgetSidebar } from "./sidebar.ts";
+import { WIDGET_FACTORIES, DEFAULT_WIDGETS, type Widget } from "./widgets/index.ts";
+
+const ACTOR = "pi-prism";
+
+export default function (pi: ExtensionAPI) {
+	// ── DB access grant ──────────────────────────────────────
+
+	pi.events.emit("kysely:grant", {
+		owner: "*",
+		grantee: ACTOR,
+		table: "*",
+		operations: ["select"],
+	});
+
+	let overlayHandle: OverlayHandle | null = null;
+	let isOpen = false;
+
+	// ── Build widgets from settings ──────────────────────────
+
+	function buildWidgets(settings: PrismSettings): Widget[] {
+		const ids = settings.widgets.length > 0
+			? settings.widgets.filter((id) => id in WIDGET_FACTORIES)
+			: DEFAULT_WIDGETS;
+
+		const widgets: Widget[] = [];
+		for (const id of ids) {
+			const factory = WIDGET_FACTORIES[id];
+			if (factory) widgets.push(factory());
+		}
+		return widgets;
+	}
+
+	// ── Toggle sidebar ───────────────────────────────────────
+
+	async function toggle(ctx: { hasUI: boolean; ui: any }) {
+		if (!ctx.hasUI) return;
+
+		// Toggle if already exists
+		if (overlayHandle && isOpen) {
+			overlayHandle.setHidden(true);
+			isOpen = false;
+			return;
+		}
+		if (overlayHandle && !isOpen) {
+			overlayHandle.setHidden(false);
+			isOpen = true;
+			return;
+		}
+
+		const cwd = process.cwd();
+		const settings = resolveSettings(cwd);
+		const widgets = buildWidgets(settings);
+
+		if (widgets.length === 0) return;
+
+		ctx.ui.custom(
+			(tui: TUI, theme: any, _kb: unknown, done: (v: undefined) => void) => {
+				return new WidgetSidebar(tui, theme, pi, cwd, widgets, () => {
+					isOpen = false;
+					done(undefined);
+					overlayHandle = null;
+				});
+			},
+			{
+				overlay: true,
+				overlayOptions: {
+					anchor: "right-center" as const,
+					width: "34%",
+					minWidth: 28,
+					maxHeight: "95%",
+					margin: { right: 1, top: 1, bottom: 1 },
+					visible: (termWidth: number) => termWidth >= 90,
+				},
+				onHandle: (handle: OverlayHandle) => {
+					overlayHandle = handle;
+					isOpen = true;
+				},
+			},
+		);
+	}
+
+	// ── Auto-launch on session start ─────────────────────────
+
+	pi.on("session_start", async (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		const settings = resolveSettings(process.cwd());
+		if (!settings.autoOpen) return;
+		setTimeout(() => toggle(ctx), 800);
+	});
+
+	// ── Command & shortcut ───────────────────────────────────
+
+	pi.registerCommand("prism", {
+		description: "Toggle Prism widget sidebar",
+		handler: async (_args, ctx) => toggle(ctx),
+	});
+
+	pi.registerShortcut(Key.ctrlShift("p"), {
+		description: "Toggle Prism sidebar",
+		handler: async (ctx) => toggle(ctx),
+	});
+}

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -140,13 +140,7 @@ export default function (pi: ExtensionAPI) {
 		autoOpenTimer = setTimeout(() => { autoOpenTimer = null; toggle(ctx); }, 800);
 	});
 
-	// ── Dispose sidebar on session end to stop the refresh timer ─
-
-	pi.on("session_end", async () => {
-		if (liveSidebar) {
-			liveSidebar.dispose();
-		}
-	});
+	// ── Dispose sidebar on session shutdown to stop the refresh timer ─
 
 	pi.on("session_shutdown", async () => {
 		if (autoOpenTimer) { clearTimeout(autoOpenTimer); autoOpenTimer = null; }

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -142,6 +142,12 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Dispose sidebar on session end to stop the refresh timer ─
 
+	pi.on("session_end", async () => {
+		if (liveSidebar) {
+			liveSidebar.dispose();
+		}
+	});
+
 	pi.on("session_shutdown", async () => {
 		if (autoOpenTimer) { clearTimeout(autoOpenTimer); autoOpenTimer = null; }
 		if (liveSidebar) {

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -34,6 +34,8 @@ export default function (pi: ExtensionAPI) {
 
 	let overlayHandle: OverlayHandle | null = null;
 	let isOpen = false;
+	/** Reference to the live sidebar instance — needed to dispose its timer on session end. */
+	let liveSidebar: import("./sidebar.ts").WidgetSidebar | null = null;
 
 	// ── Build widgets from settings ──────────────────────────
 
@@ -75,11 +77,14 @@ export default function (pi: ExtensionAPI) {
 
 		ctx.ui.custom(
 			(tui: TUI, theme: any, _kb: unknown, done: (v: undefined) => void) => {
-				return new WidgetSidebar(tui, theme, pi, cwd, widgets, () => {
+				const sidebar = new WidgetSidebar(tui, theme, pi, cwd, widgets, () => {
 					isOpen = false;
 					done(undefined);
 					overlayHandle = null;
+					liveSidebar = null;
 				});
+				liveSidebar = sidebar;
+				return sidebar;
 			},
 			{
 				overlay: true,
@@ -102,10 +107,28 @@ export default function (pi: ExtensionAPI) {
 	// ── Auto-launch on session start ─────────────────────────
 
 	pi.on("session_start", async (_event, ctx) => {
+		// Dispose any sidebar that survived from a previous session
+		if (liveSidebar) {
+			liveSidebar.dispose();
+			liveSidebar = null;
+			overlayHandle = null;
+			isOpen = false;
+		}
 		if (!ctx.hasUI) return;
 		const settings = resolveSettings(process.cwd());
 		if (!settings.autoOpen) return;
 		setTimeout(() => toggle(ctx), 800);
+	});
+
+	// ── Dispose sidebar on session end to stop the refresh timer ─
+
+	pi.on("session_shutdown", async () => {
+		if (liveSidebar) {
+			liveSidebar.dispose();
+			liveSidebar = null;
+			overlayHandle = null;
+			isOpen = false;
+		}
 	});
 
 	// ── Command & shortcut ───────────────────────────────────

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -107,9 +107,11 @@ export default function (pi: ExtensionAPI) {
 	// ── Auto-launch on session start ─────────────────────────
 
 	pi.on("session_start", async (_event, ctx) => {
-		// Dispose any sidebar that survived from a previous session
+		// Close any sidebar that survived from a previous session.
+		// close() calls both dispose() (stops the timer) and done() (pops the
+		// TUI overlay stack) so no ghost frame accumulates on restart.
 		if (liveSidebar) {
-			liveSidebar.dispose();
+			liveSidebar.close();
 			liveSidebar = null;
 			overlayHandle = null;
 			isOpen = false;
@@ -124,7 +126,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async () => {
 		if (liveSidebar) {
-			liveSidebar.dispose();
+			liveSidebar.close();
 			liveSidebar = null;
 			overlayHandle = null;
 			isOpen = false;

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -23,14 +23,28 @@ import { WIDGET_FACTORIES, DEFAULT_WIDGETS, type Widget } from "./widgets/index.
 const ACTOR = "pi-prism";
 
 export default function (pi: ExtensionAPI) {
-	// ── DB access grant ──────────────────────────────────────
+	// ── DB access grants (read-only, scoped to needed tables) ─────────────
+	//
+	// Enumerate exactly the tables each widget reads. A wildcard owner/table
+	// grant would expose vault credentials, auth tokens, and private notes.
 
-	pi.events.emit("kysely:grant", {
-		owner: "*",
-		grantee: ACTOR,
-		table: "*",
-		operations: ["select"],
-	});
+	const PRISM_GRANTS: { owner: string; tables: string[] }[] = [
+		{ owner: "pi-jobs",         tables: ["jobs", "tool_calls"] },
+		{ owner: "pi-myfinance",    tables: ["finance_transactions", "finance_accounts", "finance_budgets", "finance_categories"] },
+		{ owner: "pi-personal-crm", tables: ["crm_contacts", "crm_companies", "crm_reminders"] },
+		{ owner: "pi-calendar",     tables: ["calendar_events"] },
+	];
+
+	for (const { owner, tables } of PRISM_GRANTS) {
+		for (const table of tables) {
+			pi.events.emit("kysely:grant", {
+				owner,
+				grantee: ACTOR,
+				table,
+				operations: ["select"],
+			});
+		}
+	}
 
 	let overlayHandle: OverlayHandle | null = null;
 	let isOpen = false;

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -30,7 +30,7 @@ export default function (pi: ExtensionAPI) {
 
 	const PRISM_GRANTS: { owner: string; tables: string[] }[] = [
 		{ owner: "pi-jobs",         tables: ["jobs", "tool_calls"] },
-		{ owner: "pi-myfinance",    tables: ["finance_transactions", "finance_accounts", "finance_budgets", "finance_categories"] },
+		{ owner: "pi-myfinance",    tables: ["finance_transactions", "finance_accounts", "finance_budgets", "finance_categories", "finance_vendors"] },
 		{ owner: "pi-personal-crm", tables: ["crm_contacts", "crm_companies", "crm_reminders"] },
 		{ owner: "pi-calendar",     tables: ["calendar_events"] },
 	];
@@ -50,6 +50,8 @@ export default function (pi: ExtensionAPI) {
 	let isOpen = false;
 	/** Reference to the live sidebar instance — needed to dispose its timer on session end. */
 	let liveSidebar: import("./sidebar.ts").WidgetSidebar | null = null;
+	/** Auto-open timer — stored so it can be cancelled if session_shutdown fires first. */
+	let autoOpenTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// ── Build widgets from settings ──────────────────────────
 
@@ -121,6 +123,8 @@ export default function (pi: ExtensionAPI) {
 	// ── Auto-launch on session start ─────────────────────────
 
 	pi.on("session_start", async (_event, ctx) => {
+		// Cancel any pending auto-open from a previous session
+		if (autoOpenTimer) { clearTimeout(autoOpenTimer); autoOpenTimer = null; }
 		// Close any sidebar that survived from a previous session.
 		// close() calls both dispose() (stops the timer) and done() (pops the
 		// TUI overlay stack) so no ghost frame accumulates on restart.
@@ -133,12 +137,13 @@ export default function (pi: ExtensionAPI) {
 		if (!ctx.hasUI) return;
 		const settings = resolveSettings(process.cwd());
 		if (!settings.autoOpen) return;
-		setTimeout(() => toggle(ctx), 800);
+		autoOpenTimer = setTimeout(() => { autoOpenTimer = null; toggle(ctx); }, 800);
 	});
 
 	// ── Dispose sidebar on session end to stop the refresh timer ─
 
 	pi.on("session_shutdown", async () => {
+		if (autoOpenTimer) { clearTimeout(autoOpenTimer); autoOpenTimer = null; }
 		if (liveSidebar) {
 			liveSidebar.close();
 			liveSidebar = null;

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -77,11 +77,13 @@ export default function (pi: ExtensionAPI) {
 		if (overlayHandle && isOpen) {
 			overlayHandle.setHidden(true);
 			isOpen = false;
+			if (liveSidebar) liveSidebar.pause();
 			return;
 		}
 		if (overlayHandle && !isOpen) {
 			overlayHandle.setHidden(false);
 			isOpen = true;
+			if (liveSidebar) liveSidebar.resume();
 			return;
 		}
 

--- a/extensions/pi-prism/src/settings.ts
+++ b/extensions/pi-prism/src/settings.ts
@@ -1,0 +1,30 @@
+/**
+ * Settings loader for pi-prism.
+ */
+
+import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+
+export interface PrismSettings {
+	/** Widget IDs to show (order matters). */
+	widgets: string[];
+	/** Auto-open sidebar on session start (default: true). */
+	autoOpen: boolean;
+}
+
+const DEFAULTS: PrismSettings = {
+	widgets: [],
+	autoOpen: true,
+};
+
+export function resolveSettings(cwd: string): PrismSettings {
+	const agentDir = getAgentDir();
+	const sm = SettingsManager.create(cwd, agentDir);
+	const global = (sm.getGlobalSettings() as Record<string, any>)?.["pi-prism"] ?? {};
+	const project = (sm.getProjectSettings() as Record<string, any>)?.["pi-prism"] ?? {};
+	const merged = { ...global, ...project };
+
+	return {
+		widgets: Array.isArray(merged.widgets) ? merged.widgets : DEFAULTS.widgets,
+		autoOpen: typeof merged.autoOpen === "boolean" ? merged.autoOpen : DEFAULTS.autoOpen,
+	};
+}

--- a/extensions/pi-prism/src/settings.ts
+++ b/extensions/pi-prism/src/settings.ts
@@ -9,22 +9,45 @@ export interface PrismSettings {
 	widgets: string[];
 	/** Auto-open sidebar on session start (default: true). */
 	autoOpen: boolean;
+	/** Hub JSON-RPC URL (read from pi-a2a.hub.url). */
+	hubUrl: string | null;
+	/** Hub API key (read from pi-a2a.hub.apiKey). */
+	hubApiKey: string | null;
+	/** Optional project filter for hub task widgets. */
+	project: string | null;
 }
 
 const DEFAULTS: PrismSettings = {
 	widgets: [],
 	autoOpen: true,
+	hubUrl: null,
+	hubApiKey: null,
+	project: null,
 };
 
 export function resolveSettings(cwd: string): PrismSettings {
 	const agentDir = getAgentDir();
 	const sm = SettingsManager.create(cwd, agentDir);
-	const global = (sm.getGlobalSettings() as Record<string, any>)?.["pi-prism"] ?? {};
+	const globalRaw = sm.getGlobalSettings() as Record<string, any>;
+	const global = globalRaw?.["pi-prism"] ?? {};
 	const project = (sm.getProjectSettings() as Record<string, any>)?.["pi-prism"] ?? {};
 	const merged = { ...global, ...project };
+
+	// Read Hub config from pi-a2a settings (global + project, project wins)
+	const a2aGlobal = globalRaw?.["pi-a2a"] ?? {};
+	const a2aProject = (sm.getProjectSettings() as Record<string, any>)?.["pi-a2a"] ?? {};
+	const a2aMerged = { ...a2aGlobal, ...a2aProject };
+	const hubCfg = a2aMerged?.hub ?? {};
+	const rawHubUrl: string | null = typeof hubCfg.url === "string" ? hubCfg.url : null;
+	// Normalise: RPC endpoint is at <baseUrl>/rpc
+	const hubUrl = rawHubUrl ? `${rawHubUrl.replace(/\/$/, "")}/rpc` : null;
+	const hubApiKey: string | null = typeof hubCfg.apiKey === "string" ? hubCfg.apiKey : null;
 
 	return {
 		widgets: Array.isArray(merged.widgets) ? merged.widgets : DEFAULTS.widgets,
 		autoOpen: typeof merged.autoOpen === "boolean" ? merged.autoOpen : DEFAULTS.autoOpen,
+		hubUrl,
+		hubApiKey,
+		project: typeof merged.project === "string" ? merged.project : null,
 	};
 }

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -29,6 +29,8 @@ export class WidgetSidebar {
 	private lastRefresh = 0;
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private disposed = false;
+	private paused = false;
+	private refreshing = false;
 
 	// Cache
 	private cache: string[] = [];
@@ -53,9 +55,12 @@ export class WidgetSidebar {
 
 	private async refresh(): Promise<void> {
 		if (this.disposed) return;
+		if (this.paused) return;
+		if (this.refreshing) return;
+		this.refreshing = true;
 		this.loading = true;
 		this.ver++;
-		this.tui.requestRender();
+		if (!this.disposed) this.tui.requestRender();
 
 		const ctx: WidgetContext = {
 			query: this.query,
@@ -70,10 +75,12 @@ export class WidgetSidebar {
 		this.loading = false;
 		this.lastRefresh = Date.now();
 		this.ver++;
+		this.refreshing = false;
 		this.tui.requestRender();
 	}
 
 	handleInput(data: string): void {
+		if (this.disposed) return;
 		if (matchesKey(data, Key.escape) || data === "q" || data === "Q") {
 			this.dispose();
 			this.done();
@@ -90,7 +97,12 @@ export class WidgetSidebar {
 			this.tui.requestRender();
 		}
 		if (data === "r" || data === "R") {
-			this.refresh();
+			this.refresh().catch(() => {});
+		}
+		if (data === "h" || data === "H") {
+			this.paused = !this.paused;
+			this.ver++;
+			this.tui.requestRender();
 		}
 	}
 
@@ -147,10 +159,11 @@ export class WidgetSidebar {
 
 		// ── Footer ──
 		lines.push(sep());
-		const keys = `${th.fg("muted", "j/k")} scroll ${th.fg("muted", "│ r")} refresh ${th.fg("muted", "│ q")} close`;
+		const keys = `${th.fg("muted", "j/k")} scroll ${th.fg("muted", "│ r")} refresh ${th.fg("muted", "│ h")} pause ${th.fg("muted", "│ q")} close`;
 		lines.push(row(` ${keys}`));
 		if (this.lastRefresh) {
-			lines.push(row(` ${th.fg("dim", fmtAgo(this.lastRefresh))} ${th.fg("dim", `· ${this.widgets.length} widgets`)}`));
+			const pauseStatus = this.paused ? th.fg("warning", " │ PAUSED") : "";
+			lines.push(row(` ${th.fg("dim", fmtAgo(this.lastRefresh))} ${th.fg("dim", `· ${this.widgets.length} widgets`)}${pauseStatus}`));
 		}
 		lines.push(bdr("╰" + "─".repeat(innerW) + "╯"));
 

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -160,11 +160,25 @@ export class WidgetSidebar {
 		this.cacheVer = -1;
 	}
 
+	/**
+	 * Stop the refresh timer and release resources.
+	 * Does NOT signal the TUI to pop the overlay — use close() for that.
+	 */
 	dispose(): void {
 		this.disposed = true;
 		if (this.timer) {
 			clearInterval(this.timer);
 			this.timer = null;
 		}
+	}
+
+	/**
+	 * Close the sidebar: stop the timer AND signal the TUI to pop the overlay.
+	 * Call this from session_start / session_shutdown instead of dispose()
+	 * so the TUI stack stays consistent and no ghost frame is left behind.
+	 */
+	close(): void {
+		this.dispose();
+		this.done();
 	}
 }

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -179,6 +179,23 @@ export class WidgetSidebar {
 	}
 
 	/**
+	 * Pause the refresh timer — stops background data fetches while hidden.
+	 */
+	pause(): void {
+		this.paused = true;
+		this.ver++;
+		this.tui.requestRender();
+	}
+
+	/**
+	 * Resume the refresh timer — restarts data fetches when shown again.
+	 */
+	resume(): void {
+		this.paused = false;
+		this.refresh().catch(() => {});
+	}
+
+	/**
 	 * Stop the refresh timer and release resources.
 	 * Does NOT signal the TUI to pop the overlay — use close() for that.
 	 */

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -1,0 +1,156 @@
+/**
+ * WidgetSidebar — the main TUI overlay component for Prism.
+ *
+ * Renders a bordered panel with stacked widgets, handles scrolling,
+ * refresh, and keyboard input.
+ */
+
+import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
+import type { TUI } from "@mariozechner/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth, Key } from "@mariozechner/pi-tui";
+import { createQuery, fmtAgo, type Q } from "./helpers.ts";
+import type { Widget, WidgetContext } from "./widgets/index.ts";
+
+export class WidgetSidebar {
+	private tui: TUI;
+	private theme: Theme;
+	private query: Q;
+	private cwd: string;
+	private done: () => void;
+	private widgets: Widget[] = [];
+
+	private scroll = 0;
+	private maxScroll = 0;
+	private loading = true;
+	private lastRefresh = 0;
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private disposed = false;
+
+	// Cache
+	private cache: string[] = [];
+	private cacheW = 0;
+	private ver = 0;
+	private cacheVer = -1;
+
+	constructor(tui: TUI, theme: Theme, pi: ExtensionAPI, cwd: string, widgets: Widget[], done: () => void) {
+		this.tui = tui;
+		this.theme = theme;
+		this.query = createQuery(pi.events);
+		this.cwd = cwd;
+		this.widgets = widgets;
+		this.done = done;
+		this.refresh();
+		this.timer = setInterval(() => this.refresh(), 60000);
+	}
+
+	private async refresh(): Promise<void> {
+		if (this.disposed) return;
+		this.loading = true;
+		this.ver++;
+		this.tui.requestRender();
+
+		const ctx: WidgetContext = { query: this.query, cwd: this.cwd };
+		await Promise.all(this.widgets.map((w) => w.refresh(ctx).catch(() => {})));
+
+		if (this.disposed) return;
+		this.loading = false;
+		this.lastRefresh = Date.now();
+		this.ver++;
+		this.tui.requestRender();
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.escape) || data === "q" || data === "Q") {
+			this.dispose();
+			this.done();
+			return;
+		}
+		if ((matchesKey(data, Key.down) || data === "j") && this.scroll < this.maxScroll) {
+			this.scroll++;
+			this.ver++;
+			this.tui.requestRender();
+		}
+		if ((matchesKey(data, Key.up) || data === "k") && this.scroll > 0) {
+			this.scroll--;
+			this.ver++;
+			this.tui.requestRender();
+		}
+		if (data === "r" || data === "R") {
+			this.refresh();
+		}
+	}
+
+	render(width: number): string[] {
+		if (width === this.cacheW && this.cacheVer === this.ver) return this.cache;
+
+		const th = this.theme;
+		const w = Math.max(24, width);
+		const innerW = w - 2;
+		const lines: string[] = [];
+
+		const bdr = (c: string) => th.fg("border", c);
+		const padLine = (s: string) => truncateToWidth(s, innerW, "...", true);
+		const row = (s: string) => bdr("│") + padLine(s) + bdr("│");
+		const sep = () => bdr("├" + "─".repeat(innerW) + "┤");
+
+		// ── Header ──
+		const title = th.fg("accent", th.bold(" ◈ PRISM"));
+		const spin = this.loading ? th.fg("warning", " ⟳") : "";
+		const date = th.fg("muted",
+			new Date().toLocaleDateString("en-GB", { timeZone: "Europe/Oslo", weekday: "short", day: "numeric", month: "short" }) + " ",
+		);
+		const headerGap = Math.max(1, innerW - visibleWidth(title) - visibleWidth(spin) - visibleWidth(date));
+		lines.push(bdr("╭" + "─".repeat(innerW) + "╮"));
+		lines.push(bdr("│") + truncateToWidth(title + spin + " ".repeat(headerGap) + date, innerW) + bdr("│"));
+
+		// ── Widgets ──
+		const SEP_TAG = "\x00SEP";
+		const content: string[] = [];
+		for (let i = 0; i < this.widgets.length; i++) {
+			if (i > 0) content.push(SEP_TAG);
+			content.push(th.bold(` ${this.widgets[i].icon} ${th.fg("accent", this.widgets[i].label.toUpperCase())}`));
+			const widgetLines = this.widgets[i].render(innerW, th);
+			content.push(...widgetLines);
+		}
+
+		// Apply scroll
+		const maxVisible = 40;
+		this.maxScroll = Math.max(0, content.length - maxVisible);
+		const visible = content.slice(this.scroll, this.scroll + maxVisible);
+
+		for (const line of visible) {
+			if (line === SEP_TAG) {
+				lines.push(sep());
+			} else {
+				lines.push(row(line));
+			}
+		}
+
+		// ── Footer ──
+		lines.push(sep());
+		const keys = `${th.fg("muted", "j/k")} scroll ${th.fg("muted", "│ r")} refresh ${th.fg("muted", "│ q")} close`;
+		lines.push(row(` ${keys}`));
+		if (this.lastRefresh) {
+			lines.push(row(` ${th.fg("dim", fmtAgo(this.lastRefresh))} ${th.fg("dim", `· ${this.widgets.length} widgets`)}`));
+		}
+		lines.push(bdr("╰" + "─".repeat(innerW) + "╯"));
+
+		this.cache = lines;
+		this.cacheW = width;
+		this.cacheVer = this.ver;
+		return lines;
+	}
+
+	invalidate(): void {
+		this.cacheW = 0;
+		this.cacheVer = -1;
+	}
+
+	dispose(): void {
+		this.disposed = true;
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+	}
+}

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -127,8 +127,12 @@ export class WidgetSidebar {
 			content.push(...widgetLines);
 		}
 
-		// Apply scroll
-		const maxVisible = 40;
+		// Apply scroll — compute visible rows from terminal height so scrolling
+		// works on small terminals. Overlay is capped at ~95% of terminal rows;
+		// subtract header (2) + footer (4) to get the content viewport.
+		const termRows = this.tui.terminal.rows;
+		const overlayRows = Math.floor(termRows * 0.95);
+		const maxVisible = Math.max(8, overlayRows - 6);
 		this.maxScroll = Math.max(0, content.length - maxVisible);
 		const visible = content.slice(this.scroll, this.scroll + maxVisible);
 

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -47,8 +47,8 @@ export class WidgetSidebar {
 		this.hubUrl = settings.hubUrl;
 		this.hubApiKey = settings.hubApiKey;
 		this.project = settings.project;
-		this.refresh();
-		this.timer = setInterval(() => this.refresh(), 60000);
+		this.refresh().catch(() => {});
+		this.timer = setInterval(() => this.refresh().catch(() => {}), 60000);
 	}
 
 	private async refresh(): Promise<void> {
@@ -134,6 +134,7 @@ export class WidgetSidebar {
 		const overlayRows = Math.floor(termRows * 0.95);
 		const maxVisible = Math.max(8, overlayRows - 6);
 		this.maxScroll = Math.max(0, content.length - maxVisible);
+		this.scroll = Math.min(this.scroll, this.maxScroll);
 		const visible = content.slice(this.scroll, this.scroll + maxVisible);
 
 		for (const line of visible) {

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -9,6 +9,7 @@ import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
 import type { TUI } from "@mariozechner/pi-tui";
 import { matchesKey, truncateToWidth, visibleWidth, Key } from "@mariozechner/pi-tui";
 import { createQuery, fmtAgo, type Q } from "./helpers.ts";
+import { resolveSettings } from "./settings.ts";
 import type { Widget, WidgetContext } from "./widgets/index.ts";
 
 export class WidgetSidebar {
@@ -16,6 +17,9 @@ export class WidgetSidebar {
 	private theme: Theme;
 	private query: Q;
 	private cwd: string;
+	private hubUrl: string | null;
+	private hubApiKey: string | null;
+	private project: string | null;
 	private done: () => void;
 	private widgets: Widget[] = [];
 
@@ -39,6 +43,10 @@ export class WidgetSidebar {
 		this.cwd = cwd;
 		this.widgets = widgets;
 		this.done = done;
+		const settings = resolveSettings(cwd);
+		this.hubUrl = settings.hubUrl;
+		this.hubApiKey = settings.hubApiKey;
+		this.project = settings.project;
 		this.refresh();
 		this.timer = setInterval(() => this.refresh(), 60000);
 	}
@@ -49,7 +57,13 @@ export class WidgetSidebar {
 		this.ver++;
 		this.tui.requestRender();
 
-		const ctx: WidgetContext = { query: this.query, cwd: this.cwd };
+		const ctx: WidgetContext = {
+			query: this.query,
+			cwd: this.cwd,
+			hubUrl: this.hubUrl,
+			hubApiKey: this.hubApiKey,
+			project: this.project,
+		};
 		await Promise.all(this.widgets.map((w) => w.refresh(ctx).catch(() => {})));
 
 		if (this.disposed) return;

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -71,7 +71,11 @@ export class WidgetSidebar {
 		};
 		await Promise.all(this.widgets.map((w) => w.refresh(ctx).catch(() => {})));
 
-		if (this.disposed) return;
+		if (this.disposed) {
+			this.refreshing = false;
+			this.loading = false;
+			return;
+		}
 		this.loading = false;
 		this.lastRefresh = Date.now();
 		this.ver++;

--- a/extensions/pi-prism/src/widgets/accounts.ts
+++ b/extensions/pi-prism/src/widgets/accounts.ts
@@ -1,0 +1,33 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { fmtMoney, pad } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class AccountsWidget implements Widget {
+	readonly id = "accounts";
+	readonly label = "Accounts";
+	readonly icon = "💳";
+	private accounts: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		try {
+			this.accounts = (await ctx.query(`SELECT name, currency, balance FROM finance_accounts ORDER BY name ASC`)).rows;
+		} catch {
+			this.accounts = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.accounts.length === 0) return [th.fg("muted", "  no accounts")];
+		const out: string[] = [];
+		for (const a of this.accounts) {
+			const name = String(a.name ?? "?");
+			const bal = Number(a.balance ?? 0);
+			const cur = String(a.currency ?? "NOK");
+			const balStr = bal >= 0 ? th.fg("success", fmtMoney(bal, cur)) : th.fg("error", fmtMoney(bal, cur));
+			const nameW = Math.max(8, w - visibleWidth(balStr) - 3);
+			out.push(` ${pad(truncateToWidth(name, nameW), nameW)} ${balStr}`);
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/active-task.ts
+++ b/extensions/pi-prism/src/widgets/active-task.ts
@@ -1,0 +1,30 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { execCmd } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class ActiveTaskWidget implements Widget {
+	readonly id = "active-task";
+	readonly label = "Active Task";
+	readonly icon = "🎯";
+	private lines: string[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const raw = await execCmd("td status 2>/dev/null", ctx.cwd);
+		this.lines = raw ? raw.split("\n").slice(0, 8) : [];
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.lines.length === 0) return [th.fg("muted", "  no active task")];
+		const out: string[] = [];
+		for (const l of this.lines) {
+			let s = l;
+			if (/\[WIP\]|\[PROGRESS\]/i.test(l)) s = th.fg("warning", l);
+			else if (/\[DONE\]|\[CLOSED\]|\[APPROVED\]/i.test(l)) s = th.fg("success", l);
+			else if (/\[BLOCKED\]/i.test(l)) s = th.fg("error", l);
+			else if (/branch:|session:/i.test(l)) s = th.fg("muted", l);
+			out.push(truncateToWidth(` ${s}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/active-task.ts
+++ b/extensions/pi-prism/src/widgets/active-task.ts
@@ -26,23 +26,26 @@ export class ActiveTaskWidget implements Widget {
 			return;
 		}
 
-		// Fetch tasks in active states — building first, then reviewing / pr_ready
-		const result = await hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", {
-			...(ctx.project ? { project: ctx.project } : {}),
-			limit: 3,
-		});
+		// Fetch each active state separately so pagination doesn't hide results.
+		// A single tasks.list call with no state filter could return limit rows
+		// of queued/planning tasks, silently missing building/reviewing tasks.
+		const projectFilter = ctx.project ? { project: ctx.project } : {};
+		const [buildingRes, reviewingRes, prReadyRes] = await Promise.all([
+			hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", { ...projectFilter, state: "building", limit: 2 }),
+			hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", { ...projectFilter, state: "reviewing", limit: 1 }),
+			hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", { ...projectFilter, state: "pr_ready", limit: 1 }),
+		]);
 
-		if (!result) {
+		if (!buildingRes && !reviewingRes && !prReadyRes) {
 			this.error = "hub unreachable";
 			return;
 		}
 
-		const all = ((result.tasks as HubTask[]) ?? []);
-		// Filter to active states, prefer building
-		const active = all.filter((t) =>
-			["building", "reviewing", "pr_ready"].includes(t.state),
-		);
-		this.tasks = active.slice(0, 2);
+		// building first (highest urgency), then reviewing, then pr_ready
+		const building: HubTask[] = (buildingRes?.tasks as HubTask[]) ?? [];
+		const reviewing: HubTask[] = (reviewingRes?.tasks as HubTask[]) ?? [];
+		const prReady: HubTask[] = (prReadyRes?.tasks as HubTask[]) ?? [];
+		this.tasks = [...building, ...reviewing, ...prReady].slice(0, 2);
 	}
 
 	render(w: number, th: Theme): string[] {

--- a/extensions/pi-prism/src/widgets/active-task.ts
+++ b/extensions/pi-prism/src/widgets/active-task.ts
@@ -1,29 +1,74 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { execCmd } from "../helpers.ts";
+import { hubRpc, type HubTask } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
+
+const STATE_ICON: Record<string, string> = {
+	building: "🔨",
+	reviewing: "👀",
+	pr_ready: "🚀",
+	planning: "📐",
+};
 
 export class ActiveTaskWidget implements Widget {
 	readonly id = "active-task";
 	readonly label = "Active Task";
 	readonly icon = "🎯";
-	private lines: string[] = [];
+	private tasks: HubTask[] = [];
+	private error: string | null = null;
 
 	async refresh(ctx: WidgetContext): Promise<void> {
-		const raw = await execCmd("td status 2>/dev/null", ctx.cwd);
-		this.lines = raw ? raw.split("\n").slice(0, 8) : [];
+		this.tasks = [];
+		this.error = null;
+
+		if (!ctx.hubUrl || !ctx.hubApiKey) {
+			this.error = "hub not configured";
+			return;
+		}
+
+		// Fetch tasks in active states — building first, then reviewing / pr_ready
+		const result = await hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", {
+			...(ctx.project ? { project: ctx.project } : {}),
+			limit: 3,
+		});
+
+		if (!result) {
+			this.error = "hub unreachable";
+			return;
+		}
+
+		const all = ((result.tasks as HubTask[]) ?? []);
+		// Filter to active states, prefer building
+		const active = all.filter((t) =>
+			["building", "reviewing", "pr_ready"].includes(t.state),
+		);
+		this.tasks = active.slice(0, 2);
 	}
 
 	render(w: number, th: Theme): string[] {
-		if (this.lines.length === 0) return [th.fg("muted", "  no active task")];
+		if (this.error) return [th.fg("muted", `  ${this.error}`)];
+		if (this.tasks.length === 0) return [th.fg("muted", "  no active task")];
+
 		const out: string[] = [];
-		for (const l of this.lines) {
-			let s = l;
-			if (/\[WIP\]|\[PROGRESS\]/i.test(l)) s = th.fg("warning", l);
-			else if (/\[DONE\]|\[CLOSED\]|\[APPROVED\]/i.test(l)) s = th.fg("success", l);
-			else if (/\[BLOCKED\]/i.test(l)) s = th.fg("error", l);
-			else if (/branch:|session:/i.test(l)) s = th.fg("muted", l);
-			out.push(truncateToWidth(` ${s}`, w));
+		for (const task of this.tasks) {
+			const icon = STATE_ICON[task.state] ?? "▸";
+			const stateColor = task.state === "building" ? "warning"
+				: task.state === "pr_ready" ? "success"
+				: "accent";
+			const stateLabel = th.fg(stateColor, `[${task.state}]`);
+			const title = task.title.length > 38 ? task.title.slice(0, 35) + "…" : task.title;
+			out.push(truncateToWidth(` ${icon} ${stateLabel} ${title}`, w));
+
+			if (task.project) {
+				out.push(truncateToWidth(`   ${th.fg("muted", `project: ${task.project}`)}`, w));
+			}
+			if (task.branch) {
+				out.push(truncateToWidth(`   ${th.fg("muted", `branch:  ${task.branch}`)}`, w));
+			}
+			if (task.prNumber) {
+				const prLine = `   ${th.fg("accent", `PR #${task.prNumber}`)}${task.prUrl ? th.fg("muted", ` · ${task.prUrl}`) : ""}`;
+				out.push(truncateToWidth(prLine, w));
+			}
 		}
 		return out;
 	}

--- a/extensions/pi-prism/src/widgets/budget-bars.ts
+++ b/extensions/pi-prism/src/widgets/budget-bars.ts
@@ -1,0 +1,54 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { bar, pad } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class BudgetBarsWidget implements Widget {
+	readonly id = "budget-bars";
+	readonly label = "Budget";
+	readonly icon = "📊";
+	private budgets: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const now = new Date();
+		const m = now.getMonth() + 1;
+		const y = now.getFullYear();
+		const ms = String(m).padStart(2, "0");
+		const ys = String(y);
+		try {
+			this.budgets = (
+				await ctx.query(
+					`SELECT b.id, c.name as category, c.icon, b.amount as budget_amount,
+					COALESCE((
+						SELECT SUM(t.amount) FROM finance_transactions t
+						WHERE t.category_id = b.category_id AND t.transaction_type = 'out'
+						AND strftime('%m', t.date) = ? AND strftime('%Y', t.date) = ?
+					), 0) as spent
+					FROM finance_budgets b JOIN finance_categories c ON b.category_id = c.id
+					WHERE b.month = ? AND b.year = ? ORDER BY b.amount DESC LIMIT 8`,
+					[ms, ys, m, y],
+				)
+			).rows;
+		} catch {
+			this.budgets = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.budgets.length === 0) return [th.fg("muted", "  no budgets this month")];
+		const barW = Math.max(6, Math.min(12, w - 18));
+		const out: string[] = [];
+		for (const b of this.budgets) {
+			const cat = String(b.category ?? "?");
+			const icon = b.icon ? `${b.icon} ` : "";
+			const budget = Number(b.budget_amount ?? 0);
+			const spent = Number(b.spent ?? 0);
+			const ratio = budget > 0 ? spent / budget : 0;
+			const pct = Math.round(ratio * 100);
+			const color: "error" | "warning" | "success" = ratio > 0.9 ? "error" : ratio > 0.7 ? "warning" : "success";
+			const labelW = Math.max(6, w - barW - 8);
+			out.push(` ${pad(truncateToWidth(`${icon}${cat}`, labelW), labelW)} ${th.fg(color, bar(ratio, barW))} ${th.fg(color, `${pct}%`)}`);
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/clock.ts
+++ b/extensions/pi-prism/src/widgets/clock.ts
@@ -1,0 +1,41 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class ClockWidget implements Widget {
+	readonly id = "clock";
+	readonly label = "Clock";
+	readonly icon = "🕐";
+
+	async refresh(): Promise<void> {
+		/* no-op — renders current time */
+	}
+
+	render(w: number, th: Theme): string[] {
+		const now = new Date();
+		const time = now.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit", timeZone: "Europe/Oslo" });
+		const date = now.toLocaleDateString("en-GB", { weekday: "long", day: "numeric", month: "long", year: "numeric", timeZone: "Europe/Oslo" });
+
+		const digits: Record<string, string[]> = {
+			"0": ["█▀█", "█ █", "▀▀▀"],
+			"1": [" ▀█", "  █", "  ▀"],
+			"2": ["▀▀█", "█▀▀", "▀▀▀"],
+			"3": ["▀▀█", " ▀█", "▀▀▀"],
+			"4": ["█ █", "▀▀█", "  ▀"],
+			"5": ["█▀▀", "▀▀█", "▀▀▀"],
+			"6": ["█▀▀", "█▀█", "▀▀▀"],
+			"7": ["▀▀█", "  █", "  ▀"],
+			"8": ["█▀█", "█▀█", "▀▀▀"],
+			"9": ["█▀█", "▀▀█", "▀▀▀"],
+			":": [" ", "·", " "],
+		};
+
+		const chars = time.slice(0, 5).split(""); // HH:MM
+		const rows = [0, 1, 2].map((row) => {
+			const line = chars.map((c) => (digits[c] ?? [" ", " ", " "])[row] ?? " ").join(" ");
+			return truncateToWidth(` ${th.fg("accent", line)}`, w);
+		});
+
+		return [...rows, truncateToWidth(` ${th.fg("muted", date)}`, w)];
+	}
+}

--- a/extensions/pi-prism/src/widgets/git-status.ts
+++ b/extensions/pi-prism/src/widgets/git-status.ts
@@ -1,0 +1,64 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { execCmd } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class GitStatusWidget implements Widget {
+	readonly id = "git-status";
+	readonly label = "Git Status";
+	readonly icon = "🔀";
+	private branch = "";
+	private ahead = 0;
+	private behind = 0;
+	private staged = 0;
+	private modified = 0;
+	private untracked = 0;
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const branchRaw = await execCmd("git branch --show-current 2>/dev/null", ctx.cwd);
+		this.branch = branchRaw || "detached";
+
+		const status = await execCmd("git status --porcelain -b 2>/dev/null", ctx.cwd);
+		this.staged = 0;
+		this.modified = 0;
+		this.untracked = 0;
+		this.ahead = 0;
+		this.behind = 0;
+
+		for (const line of status.split("\n")) {
+			if (line.startsWith("##")) {
+				const m = line.match(/ahead (\d+)/);
+				if (m) this.ahead = parseInt(m[1]);
+				const m2 = line.match(/behind (\d+)/);
+				if (m2) this.behind = parseInt(m2[1]);
+			} else if (line.length >= 2) {
+				const x = line[0], y = line[1];
+				if (x === "?" && y === "?") this.untracked++;
+				else {
+					if (x !== " " && x !== "?") this.staged++;
+					if (y !== " " && y !== "?") this.modified++;
+				}
+			}
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		const out: string[] = [];
+		const branchColor = this.branch === "main" || this.branch === "master" ? "error" : "accent";
+		out.push(truncateToWidth(` ${th.fg("muted", "branch")} ${th.fg(branchColor, this.branch)}`, w));
+
+		const parts: string[] = [];
+		if (this.ahead) parts.push(th.fg("success", `↑${this.ahead}`));
+		if (this.behind) parts.push(th.fg("warning", `↓${this.behind}`));
+		if (this.staged) parts.push(th.fg("success", `${this.staged} staged`));
+		if (this.modified) parts.push(th.fg("warning", `${this.modified} modified`));
+		if (this.untracked) parts.push(th.fg("muted", `${this.untracked} untracked`));
+
+		if (parts.length === 0) {
+			out.push(` ${th.fg("success", "✓")} ${th.fg("muted", "clean")}`);
+		} else {
+			out.push(truncateToWidth(` ${parts.join(th.fg("dim", " · "))}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/index.ts
+++ b/extensions/pi-prism/src/widgets/index.ts
@@ -10,6 +10,12 @@ import type { Q } from "../helpers.ts";
 export interface WidgetContext {
 	query: Q;
 	cwd: string;
+	/** Hub JSON-RPC endpoint (e.g. http://localhost:8080/api/rpc). Null if not configured. */
+	hubUrl: string | null;
+	/** Hub API key for the X-API-Key header. Null if not configured. */
+	hubApiKey: string | null;
+	/** Optional project filter for hub task widgets. */
+	project: string | null;
 }
 
 export interface Widget {

--- a/extensions/pi-prism/src/widgets/index.ts
+++ b/extensions/pi-prism/src/widgets/index.ts
@@ -1,0 +1,59 @@
+/**
+ * Widget registry — all available widgets and their factories.
+ */
+
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { Q } from "../helpers.ts";
+
+// ── Widget interface ─────────────────────────────────────────
+
+export interface WidgetContext {
+	query: Q;
+	cwd: string;
+}
+
+export interface Widget {
+	readonly id: string;
+	readonly label: string;
+	readonly icon: string;
+	refresh(ctx: WidgetContext): Promise<void>;
+	render(w: number, th: Theme): string[];
+}
+
+// ── Widget imports ───────────────────────────────────────────
+
+import { ActiveTaskWidget } from "./active-task.ts";
+import { TaskQueueWidget } from "./task-queue.ts";
+import { GitStatusWidget } from "./git-status.ts";
+import { TodayCalendarWidget } from "./today-calendar.ts";
+import { WeekCalendarWidget } from "./week-calendar.ts";
+import { RecentOpsWidget } from "./recent-ops.ts";
+import { SystemHealthWidget } from "./system-health.ts";
+import { AccountsWidget } from "./accounts.ts";
+import { BudgetBarsWidget } from "./budget-bars.ts";
+import { RecentTxnsWidget } from "./recent-txns.ts";
+import { RemindersWidget } from "./reminders.ts";
+import { RecentContactsWidget } from "./recent-contacts.ts";
+import { SessionStatsWidget } from "./session-stats.ts";
+import { ClockWidget } from "./clock.ts";
+
+// ── Registry ─────────────────────────────────────────────────
+
+export const WIDGET_FACTORIES: Record<string, () => Widget> = {
+	"active-task": () => new ActiveTaskWidget(),
+	"task-queue": () => new TaskQueueWidget(),
+	"git-status": () => new GitStatusWidget(),
+	"today-calendar": () => new TodayCalendarWidget(),
+	"week-calendar": () => new WeekCalendarWidget(),
+	"recent-ops": () => new RecentOpsWidget(),
+	"system-health": () => new SystemHealthWidget(),
+	accounts: () => new AccountsWidget(),
+	"budget-bars": () => new BudgetBarsWidget(),
+	"recent-txns": () => new RecentTxnsWidget(),
+	reminders: () => new RemindersWidget(),
+	"recent-contacts": () => new RecentContactsWidget(),
+	"session-stats": () => new SessionStatsWidget(),
+	clock: () => new ClockWidget(),
+};
+
+export const DEFAULT_WIDGETS = ["active-task", "today-calendar", "recent-ops", "accounts"];

--- a/extensions/pi-prism/src/widgets/recent-contacts.ts
+++ b/extensions/pi-prism/src/widgets/recent-contacts.ts
@@ -1,0 +1,37 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { fmtDate } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class RecentContactsWidget implements Widget {
+	readonly id = "recent-contacts";
+	readonly label = "Contacts";
+	readonly icon = "👥";
+	private contacts: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		try {
+			this.contacts = (
+				await ctx.query(
+					`SELECT c.first_name, c.last_name, co.name as company, c.last_contacted_at
+					FROM crm_contacts c LEFT JOIN crm_companies co ON c.company_id = co.id
+					ORDER BY c.last_contacted_at DESC NULLS LAST LIMIT 6`,
+				)
+			).rows;
+		} catch {
+			this.contacts = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.contacts.length === 0) return [th.fg("muted", "  no contacts")];
+		const out: string[] = [];
+		for (const c of this.contacts) {
+			const name = `${c.first_name ?? ""} ${c.last_name ?? ""}`.trim();
+			const co = c.company ? th.fg("dim", ` (${c.company})`) : "";
+			const ago = c.last_contacted_at ? th.fg("muted", ` ${fmtDate(String(c.last_contacted_at))}`) : th.fg("muted", " never");
+			out.push(truncateToWidth(` ${th.fg("accent", name)}${co}${ago}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/recent-ops.ts
+++ b/extensions/pi-prism/src/widgets/recent-ops.ts
@@ -1,0 +1,37 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { fmtTime } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class RecentOpsWidget implements Widget {
+	readonly id = "recent-ops";
+	readonly label = "Recent Ops";
+	readonly icon = "⚡";
+	private ops: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		try {
+			this.ops = (
+				await ctx.query(
+					`SELECT tool_name, is_error, duration_ms, created_at
+					FROM tool_calls ORDER BY id DESC LIMIT 8`,
+				)
+			).rows;
+		} catch {
+			this.ops = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.ops.length === 0) return [th.fg("muted", "  no recent ops")];
+		const out: string[] = [];
+		for (const op of this.ops) {
+			const t = fmtTime(String(op.created_at ?? ""));
+			const tool = String(op.tool_name ?? "?");
+			const ok = op.is_error ? th.fg("error", "✗") : th.fg("success", "✓");
+			const ms = op.duration_ms ? th.fg("dim", ` ${op.duration_ms}ms`) : "";
+			out.push(truncateToWidth(` ${th.fg("muted", t)} ${ok} ${th.fg("accent", tool)}${ms}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/recent-txns.ts
+++ b/extensions/pi-prism/src/widgets/recent-txns.ts
@@ -1,0 +1,44 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { fmtDate, fmtMoney, pad } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class RecentTxnsWidget implements Widget {
+	readonly id = "recent-txns";
+	readonly label = "Transactions";
+	readonly icon = "💸";
+	private txns: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		try {
+			this.txns = (
+				await ctx.query(
+					`SELECT t.date, t.description, t.amount, t.transaction_type,
+					a.currency, v.name as vendor_name
+					FROM finance_transactions t
+					LEFT JOIN finance_accounts a ON t.account_id = a.id
+					LEFT JOIN finance_vendors v ON t.vendor_id = v.id
+					ORDER BY t.date DESC, t.id DESC LIMIT 5`,
+				)
+			).rows;
+		} catch {
+			this.txns = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.txns.length === 0) return [th.fg("muted", "  no transactions")];
+		const out: string[] = [];
+		for (const tx of this.txns) {
+			const date = fmtDate(String(tx.date ?? ""));
+			const desc = String(tx.vendor_name ?? tx.description ?? "?");
+			const amt = Number(tx.amount ?? 0);
+			const type = String(tx.transaction_type ?? "out");
+			const cur = String(tx.currency ?? "NOK");
+			const amtStr = type === "in" ? th.fg("success", `+${fmtMoney(amt, cur)}`) : th.fg("error", `-${fmtMoney(amt, cur)}`);
+			const descW = Math.max(6, w - visibleWidth(date) - visibleWidth(amtStr) - 5);
+			out.push(` ${th.fg("muted", date)} ${pad(truncateToWidth(desc, descW), descW)} ${amtStr}`);
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/reminders.ts
+++ b/extensions/pi-prism/src/widgets/reminders.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { fmtDate, daysAheadIso } from "../helpers.ts";
+import { fmtDate, todayIso, daysAheadIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class RemindersWidget implements Widget {
@@ -10,7 +10,7 @@ export class RemindersWidget implements Widget {
 	private reminders: Record<string, unknown>[] = [];
 
 	async refresh(ctx: WidgetContext): Promise<void> {
-		const today = new Date().toISOString().slice(0, 10);
+		const today = todayIso();
 		const end = daysAheadIso(14);
 		try {
 			this.reminders = (

--- a/extensions/pi-prism/src/widgets/reminders.ts
+++ b/extensions/pi-prism/src/widgets/reminders.ts
@@ -1,0 +1,45 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { fmtDate } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class RemindersWidget implements Widget {
+	readonly id = "reminders";
+	readonly label = "Reminders";
+	readonly icon = "🔔";
+	private reminders: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const today = new Date().toISOString().slice(0, 10);
+		const end = new Date(Date.now() + 14 * 86400000).toISOString().slice(0, 10);
+		try {
+			this.reminders = (
+				await ctx.query(
+					`SELECT r.reminder_type, r.reminder_date, r.message,
+					c.first_name, c.last_name
+					FROM crm_reminders r
+					LEFT JOIN crm_contacts c ON r.contact_id = c.id
+					WHERE r.reminder_date >= ? AND r.reminder_date <= ?
+					ORDER BY r.reminder_date ASC LIMIT 6`,
+					[today, end],
+				)
+			).rows;
+		} catch {
+			this.reminders = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.reminders.length === 0) return [th.fg("muted", "  no upcoming reminders")];
+		const out: string[] = [];
+		for (const r of this.reminders) {
+			const date = fmtDate(String(r.reminder_date ?? ""));
+			const name = `${r.first_name ?? ""} ${r.last_name ?? ""}`.trim();
+			const type = String(r.reminder_type ?? "");
+			const icon = type === "birthday" ? "🎂" : type === "anniversary" ? "💍" : "📌";
+			const msg = r.message ? String(r.message) : name;
+			out.push(truncateToWidth(` ${icon} ${th.fg("muted", date)}  ${msg}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/reminders.ts
+++ b/extensions/pi-prism/src/widgets/reminders.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { fmtDate } from "../helpers.ts";
+import { fmtDate, daysAheadIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class RemindersWidget implements Widget {
@@ -11,7 +11,7 @@ export class RemindersWidget implements Widget {
 
 	async refresh(ctx: WidgetContext): Promise<void> {
 		const today = new Date().toISOString().slice(0, 10);
-		const end = new Date(Date.now() + 14 * 86400000).toISOString().slice(0, 10);
+		const end = daysAheadIso(14);
 		try {
 			this.reminders = (
 				await ctx.query(

--- a/extensions/pi-prism/src/widgets/session-stats.ts
+++ b/extensions/pi-prism/src/widgets/session-stats.ts
@@ -1,5 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
+import { todayIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class SessionStatsWidget implements Widget {
@@ -13,7 +14,7 @@ export class SessionStatsWidget implements Widget {
 	private model = "";
 
 	async refresh(ctx: WidgetContext): Promise<void> {
-		const today = new Date().toISOString().slice(0, 10);
+		const today = todayIso();
 		try {
 			// Day totals — no GROUP BY so counts span all models used today
 			const totals = await ctx.query(

--- a/extensions/pi-prism/src/widgets/session-stats.ts
+++ b/extensions/pi-prism/src/widgets/session-stats.ts
@@ -1,0 +1,47 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class SessionStatsWidget implements Widget {
+	readonly id = "session-stats";
+	readonly label = "Session";
+	readonly icon = "⏱";
+	private startedAt = Date.now();
+	private todayCost = 0;
+	private todayJobs = 0;
+	private todayToolCalls = 0;
+	private model = "";
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const today = new Date().toISOString().slice(0, 10);
+		try {
+			const r = await ctx.query(
+				`SELECT SUM(cost_total) as cost, COUNT(*) as jobs, SUM(tool_call_count) as tools,
+				model FROM jobs WHERE date(created_at) = ? GROUP BY model ORDER BY cost DESC LIMIT 1`,
+				[today],
+			);
+			const row = r.rows[0];
+			this.todayCost = Number(row?.cost ?? 0);
+			this.todayJobs = Number(row?.jobs ?? 0);
+			this.todayToolCalls = Number(row?.tools ?? 0);
+			this.model = String(row?.model ?? "?");
+		} catch {
+			// stats unavailable
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		const elapsed = Date.now() - this.startedAt;
+		const mins = Math.floor(elapsed / 60000);
+		const out: string[] = [];
+		out.push(truncateToWidth(` ${th.fg("muted", "uptime")}  ${th.fg("accent", `${mins}m`)}`, w));
+		out.push(truncateToWidth(` ${th.fg("muted", "model")}   ${th.fg("accent", truncateToWidth(this.model, w - 12))}`, w));
+		out.push(
+			truncateToWidth(
+				` ${th.fg("muted", "today")}   ${th.fg("accent", `${this.todayJobs}`)} jobs · ${th.fg("accent", `${this.todayToolCalls}`)} tools · ${th.fg("success", `$${this.todayCost.toFixed(2)}`)}`,
+				w,
+			),
+		);
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/session-stats.ts
+++ b/extensions/pi-prism/src/widgets/session-stats.ts
@@ -15,16 +15,24 @@ export class SessionStatsWidget implements Widget {
 	async refresh(ctx: WidgetContext): Promise<void> {
 		const today = new Date().toISOString().slice(0, 10);
 		try {
-			const r = await ctx.query(
-				`SELECT SUM(cost_total) as cost, COUNT(*) as jobs, SUM(tool_call_count) as tools,
-				model FROM jobs WHERE date(created_at) = ? GROUP BY model ORDER BY cost DESC LIMIT 1`,
+			// Day totals — no GROUP BY so counts span all models used today
+			const totals = await ctx.query(
+				`SELECT SUM(cost_total) as cost, COUNT(*) as jobs, SUM(tool_call_count) as tools
+				FROM jobs WHERE date(created_at) = ?`,
 				[today],
 			);
-			const row = r.rows[0];
-			this.todayCost = Number(row?.cost ?? 0);
-			this.todayJobs = Number(row?.jobs ?? 0);
-			this.todayToolCalls = Number(row?.tools ?? 0);
-			this.model = String(row?.model ?? "?");
+			const t = totals.rows[0];
+			this.todayCost = Number(t?.cost ?? 0);
+			this.todayJobs = Number(t?.jobs ?? 0);
+			this.todayToolCalls = Number(t?.tools ?? 0);
+
+			// Dominant model — separate query for display only
+			const dominant = await ctx.query(
+				`SELECT model FROM jobs WHERE date(created_at) = ?
+				GROUP BY model ORDER BY SUM(cost_total) DESC LIMIT 1`,
+				[today],
+			);
+			this.model = String(dominant.rows[0]?.model ?? "?");
 		} catch {
 			// stats unavailable
 		}

--- a/extensions/pi-prism/src/widgets/system-health.ts
+++ b/extensions/pi-prism/src/widgets/system-health.ts
@@ -22,11 +22,17 @@ export class SystemHealthWidget implements Widget {
 
 		// Memory check
 		try {
-			const fs = await import("node:fs");
 			const path = await import("node:path");
+			const fsPromises = await import("node:fs/promises");
 			const memDir = path.join(ctx.cwd, "memory");
-			const files = fs.existsSync(memDir) ? fs.readdirSync(memDir).filter((f: string) => f.endsWith(".md")) : [];
-			this.checks.push({ name: "Memory", ok: true, detail: `${files.length} logs` });
+			let files: string[];
+			try {
+				files = await fsPromises.readdir(memDir);
+			} catch {
+				files = [];
+			}
+			const mdFiles = files.filter((f) => f.endsWith(".md"));
+			this.checks.push({ name: "Memory", ok: true, detail: `${mdFiles.length} logs` });
 		} catch {
 			this.checks.push({ name: "Memory", ok: false, detail: "error" });
 		}

--- a/extensions/pi-prism/src/widgets/system-health.ts
+++ b/extensions/pi-prism/src/widgets/system-health.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { execCmd, pad } from "../helpers.ts";
+import { execCmd, hubRpc, pad } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class SystemHealthWidget implements Widget {
@@ -35,9 +35,13 @@ export class SystemHealthWidget implements Widget {
 		const branch = await execCmd("git branch --show-current 2>/dev/null", ctx.cwd);
 		this.checks.push({ name: "Git", ok: !!branch, detail: branch || "no repo" });
 
-		// td check
-		const tdOut = await execCmd("td status 2>/dev/null | head -1", ctx.cwd);
-		this.checks.push({ name: "Tasks", ok: !!tdOut, detail: tdOut ? "ok" : "unavailable" });
+		// Hub reachability check (replaces retired td CLI)
+		if (ctx.hubUrl && ctx.hubApiKey) {
+			const hubResult = await hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", { limit: 1 });
+			this.checks.push({ name: "Hub", ok: !!hubResult, detail: hubResult ? "reachable" : "unreachable" });
+		} else {
+			this.checks.push({ name: "Hub", ok: false, detail: "not configured" });
+		}
 	}
 
 	render(w: number, th: Theme): string[] {

--- a/extensions/pi-prism/src/widgets/system-health.ts
+++ b/extensions/pi-prism/src/widgets/system-health.ts
@@ -1,0 +1,51 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { execCmd, pad } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class SystemHealthWidget implements Widget {
+	readonly id = "system-health";
+	readonly label = "System";
+	readonly icon = "🟢";
+	private checks: { name: string; ok: boolean; detail: string }[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		this.checks = [];
+
+		// DB check
+		try {
+			const r = await ctx.query(`SELECT count(*) as c FROM tool_calls`);
+			this.checks.push({ name: "DB", ok: true, detail: `${r.rows[0]?.c ?? 0} tool calls` });
+		} catch {
+			this.checks.push({ name: "DB", ok: false, detail: "unreachable" });
+		}
+
+		// Memory check
+		try {
+			const fs = await import("node:fs");
+			const path = await import("node:path");
+			const memDir = path.join(ctx.cwd, "memory");
+			const files = fs.existsSync(memDir) ? fs.readdirSync(memDir).filter((f: string) => f.endsWith(".md")) : [];
+			this.checks.push({ name: "Memory", ok: true, detail: `${files.length} logs` });
+		} catch {
+			this.checks.push({ name: "Memory", ok: false, detail: "error" });
+		}
+
+		// Git check
+		const branch = await execCmd("git branch --show-current 2>/dev/null", ctx.cwd);
+		this.checks.push({ name: "Git", ok: !!branch, detail: branch || "no repo" });
+
+		// td check
+		const tdOut = await execCmd("td status 2>/dev/null | head -1", ctx.cwd);
+		this.checks.push({ name: "Tasks", ok: !!tdOut, detail: tdOut ? "ok" : "unavailable" });
+	}
+
+	render(w: number, th: Theme): string[] {
+		const out: string[] = [];
+		for (const c of this.checks) {
+			const dot = c.ok ? th.fg("success", "●") : th.fg("error", "●");
+			out.push(truncateToWidth(` ${dot} ${pad(c.name, 8)} ${th.fg("muted", c.detail)}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/task-queue.ts
+++ b/extensions/pi-prism/src/widgets/task-queue.ts
@@ -1,0 +1,31 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { execCmd } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class TaskQueueWidget implements Widget {
+	readonly id = "task-queue";
+	readonly label = "Task Queue";
+	readonly icon = "📋";
+	private lines: string[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const raw = await execCmd("td list --limit 6 2>/dev/null", ctx.cwd);
+		this.lines = raw ? raw.split("\n").slice(0, 8) : [];
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.lines.length === 0) return [th.fg("muted", "  no tasks")];
+		const out: string[] = [];
+		for (const l of this.lines) {
+			let s = l;
+			if (/\[WIP\]|\[PROGRESS\]/i.test(l)) s = th.fg("warning", l);
+			else if (/\[DONE\]|\[CLOSED\]/i.test(l)) s = th.fg("success", l);
+			else if (/\[BLOCKED\]/i.test(l)) s = th.fg("error", l);
+			else if (/\[RDY\]|\[READY\]/i.test(l)) s = th.fg("accent", l);
+			else if (/\[REV\]|\[REVIEW\]/i.test(l)) s = th.fg("warning", l);
+			out.push(truncateToWidth(` ${s}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/task-queue.ts
+++ b/extensions/pi-prism/src/widgets/task-queue.ts
@@ -1,31 +1,89 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { Theme, ThemeColor } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { execCmd } from "../helpers.ts";
+import { hubRpc, type HubTask } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
+
+const PRIORITY_COLOR: Record<string, ThemeColor> = {
+	critical: "error",
+	high: "warning",
+	normal: "text",
+	low: "muted",
+};
+
+const STATE_ICON: Record<string, string> = {
+	queued: "📋",
+	planning: "📐",
+	building: "🔨",
+	reviewing: "👀",
+	pr_ready: "🚀",
+	blocked: "🚧",
+};
 
 export class TaskQueueWidget implements Widget {
 	readonly id = "task-queue";
 	readonly label = "Task Queue";
 	readonly icon = "📋";
-	private lines: string[] = [];
+	private tasks: HubTask[] = [];
+	private total = 0;
+	private error: string | null = null;
 
 	async refresh(ctx: WidgetContext): Promise<void> {
-		const raw = await execCmd("td list --limit 6 2>/dev/null", ctx.cwd);
-		this.lines = raw ? raw.split("\n").slice(0, 8) : [];
+		this.tasks = [];
+		this.total = 0;
+		this.error = null;
+
+		if (!ctx.hubUrl || !ctx.hubApiKey) {
+			this.error = "hub not configured";
+			return;
+		}
+
+		// Fetch queued + planning tasks (the backlog / upcoming work)
+		const [queuedRes, planningRes] = await Promise.all([
+			hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", {
+				...(ctx.project ? { project: ctx.project } : {}),
+				state: "queued",
+				limit: 4,
+			}),
+			hubRpc(ctx.hubUrl, ctx.hubApiKey, "tasks.list", {
+				...(ctx.project ? { project: ctx.project } : {}),
+				state: "planning",
+				limit: 2,
+			}),
+		]);
+
+		if (!queuedRes && !planningRes) {
+			this.error = "hub unreachable";
+			return;
+		}
+
+		const queued: HubTask[] = ((queuedRes?.tasks as HubTask[]) ?? []);
+		const planning: HubTask[] = ((planningRes?.tasks as HubTask[]) ?? []);
+
+		// planning first (higher priority), then queued
+		this.tasks = [...planning, ...queued].slice(0, 6);
+		this.total = ((queuedRes?.total as number) ?? 0) + ((planningRes?.total as number) ?? 0);
 	}
 
 	render(w: number, th: Theme): string[] {
-		if (this.lines.length === 0) return [th.fg("muted", "  no tasks")];
+		if (this.error) return [th.fg("muted", `  ${this.error}`)];
+		if (this.tasks.length === 0) return [th.fg("muted", "  queue empty")];
+
 		const out: string[] = [];
-		for (const l of this.lines) {
-			let s = l;
-			if (/\[WIP\]|\[PROGRESS\]/i.test(l)) s = th.fg("warning", l);
-			else if (/\[DONE\]|\[CLOSED\]/i.test(l)) s = th.fg("success", l);
-			else if (/\[BLOCKED\]/i.test(l)) s = th.fg("error", l);
-			else if (/\[RDY\]|\[READY\]/i.test(l)) s = th.fg("accent", l);
-			else if (/\[REV\]|\[REVIEW\]/i.test(l)) s = th.fg("warning", l);
-			out.push(truncateToWidth(` ${s}`, w));
+		for (const task of this.tasks) {
+			const icon = STATE_ICON[task.state] ?? "▸";
+			const prioColor = PRIORITY_COLOR[task.priority] ?? "fg";
+			const prio = task.priority !== "normal" ? th.fg(prioColor, `[${task.priority}]`) + " " : "";
+			const title = task.title.length > 36 ? task.title.slice(0, 33) + "…" : task.title;
+			out.push(truncateToWidth(` ${icon} ${prio}${title}`, w));
+			if (task.project) {
+				out.push(truncateToWidth(`   ${th.fg("muted", task.project)}`, w));
+			}
 		}
+
+		if (this.total > this.tasks.length) {
+			out.push(th.fg("muted", `  … ${this.total - this.tasks.length} more in queue`));
+		}
+
 		return out;
 	}
 }

--- a/extensions/pi-prism/src/widgets/today-calendar.ts
+++ b/extensions/pi-prism/src/widgets/today-calendar.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { fmtTime } from "../helpers.ts";
+import { fmtTime, todayIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class TodayCalendarWidget implements Widget {
@@ -10,7 +10,7 @@ export class TodayCalendarWidget implements Widget {
 	private events: Record<string, unknown>[] = [];
 
 	async refresh(ctx: WidgetContext): Promise<void> {
-		const today = new Date().toISOString().slice(0, 10);
+		const today = todayIso();
 		try {
 			this.events = (
 				await ctx.query(

--- a/extensions/pi-prism/src/widgets/today-calendar.ts
+++ b/extensions/pi-prism/src/widgets/today-calendar.ts
@@ -1,0 +1,36 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { fmtTime } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class TodayCalendarWidget implements Widget {
+	readonly id = "today-calendar";
+	readonly label = "Today";
+	readonly icon = "📅";
+	private events: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const today = new Date().toISOString().slice(0, 10);
+		try {
+			this.events = (
+				await ctx.query(
+					`SELECT title, start_time, end_time, all_day FROM calendar_events
+					WHERE date(start_time) = ? ORDER BY start_time ASC LIMIT 8`,
+					[today],
+				)
+			).rows;
+		} catch {
+			this.events = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.events.length === 0) return [th.fg("muted", "  no events today")];
+		const out: string[] = [];
+		for (const ev of this.events) {
+			const time = ev.all_day ? th.fg("muted", "all day") : th.fg("accent", fmtTime(String(ev.start_time ?? "")));
+			out.push(truncateToWidth(` ${time}  ${ev.title}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/week-calendar.ts
+++ b/extensions/pi-prism/src/widgets/week-calendar.ts
@@ -1,0 +1,47 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import { fmtDate, fmtTime } from "../helpers.ts";
+import type { Widget, WidgetContext } from "./index.ts";
+
+export class WeekCalendarWidget implements Widget {
+	readonly id = "week-calendar";
+	readonly label = "This Week";
+	readonly icon = "🗓️";
+	private events: Record<string, unknown>[] = [];
+
+	async refresh(ctx: WidgetContext): Promise<void> {
+		const today = new Date().toISOString().slice(0, 10);
+		const end = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
+		try {
+			this.events = (
+				await ctx.query(
+					`SELECT title, start_time, all_day FROM calendar_events
+					WHERE date(start_time) >= ? AND date(start_time) <= ?
+					ORDER BY start_time ASC LIMIT 12`,
+					[today, end],
+				)
+			).rows;
+		} catch {
+			this.events = [];
+		}
+	}
+
+	render(w: number, th: Theme): string[] {
+		if (this.events.length === 0) return [th.fg("muted", "  no events this week")];
+		const today = new Date().toISOString().slice(0, 10);
+		const out: string[] = [];
+		let curDate = "";
+		for (const ev of this.events) {
+			const start = String(ev.start_time ?? "");
+			const date = start.slice(0, 10);
+			if (date !== curDate) {
+				const label = date === today ? th.fg("warning", "TODAY") : th.fg("muted", fmtDate(date));
+				out.push(` ${th.bold(label)}`);
+				curDate = date;
+			}
+			const time = ev.all_day ? th.fg("muted", "all day") : th.fg("accent", fmtTime(start));
+			out.push(truncateToWidth(`   ${time}  ${ev.title}`, w));
+		}
+		return out;
+	}
+}

--- a/extensions/pi-prism/src/widgets/week-calendar.ts
+++ b/extensions/pi-prism/src/widgets/week-calendar.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { fmtDate, fmtTime } from "../helpers.ts";
+import { fmtDate, fmtTime, daysAheadIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class WeekCalendarWidget implements Widget {
@@ -11,7 +11,7 @@ export class WeekCalendarWidget implements Widget {
 
 	async refresh(ctx: WidgetContext): Promise<void> {
 		const today = new Date().toISOString().slice(0, 10);
-		const end = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
+		const end = daysAheadIso(7);
 		try {
 			this.events = (
 				await ctx.query(

--- a/extensions/pi-prism/src/widgets/week-calendar.ts
+++ b/extensions/pi-prism/src/widgets/week-calendar.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
-import { fmtDate, fmtTime, daysAheadIso } from "../helpers.ts";
+import { fmtDate, fmtTime, todayIso, daysAheadIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class WeekCalendarWidget implements Widget {
@@ -10,7 +10,7 @@ export class WeekCalendarWidget implements Widget {
 	private events: Record<string, unknown>[] = [];
 
 	async refresh(ctx: WidgetContext): Promise<void> {
-		const today = new Date().toISOString().slice(0, 10);
+		const today = todayIso();
 		const end = daysAheadIso(7);
 		try {
 			this.events = (
@@ -28,7 +28,7 @@ export class WeekCalendarWidget implements Widget {
 
 	render(w: number, th: Theme): string[] {
 		if (this.events.length === 0) return [th.fg("muted", "  no events this week")];
-		const today = new Date().toISOString().slice(0, 10);
+		const today = todayIso();
 		const out: string[] = [];
 		let curDate = "";
 		for (const ev of this.events) {

--- a/extensions/pi-prism/tsconfig.json
+++ b/extensions/pi-prism/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Changes

### Task 1 — Rewrite active-task and task-queue widgets (hub_tasks 075115d8)
Replaces `td status` / `td list` CLI shell-outs with JSON-RPC calls to the A2A Hub pipeline API.

- **settings.ts** — extends `PrismSettings` with `hubUrl`, `hubApiKey` (auto-read from `pi-a2a.hub.*`), and optional `project` filter
- **widgets/index.ts** — adds `hubUrl`, `hubApiKey`, `project` to `WidgetContext`
- **sidebar.ts** — reads hub config from settings and populates context on each refresh
- **helpers.ts** — adds `HubTask` interface and `hubRpc()` fetch helper (8s timeout, JSON-RPC 2.0)
- **active-task.ts** — fetches tasks in `building` / `reviewing` / `pr_ready` states via `tasks.list`; shows state icon, title, project, branch, PR number
- **task-queue.ts** — fetches `planning` + `queued` tasks in parallel; shows priority-coloured rows with overflow count

### Task 2 — Peer dep bump to 0.65.2 (hub_tasks 9b86715b)
- Pins peer deps to `>=0.65.2` in package.json
- Adds matching devDependencies for local typecheck
- Fixes `ThemeColor` type error surfaced by 0.65.2 strict typing (`"fg"` → typed `ThemeColor` record)
- `npm run typecheck` passes clean

### Task 3 — Symlink + configure in aivena
⏳ Deferred — as requested, this runs after the branch is merged to main.

## Typecheck
```
npm run typecheck → tsc --noEmit (exit 0)
```