### PR TITLE
fix(pi-a2a): skip re-processing inbound tasks already completed

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -430,15 +430,30 @@ export class PiAgentExecutor implements AgentExecutor {
 		//
 		// Re-publish the existing terminal task so the caller's message/send
 		// response carries the result directly (no extra polling needed).
-		const existingTask = await this.taskStore.load(taskId);
-		const existingState = existingTask?.status?.state;
-		if (existingState === "completed" || existingState === "failed" || existingState === "canceled") {
-			this.log("executor_skip_terminal_task", { taskId, state: existingState });
-			// Re-publish the completed task so the caller gets the result in-band
-			if (existingTask) {
-				eventBus.publish(existingTask as Task);
+		try {
+			const existingTask = await this.taskStore.load(taskId);
+			const existingState = existingTask?.status?.state;
+			if (existingState === "completed" || existingState === "failed" || existingState === "canceled") {
+				this.log("executor_skip_terminal_task", { taskId, state: existingState });
+				// Re-publish the completed task so the caller gets the result in-band
+				if (existingTask) {
+					eventBus.publish(existingTask as Task);
+				}
+				eventBus.finished();
+				this.taskContexts.delete(taskId);
+				releaseQueue!();
+				return;
 			}
+		} catch (err: unknown) {
+			// Store error (DB failure, disk full, etc.) — log and fall through to
+			// normal processing. Better to risk a duplicate turn than to deadlock
+			// the queue by never calling releaseQueue.
+			const msg = err instanceof Error ? err.message : String(err);
+			this.log("executor_store_load_error", { taskId, error: msg }, "ERROR");
+			// Guard failed — abort this turn so the queue stays healthy
+			this.publishError(taskId, contextId, eventBus, `Store error during duplicate-send check: ${msg}`);
 			eventBus.finished();
+			this.taskContexts.delete(taskId);
 			releaseQueue!();
 			return;
 		}

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -445,13 +445,12 @@ export class PiAgentExecutor implements AgentExecutor {
 				return;
 			}
 		} catch (err: unknown) {
-			// Store error (DB failure, disk full, etc.) — log and fall through to
-			// normal processing. Better to risk a duplicate turn than to deadlock
-			// the queue by never calling releaseQueue.
+			// Store error (DB failure, disk full, etc.) — abort this turn to keep
+			// the queue healthy. The raw error is logged internally; the caller
+			// receives a generic message to avoid leaking internal file paths.
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_store_load_error", { taskId, error: msg }, "ERROR");
-			// Guard failed — abort this turn so the queue stays healthy
-			this.publishError(taskId, contextId, eventBus, `Store error during duplicate-send check: ${msg}`);
+			this.publishError(taskId, contextId, eventBus, "Internal error — task lookup failed. Please retry.");
 			eventBus.finished();
 			this.taskContexts.delete(taskId);
 			releaseQueue!();

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -445,12 +445,10 @@ export class PiAgentExecutor implements AgentExecutor {
 				return;
 			}
 		} catch (err: unknown) {
-			// Store error (DB failure, disk full, etc.) — abort this turn to keep
-			// the queue healthy. The raw error is logged internally; the caller
-			// receives a generic message to avoid leaking internal file paths.
+			// Store error — abort this turn; the caller gets a failed status and the queue is released.
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("executor_store_load_error", { taskId, error: msg }, "ERROR");
-			this.publishError(taskId, contextId, eventBus, "Internal error — task lookup failed. Please retry.");
+			this.publishError(taskId, contextId, eventBus, "Internal store error during duplicate-send check");
 			eventBus.finished();
 			this.taskContexts.delete(taskId);
 			releaseQueue!();

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -417,6 +417,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		// Always call eventBus.finished() to complete the SDK task lifecycle.
 		if (canceled) {
 			this.log("executor_skip_canceled", { taskId });
+			this.taskContexts.delete(taskId);
 			eventBus.finished();
 			releaseQueue!();
 			return;

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -30,6 +30,16 @@
  * Concurrency: max 1 (blocks — the main agent handles one request at a
  * time). Additional requests are queued and processed in arrival order.
  * Run more pi instances for parallel A2A processing.
+ *
+ * Duplicate-send / re-processing guard:
+ *   - If a caller resends the same message while the task is still in
+ *     'working' state, the follow-up is queued behind the active task.
+ *   - After the first processing completes (task → completed/failed), the
+ *     queued follow-up wakes up, detects the terminal state, re-publishes
+ *     the existing completed task so the caller gets the result immediately,
+ *     and exits without running processMessage again.
+ *   - This prevents callers that retry on timeout from triggering duplicate
+ *     agent turns and overwriting already-stored results.
  */
 
 import { randomUUID } from "node:crypto";
@@ -407,6 +417,27 @@ export class PiAgentExecutor implements AgentExecutor {
 		// Always call eventBus.finished() to complete the SDK task lifecycle.
 		if (canceled) {
 			this.log("executor_skip_canceled", { taskId });
+			eventBus.finished();
+			releaseQueue!();
+			return;
+		}
+
+		// ── Duplicate-send guard: skip re-processing completed tasks ───────────
+		// When a caller resends the same message/send while the task is working,
+		// the follow-up is queued. By the time it dequeues, the first processing
+		// may have already completed. Re-running processMessage would overwrite
+		// the stored result and trigger a duplicate agent turn.
+		//
+		// Re-publish the existing terminal task so the caller's message/send
+		// response carries the result directly (no extra polling needed).
+		const existingTask = await this.taskStore.load(taskId);
+		const existingState = existingTask?.status?.state;
+		if (existingState === "completed" || existingState === "failed" || existingState === "canceled") {
+			this.log("executor_skip_terminal_task", { taskId, state: existingState });
+			// Re-publish the completed task so the caller gets the result in-band
+			if (existingTask) {
+				eventBus.publish(existingTask as Task);
+			}
 			eventBus.finished();
 			releaseQueue!();
 			return;


### PR DESCRIPTION
## Problem

A2A callers (Hub, Elsa, others) loop on responses — they resend the same message body on every follow-up call within the same A2A task. Root cause is in Pi's `PiAgentExecutor.execute()`.

### Root Cause

```
1. Caller sends message M → task T created (state: working)
2. Caller retries/resends M with same taskId (timeout, impatience, etc.)
3. Follow-up lands in executor queue (not parked — no a2a_request_input pending)
4. Pi finishes first turn → saves T as completed → releases queue
5. Queued M wakes up → NO terminal state check → runs processMessage again
6. Pi overwrites T with a second response → triggers another agent turn
7. → loop continues
```

The executor's serial queue is correct for ordering, but it lacked a guard for the case where the task it just dequeued was already completed while it waited.

## Fix

**One logical change in `agent-executor.ts`:** After dequeuing (after `await myTurn`), load the task from the store and check its state. If already terminal (`completed`/`failed`/`canceled`):
1. Log the skip so it's observable
2. Re-publish the existing completed task — caller gets the result in-band from their `message/send` response (no extra `tasks/get` poll needed)
3. Release the queue and return — no `processMessage` call

This uses the existing task store (no new state, no in-memory sets) and is durable across the session restart boundary.

## What's NOT changed

- Input-required follow-ups: unaffected — parked resolvers are checked before the queue entirely (bypass path)  
- Canceled tasks: unaffected — checked before the new terminal state check
- Supervisor / loop control: unaffected — terminal check runs before supervisor so hop counts aren't incremented for skipped turns
- Task store schema: unchanged

## Typecheck

`npm run typecheck` exits clean (0).