### PR TITLE
fix(pi-mealie): fix meal plan recipe linking, expose entry IDs, add organizer CRUD

### DIFF
--- a/extensions/pi-mealie/src/tools/mealplans.ts
+++ b/extensions/pi-mealie/src/tools/mealplans.ts
@@ -21,6 +21,16 @@ function validatePathSegment(value: string, name: string): void {
 	}
 }
 
+/** Resolve a recipe slug to its UUID by fetching the recipe detail. */
+async function resolveRecipeId(slug: string, signal?: AbortSignal): Promise<string> {
+	validatePathSegment(slug, "recipeSlug");
+	const recipe = await mealie.get<{ id: string; name: string; slug: string }>(`/recipes/${slug}`, undefined, signal);
+	if (!recipe?.id) {
+		throw new Error(`Recipe not found for slug "${slug}"`);
+	}
+	return recipe.id;
+}
+
 interface MealPlanEntry {
 	id: string;
 	date: string;
@@ -154,10 +164,11 @@ export function registerMealplansTool(pi: ExtensionAPI) {
 							entryType: params.entryType || "dinner",
 						};
 						if (params.recipeSlug) {
-							body.recipeSlug = params.recipeSlug;
+							// Resolve slug → recipe UUID (Mealie API requires recipe_id, not slug)
+							const recipeId = await resolveRecipeId(params.recipeSlug, signal);
+							body.recipeId = recipeId;
 						} else if (params.title) {
 							body.title = params.title;
-							body.recipeSlug = null;
 						} else {
 							return { content: [{ type: "text", text: "Must provide either recipeSlug or title" }], details: {} };
 						}
@@ -188,8 +199,9 @@ export function registerMealplansTool(pi: ExtensionAPI) {
 
 function formatEntry(e: MealPlanEntry): string {
 	const label = ENTRY_TYPE_LABELS[e.entryType] || "[" + e.entryType + "]";
+	const idSuffix = " (id: `" + e.id + "`)";
 	if (e.recipe) {
-		return label + " " + e.recipe.name + " (_" + e.recipe.slug + "_)" + (e.note ? " -- " + e.note : "");
+		return label + " " + e.recipe.name + " (_" + e.recipe.slug + "_)" + (e.note ? " -- " + e.note : "") + idSuffix;
 	}
-	return label + " " + (e.title || "Untitled") + (e.note ? " -- " + e.note : "");
+	return label + " " + (e.title || "Untitled") + (e.note ? " -- " + e.note : "") + idSuffix;
 }

--- a/extensions/pi-mealie/src/tools/organizer.ts
+++ b/extensions/pi-mealie/src/tools/organizer.ts
@@ -120,6 +120,7 @@ async function createItem(label: string, path: string, params: { name?: string; 
 	if (params.description) body.description = params.description;
 
 	const item = await mealie.post<OrganizerItem>(path, body, signal);
+	if (!item?.id) throw new Error(`${label} API returned no data`);
 	return { content: [{ type: "text" as const, text: `✅ ${label} "${item.name}" created (_${item.slug}_, id: \`${item.id}\`)` }], details: {} };
 }
 
@@ -136,6 +137,7 @@ async function updateItem(label: string, path: string, params: { id?: string; na
 	if (params.description !== undefined) body.description = params.description;
 
 	const item = await mealie.put<OrganizerItem>(`${path}/${params.id}`, body, signal);
+	if (!item?.id) throw new Error(`${label} API returned no data`);
 	return { content: [{ type: "text" as const, text: `✅ ${label} updated: "${item.name}" (_${item.slug}_, id: \`${item.id}\`)` }], details: {} };
 }
 

--- a/extensions/pi-mealie/src/tools/organizer.ts
+++ b/extensions/pi-mealie/src/tools/organizer.ts
@@ -6,6 +6,13 @@ import type { ExtensionAPI, AgentToolResult } from "@mariozechner/pi-coding-agen
 import { Type } from "@sinclair/typebox";
 import { isClientReady, mealie, apiList } from "../client.ts";
 
+/** Validate a path segment (UUID or slug) contains only safe characters. */
+function validatePathSegment(value: string, name: string): void {
+	if (!/^[\w-]+$/.test(value)) {
+		throw new Error(`Invalid ${name}: "${value}". Only alphanumeric, hyphens, and underscores allowed.`);
+	}
+}
+
 interface OrganizerItem {
 	id: string;
 	name: string;
@@ -25,17 +32,28 @@ const actionSchema = Type.Union([
 	Type.Literal("create_tool"),
 	Type.Literal("create_food"),
 	Type.Literal("create_unit"),
+	Type.Literal("update_tag"),
+	Type.Literal("update_category"),
+	Type.Literal("update_tool"),
+	Type.Literal("update_food"),
+	Type.Literal("update_unit"),
+	Type.Literal("delete_tag"),
+	Type.Literal("delete_category"),
+	Type.Literal("delete_tool"),
+	Type.Literal("delete_food"),
+	Type.Literal("delete_unit"),
 ]);
 
 export function registerOrganizerTool(pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "mealie_organizer",
 		label: "Mealie Organizer",
-		description: "Manage Mealie organizers — list/create tags, categories, tools, foods, and units",
+		description: "Manage Mealie organizers — list/create/update/delete tags, categories, tools, foods, and units",
 		parameters: Type.Object({
 			action: actionSchema,
-			name: Type.Optional(Type.String({ description: "Name (for create actions)" })),
-			description: Type.Optional(Type.String({ description: "Description (for create actions)" })),
+			id: Type.Optional(Type.String({ description: "Item ID (for update/delete actions)" })),
+			name: Type.Optional(Type.String({ description: "Name (for create/update actions)" })),
+			description: Type.Optional(Type.String({ description: "Description (for create/update actions)" })),
 		}),
 		execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
 			if (!isClientReady()) {
@@ -47,17 +65,33 @@ export function registerOrganizerTool(pi: ExtensionAPI) {
 
 			try {
 				switch (params.action) {
+					// List
 					case "list_tags": return await listItems("Tags", "/organizers/tags", "🏷️", signal);
 					case "list_categories": return await listItems("Categories", "/organizers/categories", "📁", signal);
 					case "list_tools": return await listItems("Tools", "/organizers/tools", "🔧", signal);
 					case "list_foods": return await listItems("Foods", "/foods", "🥕", signal);
 					case "list_units": return await listItems("Units", "/units", "📏", signal);
 
+					// Create
 					case "create_tag": return await createItem("Tag", "/organizers/tags", params, signal);
 					case "create_category": return await createItem("Category", "/organizers/categories", params, signal);
 					case "create_tool": return await createItem("Tool", "/organizers/tools", params, signal);
 					case "create_food": return await createItem("Food", "/foods", params, signal);
 					case "create_unit": return await createItem("Unit", "/units", params, signal);
+
+					// Update
+					case "update_tag": return await updateItem("Tag", "/organizers/tags", params, signal);
+					case "update_category": return await updateItem("Category", "/organizers/categories", params, signal);
+					case "update_tool": return await updateItem("Tool", "/organizers/tools", params, signal);
+					case "update_food": return await updateItem("Food", "/foods", params, signal);
+					case "update_unit": return await updateItem("Unit", "/units", params, signal);
+
+					// Delete
+					case "delete_tag": return await deleteItem("Tag", "/organizers/tags", params, signal);
+					case "delete_category": return await deleteItem("Category", "/organizers/categories", params, signal);
+					case "delete_tool": return await deleteItem("Tool", "/organizers/tools", params, signal);
+					case "delete_food": return await deleteItem("Food", "/foods", params, signal);
+					case "delete_unit": return await deleteItem("Unit", "/units", params, signal);
 
 					default:
 						return { content: [{ type: "text", text: `❌ Unknown action: ${params.action}` }], details: {} };
@@ -87,4 +121,30 @@ async function createItem(label: string, path: string, params: { name?: string; 
 
 	const item = await mealie.post<OrganizerItem>(path, body, signal);
 	return { content: [{ type: "text" as const, text: `✅ ${label} "${item.name}" created (_${item.slug}_, id: \`${item.id}\`)` }], details: {} };
+}
+
+async function updateItem(label: string, path: string, params: { id?: string; name?: string; description?: string }, signal?: AbortSignal): Promise<AgentToolResult<{}>> {
+	if (!params.id) {
+		return { content: [{ type: "text" as const, text: `❌ Missing required parameter: id` }], details: {} };
+	}
+	validatePathSegment(params.id, "id");
+	if (!params.name && params.description === undefined) {
+		return { content: [{ type: "text" as const, text: `❌ Provide at least one of: name, description` }], details: {} };
+	}
+	const body: Record<string, unknown> = { id: params.id };
+	if (params.name !== undefined) body.name = params.name;
+	if (params.description !== undefined) body.description = params.description;
+
+	const item = await mealie.put<OrganizerItem>(`${path}/${params.id}`, body, signal);
+	return { content: [{ type: "text" as const, text: `✅ ${label} updated: "${item.name}" (_${item.slug}_, id: \`${item.id}\`)` }], details: {} };
+}
+
+async function deleteItem(label: string, path: string, params: { id?: string }, signal?: AbortSignal): Promise<AgentToolResult<{}>> {
+	if (!params.id) {
+		return { content: [{ type: "text" as const, text: `❌ Missing required parameter: id` }], details: {} };
+	}
+	validatePathSegment(params.id, "id");
+
+	await mealie.delete(`${path}/${params.id}`, signal);
+	return { content: [{ type: "text" as const, text: `✅ ${label} \`${params.id}\` deleted.` }], details: {} };
 }


### PR DESCRIPTION
## Bug Fixes

Fixes found during Aivena's comprehensive CRUD testing of all Mealie extension tools.

### 1. Meal plan `add` by `recipeSlug` — 422 fix
The Mealie API expects `recipe_id` (UUID), not a slug. The tool now resolves the slug to a UUID via `GET /recipes/{slug}` before creating the meal plan entry.

### 2. Meal plan entry IDs now exposed in output
The `today`, `week`, and `date` actions now include entry IDs in their output (e.g. `(id: \`abc-123\`)`), making the `remove` action actually usable.

### 3. Organizer update/delete actions added
Added `update_tag`, `update_category`, `update_tool`, `update_food`, `update_unit`, `delete_tag`, `delete_category`, `delete_tool`, `delete_food`, `delete_unit` actions. Previously only `create_*` and `list_*` existed.

### 4. `scrape_url` 400 error
Confirmed as a Mealie server-side issue (network access / scraper config), not a tool bug. No code change needed.

### Updated summary

| Tool | Create | Read | Update | Delete |
|------|--------|------|--------|--------|
| Recipes | ✅ | ✅ | ✅ | ✅ |
| Organizers | ✅ | ✅ | ✅ | ✅ |
| Meal Plans | ✅ (recipe + note) | ✅ (with entry IDs) | N/A | ✅ |
| Shopping Lists | ✅ | ✅ | ✅ | ✅ |
| Scrape URL | ⚠️ server-side | — | — | — |

Closes td-ba4502