### PR TITLE
feat(pi-mealie): add ingredients, instructions, and metadata to recipe create/update

### DIFF
--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -190,10 +190,9 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 
 						const resolvedSlug = typeof slug === "string" ? slug : (slug as unknown as RecipeDetail).slug;
 						if (!resolvedSlug) throw new Error("Could not determine recipe slug from create response");
-						// Validate server-returned slug defensively, but don't let it orphan the stub — wrap with cleanup
+						// Validate server-returned slug — never use an invalid slug in a URL path (path traversal risk)
 						if (!/^[\w-]+$/.test(resolvedSlug)) {
-							try { await mealie.delete(`/recipes/${resolvedSlug}`); } catch { /* best-effort cleanup */ }
-							throw new Error(`Invalid slug returned by Mealie: "${resolvedSlug}". The stub recipe has been cleaned up.`);
+							throw new Error(`Invalid slug returned by Mealie: "${resolvedSlug}". Cannot safely clean up — please delete the stub recipe manually.`);
 						}
 
 						// Step 2: If additional fields provided, PATCH the recipe

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -163,7 +163,13 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						// Step 2: If additional fields provided, PATCH the recipe
 						const patchBody = buildRecipeBody(params);
 						if (Object.keys(patchBody).length > 0) {
-							await mealie.patch<RecipeDetail>(`/recipes/${resolvedSlug}`, patchBody, signal);
+							try {
+								await mealie.patch<RecipeDetail>(`/recipes/${resolvedSlug}`, patchBody, signal);
+							} catch (patchErr: any) {
+								// Rollback: delete the stub recipe so we don't leave orphans
+								try { await mealie.delete(`/recipes/${resolvedSlug}`); } catch { /* best-effort */ }
+								throw new Error(`Recipe created but failed to add details (rolled back): ${patchErr.message || patchErr}`);
+							}
 						}
 
 						// Step 3: Fetch the final recipe for display

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -177,8 +177,13 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						}
 
 						// Step 3: Fetch the final recipe for display
-						const recipe = await mealie.get<RecipeDetail>(`/recipes/${resolvedSlug}`, undefined, signal);
-						return { content: [{ type: "text", text: `✅ Recipe created:\n\n${formatDetail(recipe)}` }], details: {} };
+						try {
+							const recipe = await mealie.get<RecipeDetail>(`/recipes/${resolvedSlug}`, undefined, signal);
+							return { content: [{ type: "text", text: `✅ Recipe created:\n\n${formatDetail(recipe)}` }], details: {} };
+						} catch {
+							// Recipe was created and patched successfully; only the display fetch failed
+							return { content: [{ type: "text", text: `✅ Recipe created (slug: ${resolvedSlug}). Use \`get\` action with this slug to view details.` }], details: {} };
+						}
 					}
 
 					case "update": {
@@ -214,7 +219,7 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						try {
 							const parsed = new URL(params.url);
 							const host = parsed.hostname;
-							if (/^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|::1|0\.0\.0\.0)/.test(host)) {
+							if (/^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|::1|::ffff:|0\.0\.0\.0)/.test(host) || /::ffff:(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.)/.test(host)) {
 								return { content: [{ type: "text", text: "❌ URL points to a private/internal address. Only public URLs are allowed for scraping." }], details: {} };
 							}
 						} catch {

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -34,12 +34,12 @@ interface RecipeDetail {
 	name: string;
 	slug: string;
 	description: string | null;
- recipeYield: string | null;
+	recipeYield: string | null;
 	prepTime: string | null;
 	cookTime: string | null;
 	totalTime: string | null;
-	ingredients: { note: string; quantity: number | null; unit: { name: string } | null; food: { name: string } | null }[];
-	instructions: { text: string; title: string | null }[];
+	recipeIngredient: { note: string; quantity: number | null; unit: { name: string } | null; food: { name: string } | null }[];
+	recipeInstructions: { text: string; title: string | null }[];
 	notes: { title: string | null; text: string }[];
 	tags: { id: string; name: string; slug: string }[];
 	recipeCategory: { id: string; name: string; slug: string }[];
@@ -51,6 +51,18 @@ interface RecipeDetail {
 	dateUpdated: string;
 	extras: Record<string, string>;
 }
+
+const ingredientSchema = Type.Object({
+	note: Type.Optional(Type.String({ description: "Free-text ingredient description (e.g. 'finely chopped')" })),
+	quantity: Type.Optional(Type.Number({ description: "Amount (e.g. 2, 0.5)" })),
+	unit: Type.Optional(Type.String({ description: "Unit name (e.g. 'g', 'cups', 'stk')" })),
+	food: Type.Optional(Type.String({ description: "Food name (e.g. 'kjøttdeig', 'onion')" })),
+});
+
+const instructionSchema = Type.Object({
+	text: Type.String({ description: "Step text" }),
+	title: Type.Optional(Type.String({ description: "Optional section title" })),
+});
 
 const actionSchema = Type.Union([
 	Type.Literal("list"),
@@ -73,6 +85,16 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 			query: Type.Optional(Type.String({ description: "Search query (for search action)" })),
 			name: Type.Optional(Type.String({ description: "Recipe name (for create/update)" })),
 			description: Type.Optional(Type.String({ description: "Recipe description" })),
+			recipeYield: Type.Optional(Type.String({ description: "Yield / servings (e.g. '4 servings', '2-3 wraps')" })),
+			prepTime: Type.Optional(Type.String({ description: "Prep time (e.g. '15 Minutes')" })),
+			cookTime: Type.Optional(Type.String({ description: "Cook time (e.g. '30 Minutes')" })),
+			totalTime: Type.Optional(Type.String({ description: "Total time (e.g. '45 Minutes')" })),
+			ingredients: Type.Optional(Type.Array(ingredientSchema, { description: "Recipe ingredients" })),
+			instructions: Type.Optional(Type.Array(instructionSchema, { description: "Recipe steps/instructions" })),
+			notes: Type.Optional(Type.Array(Type.Object({
+				text: Type.String({ description: "Note text" }),
+				title: Type.Optional(Type.String({ description: "Note title" })),
+			}), { description: "Recipe notes" })),
 			url: Type.Optional(Type.String({ description: "URL to scrape recipe from (for scrape_url)" })),
 			tags: Type.Optional(Type.Array(Type.String(), { description: "Tag names" })),
 			categories: Type.Optional(Type.Array(Type.String(), { description: "Category names" })),
@@ -126,13 +148,26 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 					}
 
 					case "create": {
-						const body: Record<string, unknown> = {};
-						if (params.name) body.name = params.name;
-						if (params.description) body.description = params.description;
-						if (params.tags) body.tags = params.tags;
-						if (params.categories) body.recipeCategory = params.categories;
+						// Step 1: Create minimal recipe (Mealie POST returns a slug string)
+						const createBody: Record<string, unknown> = {};
+						if (params.name) createBody.name = params.name;
+						if (params.description) createBody.description = params.description;
 
-						const recipe = await mealie.post<RecipeDetail>("/recipes", body, signal);
+						const slug = await mealie.post<string>("/recipes", createBody, signal);
+						if (!slug) throw new Error("Recipe creation returned no slug");
+
+						const resolvedSlug = typeof slug === "string" ? slug : (slug as unknown as RecipeDetail).slug;
+						if (!resolvedSlug) throw new Error("Could not determine recipe slug from create response");
+						validatePathSegment(resolvedSlug, "slug");
+
+						// Step 2: If additional fields provided, PATCH the recipe
+						const patchBody = buildRecipeBody(params);
+						if (Object.keys(patchBody).length > 0) {
+							await mealie.patch<RecipeDetail>(`/recipes/${resolvedSlug}`, patchBody, signal);
+						}
+
+						// Step 3: Fetch the final recipe for display
+						const recipe = await mealie.get<RecipeDetail>(`/recipes/${resolvedSlug}`, undefined, signal);
 						return { content: [{ type: "text", text: `✅ Recipe created:\n\n${formatDetail(recipe)}` }], details: {} };
 					}
 
@@ -140,13 +175,12 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						if (!params.slug) {
 							return { content: [{ type: "text", text: "❌ Missing required parameter: slug" }], details: {} };
 						}
-						const body: Record<string, unknown> = {};
+						validatePathSegment(params.slug, "slug");
+
+						const body = buildRecipeBody(params);
 						if (params.name !== undefined) body.name = params.name;
 						if (params.description !== undefined) body.description = params.description;
-						if (params.tags) body.tags = params.tags;
-						if (params.categories) body.recipeCategory = params.categories;
 
-						validatePathSegment(params.slug, "slug");
 						const recipe = await mealie.patch<RecipeDetail>(`/recipes/${params.slug}`, body, signal);
 						return { content: [{ type: "text", text: `✅ Recipe updated:\n\n${formatDetail(recipe)}` }], details: {} };
 					}
@@ -179,6 +213,54 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 			}
 		},
 	});
+}
+
+/** Build recipe body fields for PATCH from tool params (excludes name/description which are handled separately). */
+function buildRecipeBody(params: {
+	recipeYield?: string;
+	prepTime?: string;
+	cookTime?: string;
+	totalTime?: string;
+	ingredients?: { note?: string; quantity?: number; unit?: string; food?: string }[];
+	instructions?: { text: string; title?: string }[];
+	notes?: { text: string; title?: string }[];
+	tags?: string[];
+	categories?: string[];
+}): Record<string, unknown> {
+	const body: Record<string, unknown> = {};
+
+	if (params.recipeYield !== undefined) body.recipeYield = params.recipeYield;
+	if (params.prepTime !== undefined) body.prepTime = params.prepTime;
+	if (params.cookTime !== undefined) body.cookTime = params.cookTime;
+	if (params.totalTime !== undefined) body.totalTime = params.totalTime;
+
+	if (params.ingredients) {
+		body.recipeIngredient = params.ingredients.map((ing) => ({
+			note: ing.note || "",
+			quantity: ing.quantity ?? null,
+			unit: ing.unit ? { name: ing.unit } : null,
+			food: ing.food ? { name: ing.food } : null,
+		}));
+	}
+
+	if (params.instructions) {
+		body.recipeInstructions = params.instructions.map((step) => ({
+			text: step.text,
+			title: step.title || "",
+		}));
+	}
+
+	if (params.notes) {
+		body.notes = params.notes.map((n) => ({
+			text: n.text,
+			title: n.title || "",
+		}));
+	}
+
+	if (params.tags) body.tags = params.tags.map((name) => ({ name }));
+	if (params.categories) body.recipeCategory = params.categories.map((name) => ({ name }));
+
+	return body;
 }
 
 function formatSummary(r: RecipeSummary): string {
@@ -224,20 +306,21 @@ function formatDetail(r: RecipeDetail): string {
 		if (nutrition) lines.push(nutrition);
 	}
 
-	if (r.ingredients?.length) {
+	if (r.recipeIngredient?.length) {
 		lines.push(`\n### Ingredients`);
-		for (const ing of r.ingredients) {
+		for (const ing of r.recipeIngredient) {
 			const qty = ing.quantity ?? "";
 			const unit = ing.unit?.name ? ` ${ing.unit.name}` : "";
 			const food = ing.food?.name ? ` ${ing.food.name}` : "";
-			lines.push(`- ${qty}${unit}${food} — ${ing.note}`);
+			const note = ing.note ? ` — ${ing.note}` : "";
+			lines.push(`- ${qty}${unit}${food}${note}`);
 		}
 	}
 
-	if (r.instructions?.length) {
+	if (r.recipeInstructions?.length) {
 		lines.push(`\n### Instructions`);
-		for (let i = 0; i < r.instructions.length; i++) {
-			const step = r.instructions[i];
+		for (let i = 0; i < r.recipeInstructions.length; i++) {
+			const step = r.recipeInstructions[i];
 			const title = step.title ? ` (${step.title})` : "";
 			lines.push(`${i + 1}. ${step.text}${title}`);
 		}

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -167,8 +167,12 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 								await mealie.patch<RecipeDetail>(`/recipes/${resolvedSlug}`, patchBody, signal);
 							} catch (patchErr: any) {
 								// Rollback: delete the stub recipe so we don't leave orphans
-								try { await mealie.delete(`/recipes/${resolvedSlug}`); } catch { /* best-effort */ }
-								throw new Error(`Recipe created but failed to add details (rolled back): ${patchErr.message || patchErr}`);
+								let rolledBack = false;
+								try { await mealie.delete(`/recipes/${resolvedSlug}`); rolledBack = true; } catch { /* best-effort */ }
+								const suffix = rolledBack
+									? "(rolled back)"
+									: `ORPHAN stub recipe may remain at slug: "${resolvedSlug}" — please delete it manually`;
+								throw new Error(`Recipe created but failed to add details (${suffix}): ${patchErr.message || patchErr}`);
 							}
 						}
 
@@ -206,6 +210,15 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						}
 						if (!/^https?:\/\//i.test(params.url)) {
 							return { content: [{ type: "text", text: "❌ Invalid URL: only http(s) URLs are supported for scraping." }], details: {} };
+						}
+						try {
+							const parsed = new URL(params.url);
+							const host = parsed.hostname;
+							if (/^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|::1|0\.0\.0\.0)/.test(host)) {
+								return { content: [{ type: "text", text: "❌ URL points to a private/internal address. Only public URLs are allowed for scraping." }], details: {} };
+							}
+						} catch {
+							return { content: [{ type: "text", text: "❌ Invalid URL format." }], details: {} };
 						}
 						const result = await mealie.post<RecipeDetail>("/recipes/create/url", { url: params.url }, signal);
 						return { content: [{ type: "text", text: `✅ Recipe scraped from URL:\n\n${formatDetail(result)}` }], details: {} };

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -13,6 +13,38 @@ function validatePathSegment(value: string, name: string): void {
 	}
 }
 
+/** Check if a hostname (brackets already stripped) points to a private/internal address. */
+function checkPrivateHost(host: string): boolean {
+	// Simple hostnames: localhost
+	if (host === "localhost") return true;
+
+	// Direct IPv4 private ranges
+	if (/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|0\.0\.0\.0)/.test(host)) return true;
+
+	// IPv6 loopback
+	if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+
+	// IPv4-mapped IPv6: ::ffff:a.b.c.d or ::ffff:XXXX:XXXX (hex)
+	const fffffMatch = host.match(/^::ffff:(.+)$/i);
+	if (fffffMatch) {
+		const rest = fffffMatch[1];
+		// If it's in dotted-decimal form, test directly
+		if (/^\d+\.\d+\.\d+\.\d+$/.test(rest)) {
+			return checkPrivateHost(rest);
+		}
+		// Hex form: two 16-bit groups like 7f00:1 — convert to dotted decimal
+		const hexMatch = rest.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+		if (hexMatch) {
+			const hi = parseInt(hexMatch[1], 16);
+			const lo = parseInt(hexMatch[2], 16);
+			const ipv4 = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+			return checkPrivateHost(ipv4);
+		}
+	}
+
+	return false;
+}
+
 interface RecipeSummary {
 	id: string;
 	name: string;
@@ -158,7 +190,11 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 
 						const resolvedSlug = typeof slug === "string" ? slug : (slug as unknown as RecipeDetail).slug;
 						if (!resolvedSlug) throw new Error("Could not determine recipe slug from create response");
-						validatePathSegment(resolvedSlug, "slug");
+						// Validate server-returned slug defensively, but don't let it orphan the stub — wrap with cleanup
+						if (!/^[\w-]+$/.test(resolvedSlug)) {
+							try { await mealie.delete(`/recipes/${resolvedSlug}`); } catch { /* best-effort cleanup */ }
+							throw new Error(`Invalid slug returned by Mealie: "${resolvedSlug}". The stub recipe has been cleaned up.`);
+						}
 
 						// Step 2: If additional fields provided, PATCH the recipe
 						const patchBody = buildRecipeBody(params);
@@ -216,14 +252,17 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						if (!/^https?:\/\//i.test(params.url)) {
 							return { content: [{ type: "text", text: "❌ Invalid URL: only http(s) URLs are supported for scraping." }], details: {} };
 						}
+						let host: string;
 						try {
-							const parsed = new URL(params.url);
-							const host = parsed.hostname;
-							if (/^(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.|::1|::ffff:|0\.0\.0\.0)/.test(host) || /::ffff:(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.)/.test(host)) {
-								return { content: [{ type: "text", text: "❌ URL points to a private/internal address. Only public URLs are allowed for scraping." }], details: {} };
-							}
+							host = new URL(params.url).hostname;
 						} catch {
 							return { content: [{ type: "text", text: "❌ Invalid URL format." }], details: {} };
+						}
+						// WHATWG URL returns IPv6 hostnames bracketed, e.g. "[::ffff:7f00:1]"
+						const unbracketed = host.replace(/^\[|\]$/g, "");
+						const isPrivate = checkPrivateHost(unbracketed);
+						if (isPrivate) {
+							return { content: [{ type: "text", text: "❌ URL points to a private/internal address. Only public URLs are allowed for scraping." }], details: {} };
 						}
 						const result = await mealie.post<RecipeDetail>("/recipes/create/url", { url: params.url }, signal);
 						return { content: [{ type: "text", text: `✅ Recipe scraped from URL:\n\n${formatDetail(result)}` }], details: {} };


### PR DESCRIPTION
## Problem

The recipes tool only supported `name`, `description`, `tags`, and `categories` for create/update. Aivena reported that creating a recipe like "Smash Burger Wraps" results in a skeleton with no ingredients or instructions — users have to manually complete it in the Mealie web UI.

## Solution

### New parameters for create/update:
- `ingredients` — array of `{ note, quantity, unit, food }`
- `instructions` — array of `{ text, title }`
- `notes` — array of `{ text, title }`
- `recipeYield` — e.g. "4 servings"
- `prepTime` / `cookTime` / `totalTime` — e.g. "15 Minutes"

### Create flow fix:
Mealie's POST `/recipes` only accepts a name and returns a slug string. The tool now does a two-step create:
1. POST with name/description → gets slug
2. PATCH with ingredients, instructions, metadata → completes the recipe
3. GET to fetch the final recipe for display

### Additional fixes:
- `RecipeDetail` interface field names corrected: `ingredients`→`recipeIngredient`, `instructions`→`recipeInstructions` (matching actual Mealie API)
- Tags/categories now sent as `[{ name: "..." }]` objects instead of plain strings in PATCH body
- `buildRecipeBody()` helper shared between create and update

Closes td-261995