### PR TITLE
fix(pi-mealie): add search to organizer list, resolve tags/categories/foods by name

### DIFF
--- a/extensions/pi-mealie/src/tools/organizer.ts
+++ b/extensions/pi-mealie/src/tools/organizer.ts
@@ -54,6 +54,7 @@ export function registerOrganizerTool(pi: ExtensionAPI) {
 			id: Type.Optional(Type.String({ description: "Item ID (for update/delete actions)" })),
 			name: Type.Optional(Type.String({ description: "Name (for create/update actions)" })),
 			description: Type.Optional(Type.String({ description: "Description (for create/update actions)" })),
+			query: Type.Optional(Type.String({ description: "Search query (for list_foods, list_units)" })),
 		}),
 		execute: async (_toolCallId, params, signal, _onUpdate, _ctx) => {
 			if (!isClientReady()) {
@@ -69,8 +70,8 @@ export function registerOrganizerTool(pi: ExtensionAPI) {
 					case "list_tags": return await listItems("Tags", "/organizers/tags", "🏷️", signal);
 					case "list_categories": return await listItems("Categories", "/organizers/categories", "📁", signal);
 					case "list_tools": return await listItems("Tools", "/organizers/tools", "🔧", signal);
-					case "list_foods": return await listItems("Foods", "/foods", "🥕", signal);
-					case "list_units": return await listItems("Units", "/units", "📏", signal);
+					case "list_foods": return await listItems("Foods", "/foods", "🥕", signal, params.query);
+					case "list_units": return await listItems("Units", "/units", "📏", signal, params.query);
 
 					// Create
 					case "create_tag": return await createItem("Tag", "/organizers/tags", params, signal);
@@ -103,8 +104,11 @@ export function registerOrganizerTool(pi: ExtensionAPI) {
 	});
 }
 
-async function listItems(label: string, path: string, icon: string, signal?: AbortSignal): Promise<AgentToolResult<{}>> {
-	const items = await apiList<OrganizerItem>(path, { signal });
+async function listItems(label: string, path: string, icon: string, signal?: AbortSignal, search?: string): Promise<AgentToolResult<{}>> {
+	const items = await apiList<OrganizerItem>(path, {
+		params: search ? { search } : undefined,
+		signal,
+	});
 	if (items.length === 0) {
 		return { content: [{ type: "text" as const, text: `No ${label.toLowerCase()} found.` }], details: {} };
 	}

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -45,6 +45,12 @@ function checkPrivateHost(host: string): boolean {
 	return false;
 }
 
+interface OrganizerItem {
+	id: string;
+	name: string;
+	slug: string;
+}
+
 interface RecipeSummary {
 	id: string;
 	name: string;
@@ -196,7 +202,7 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						}
 
 						// Step 2: If additional fields provided, PATCH the recipe
-						const patchBody = buildRecipeBody(params);
+						const patchBody = await buildRecipeBody(params, signal);
 						if (Object.keys(patchBody).length > 0) {
 							try {
 								await mealie.patch<RecipeDetail>(`/recipes/${resolvedSlug}`, patchBody, signal);
@@ -227,7 +233,7 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 						}
 						validatePathSegment(params.slug, "slug");
 
-						const body = buildRecipeBody(params);
+						const body = await buildRecipeBody(params, signal);
 						if (params.name !== undefined) body.name = params.name;
 						if (params.description !== undefined) body.description = params.description;
 
@@ -277,8 +283,20 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 	});
 }
 
-/** Build recipe body fields for PATCH from tool params (excludes name/description which are handled separately). */
-function buildRecipeBody(params: {
+/** Look up an organizer item by exact name via search, returning the full object if found. */
+async function resolveOrganizerName(path: string, name: string, signal?: AbortSignal): Promise<OrganizerItem | null> {
+	try {
+		const items = await apiList<OrganizerItem>(path, { params: { search: name }, signal });
+		const match = items.find((i) => i.name.toLowerCase() === name.toLowerCase());
+		return match ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** Build recipe body fields for PATCH from tool params (excludes name/description which are handled separately).
+ *  Resolves tag, category, food, and unit names to full Mealie objects to avoid 422 errors and duplicates. */
+async function buildRecipeBody(params: {
 	recipeYield?: string;
 	prepTime?: string;
 	cookTime?: string;
@@ -288,7 +306,7 @@ function buildRecipeBody(params: {
 	notes?: { text: string; title?: string }[];
 	tags?: string[];
 	categories?: string[];
-}): Record<string, unknown> {
+}, signal?: AbortSignal): Promise<Record<string, unknown>> {
 	const body: Record<string, unknown> = {};
 
 	if (params.recipeYield !== undefined) body.recipeYield = params.recipeYield;
@@ -297,12 +315,22 @@ function buildRecipeBody(params: {
 	if (params.totalTime !== undefined) body.totalTime = params.totalTime;
 
 	if (params.ingredients) {
-		body.recipeIngredient = params.ingredients.map((ing) => ({
-			note: ing.note || "",
-			quantity: ing.quantity ?? null,
-			unit: ing.unit ? { name: ing.unit } : null,
-			food: ing.food ? { name: ing.food } : null,
-		}));
+		body.recipeIngredient = [];
+		for (const ing of params.ingredients) {
+			const entry: Record<string, unknown> = {
+				note: ing.note || "",
+				quantity: ing.quantity ?? null,
+			};
+			if (ing.unit) {
+				const found = await resolveOrganizerName("/units", ing.unit, signal);
+				entry.unit = found ? { id: found.id, name: found.name, slug: found.slug } : { name: ing.unit };
+			}
+			if (ing.food) {
+				const found = await resolveOrganizerName("/foods", ing.food, signal);
+				entry.food = found ? { id: found.id, name: found.name, slug: found.slug } : { name: ing.food };
+			}
+			(body.recipeIngredient as Record<string, unknown>[]).push(entry);
+		}
 	}
 
 	if (params.instructions) {
@@ -319,8 +347,20 @@ function buildRecipeBody(params: {
 		}));
 	}
 
-	if (params.tags) body.tags = params.tags.map((name) => ({ name }));
-	if (params.categories) body.recipeCategory = params.categories.map((name) => ({ name }));
+	if (params.tags) {
+		body.tags = [];
+		for (const name of params.tags) {
+			const found = await resolveOrganizerName("/organizers/tags", name, signal);
+			(body.tags as Record<string, unknown>[]).push(found ? { id: found.id, name: found.name, slug: found.slug } : { name });
+		}
+	}
+	if (params.categories) {
+		body.recipeCategory = [];
+		for (const name of params.categories) {
+			const found = await resolveOrganizerName("/organizers/categories", name, signal);
+			(body.recipeCategory as Record<string, unknown>[]).push(found ? { id: found.id, name: found.name, slug: found.slug } : { name });
+		}
+	}
 
 	return body;
 }


### PR DESCRIPTION
## Problem

Reported by Aivena — 3 bugs blocking real recipe usage:

1. **`list_foods` / `list_units` have no search** — dumps all 2683+ foods with no way to filter. The Mealie API supports `?search=` on both endpoints.
2. **Tags/categories sent as `{name}` cause 422** — Mealie requires full objects `{id, name, slug}` for existing tags/categories. Sending `{name}` alone is rejected.
3. **Food/unit names create duplicates** — `buildRecipeBody` sends `{food: {name: "kjøttdeig"}}` which creates a duplicate food instead of linking the existing one.

## Solution

### Bug 1: Search for foods/units
- Added optional `query` parameter to `mealie_organizer` tool schema
- `list_foods` and `list_units` actions pass it through as `search` query param to Mealie API
- Updated `listItems()` to accept optional `search` parameter

### Bug 2 & 3: Resolve by name before PATCH
- Added `resolveOrganizerName()` helper that searches Mealie API by name and matches case-insensitively
- `buildRecipeBody()` is now async — resolves tags, categories, foods, and units by name before building the PATCH body
- If found: sends full `{id, name, slug}` object (Mealie accepts this)
- If not found: falls back to `{name}` (Mealie creates it, which was the original behavior)
- Tags searched via `/organizers/tags?search=NAME`
- Categories searched via `/organizers/categories?search=NAME`
- Foods searched via `/foods?search=NAME`
- Units searched via `/units?search=NAME`

Closes td-400b5c