### PR TITLE
fix(pi-mealie): remove slug from food/unit PATCH objects

### DIFF
--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -323,11 +323,11 @@ async function buildRecipeBody(params: {
 			};
 			if (ing.unit) {
 				const found = await resolveOrganizerName("/units", ing.unit, signal);
-				entry.unit = found ? { id: found.id, name: found.name, slug: found.slug } : { name: ing.unit };
+				entry.unit = found ? { id: found.id, name: found.name } : { name: ing.unit };
 			}
 			if (ing.food) {
 				const found = await resolveOrganizerName("/foods", ing.food, signal);
-				entry.food = found ? { id: found.id, name: found.name, slug: found.slug } : { name: ing.food };
+				entry.food = found ? { id: found.id, name: found.name } : { name: ing.food };
 			}
 			(body.recipeIngredient as Record<string, unknown>[]).push(entry);
 		}


### PR DESCRIPTION
## Problem

`resolveOrganizerName` returns `{ id, name, slug }` but IngredientFood and IngredientUnit in the Mealie API do NOT have a `slug` field. Sending `slug: undefined` in food/unit objects causes a 500 TypeError on `PATCH /recipes/{slug}`.

Reported by Aivena — blocking recipe creation with ingredients.

## Fix

In `buildRecipeBody`, food and unit objects now use `{ id, name }` (no slug). Tags and categories keep `{ id, name, slug }` since they do have slugs in the Mealie API.

Closes td-b49c0d