### PR TITLE
fix(pi-mealie): auto-create missing foods/units in recipe PATCH

### DIFF
--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -323,11 +323,21 @@ async function buildRecipeBody(params: {
 			};
 			if (ing.unit) {
 				const found = await resolveOrganizerName("/units", ing.unit, signal);
-				entry.unit = found ? { id: found.id, name: found.name } : { name: ing.unit };
+				if (found) {
+					entry.unit = { id: found.id, name: found.name };
+				} else {
+					const created = await mealie.post<OrganizerItem>("/units", { name: ing.unit }, signal);
+					entry.unit = { id: created.id, name: created.name };
+				}
 			}
 			if (ing.food) {
 				const found = await resolveOrganizerName("/foods", ing.food, signal);
-				entry.food = found ? { id: found.id, name: found.name } : { name: ing.food };
+				if (found) {
+					entry.food = { id: found.id, name: found.name };
+				} else {
+					const created = await mealie.post<OrganizerItem>("/foods", { name: ing.food }, signal);
+					entry.food = { id: created.id, name: created.name };
+				}
 			}
 			(body.recipeIngredient as Record<string, unknown>[]).push(entry);
 		}


### PR DESCRIPTION
## Problem

When `buildRecipeBody` sends an ingredient with a food/unit that does not yet exist (e.g. `{ food: { name: "hvetetortilla" } }`), Mealie returns 500 ValueError. The `RecipeIngredient-Input` schema accepts `CreateIngredientFood` (name + optional id=null), but the PATCH endpoint does not actually auto-create it.

## Fix

When `resolveOrganizerName` returns null (food/unit not found), auto-create it via POST `/api/foods` or POST `/api/units` before building the ingredient object. This way `mealie_recipes create` and `update` work end-to-end without the caller needing to manually create foods/units first.

Reported by Aivena.

Closes td-c54971