### PR TITLE
fix(pi-mealie): add ingredientReferences to recipe instructions

### DIFF
--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -347,6 +347,7 @@ async function buildRecipeBody(params: {
 		body.recipeInstructions = params.instructions.map((step) => ({
 			text: step.text,
 			title: step.title || "",
+			ingredientReferences: [] as { referenceId: string }[],
 		}));
 	}
 


### PR DESCRIPTION
## Problem

Mealie v3.15.1 returns 500 TypeError when PATCHing `recipeInstructions`. Steps are sent without `ingredientReferences`, which the OpenAPI schema marks optional with default `[]`. But Mealie's backend iterates the field and crashes on undefined.

Bug #5 in the pi-mealie recipe create/update flow (previous 4 fixed in PRs #125, #126, #127).

## Fix

Explicitly send `ingredientReferences: []` for each instruction step in `buildRecipeBody`.

Found and diagnosed by Aivena.

Closes td-1c6b08