### PR TITLE
feat(pi-mealie): auto-update lastMade when adding recipe to meal plan

### DIFF
--- a/extensions/pi-mealie/AGENTS.md
+++ b/extensions/pi-mealie/AGENTS.md
@@ -10,7 +10,7 @@ Pi extension providing Mealie API access via four tools:
 - **`mealie_recipes`** — Browse, search, get, create, update, delete, and scrape recipes from URLs
 - **`mealie_mealplans`** — View today/week/date meals, add and remove meal plan entries. When adding a recipe to today or a past date, automatically updates the recipe's `lastMade` timestamp.
 - **`mealie_shopping`** — View shopping lists, add/check/uncheck/delete items
-- **`mealie_organizer`** — List and create tags, categories, tools, foods, and units
+- **`mealie_organizer`** — List, create, update, and delete tags, categories, tools, foods, and units. Supports search for foods and units.
 
 ## Configuration
 
@@ -32,10 +32,10 @@ Both `baseUrl` and `apiToken` are required. Get an API token from Mealie → Set
 - `src/index.ts` — Extension entry point; initializes client on session_start
 - `src/settings.ts` — Reads baseUrl/apiToken from global/project settings
 - `src/client.ts` — HTTP client wrapper; handles auth, pagination, error reporting
-- `src/tools/recipes.ts` — Recipe CRUD + URL scraping. `servings` param sets the numeric `recipeServings` for scaling.
+- `src/tools/recipes.ts` — Recipe CRUD + URL scraping. Supports ingredients, instructions, notes, tags, categories, servings (`recipeServings`). Auto-creates missing foods/units.
 - `src/tools/mealplans.ts` — Meal plan viewing and management
 - `src/tools/shopping.ts` — Shopping list management
-- `src/tools/organizer.ts` — Tags, categories, tools, foods, units
+- `src/tools/organizer.ts` — Full CRUD for tags, categories, tools, foods, units + search
 
 ## API Conventions
 

--- a/extensions/pi-mealie/AGENTS.md
+++ b/extensions/pi-mealie/AGENTS.md
@@ -8,7 +8,7 @@ description: Mealie recipe manager API integration for pi
 Pi extension providing Mealie API access via four tools:
 
 - **`mealie_recipes`** — Browse, search, get, create, update, delete, and scrape recipes from URLs
-- **`mealie_mealplans`** — View today/week/date meals, add and remove meal plan entries
+- **`mealie_mealplans`** — View today/week/date meals, add and remove meal plan entries. When adding a recipe to today or a past date, automatically updates the recipe's `lastMade` timestamp.
 - **`mealie_shopping`** — View shopping lists, add/check/uncheck/delete items
 - **`mealie_organizer`** — List and create tags, categories, tools, foods, and units
 
@@ -32,7 +32,7 @@ Both `baseUrl` and `apiToken` are required. Get an API token from Mealie → Set
 - `src/index.ts` — Extension entry point; initializes client on session_start
 - `src/settings.ts` — Reads baseUrl/apiToken from global/project settings
 - `src/client.ts` — HTTP client wrapper; handles auth, pagination, error reporting
-- `src/tools/recipes.ts` — Recipe CRUD + URL scraping
+- `src/tools/recipes.ts` — Recipe CRUD + URL scraping. `servings` param sets the numeric `recipeServings` for scaling.
 - `src/tools/mealplans.ts` — Meal plan viewing and management
 - `src/tools/shopping.ts` — Shopping list management
 - `src/tools/organizer.ts` — Tags, categories, tools, foods, units

--- a/extensions/pi-mealie/CHANGELOG.md
+++ b/extensions/pi-mealie/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 — 2026-04-15
+
+- `mealie_mealplans`: auto-update recipe `lastMade` when adding a recipe to today or a past date
+- `mealie_recipes`: add `servings` numeric parameter for `recipeServings` (recipe scaling); fixes recipes created with 0 portions
+
 ## 0.1.0 — 2026-04-11
 
 - Initial release

--- a/extensions/pi-mealie/CHANGELOG.md
+++ b/extensions/pi-mealie/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - `mealie_mealplans`: auto-update recipe `lastMade` when adding a recipe to today or a past date
 - `mealie_recipes`: add `servings` numeric parameter for `recipeServings` (recipe scaling); fixes recipes created with 0 portions
+- `mealie_recipes`: add ingredients, instructions, notes, tags, and categories to create/update (PR #124)
+- `mealie_recipes`: auto-resolve tags, categories, and foods by name; auto-create missing foods/units during recipe PATCH (PR #125, #127)
+- `mealie_organizer`: full CRUD — add update and delete for tags, categories, tools, foods, and units (PR #123)
+- `mealie_organizer`: search for foods and units (PR #125)
+- `mealie_mealplans`: expose entry IDs in output for remove action; fix recipe linking (PR #123)
+- Bug fixes: remove invalid slug from food/unit objects (PR #126), add ingredientReferences to instructions (PR #128)
 
 ## 0.1.0 — 2026-04-11
 

--- a/extensions/pi-mealie/README.md
+++ b/extensions/pi-mealie/README.md
@@ -6,10 +6,10 @@ Mealie recipe manager API integration for pi.
 
 | Tool | Description |
 |------|-------------|
-| `mealie_recipes` | Browse, search, get, create, update, delete, and scrape recipes |
+| `mealie_recipes` | Browse, search, get, create, update, delete, and scrape recipes. Supports ingredients, instructions, notes, tags, categories, and `servings` param for recipe scaling |
 | `mealie_mealplans` | View meals today/week/date, add and remove entries. Auto-updates recipe `lastMade` when adding a recipe to today/past dates |
 | `mealie_shopping` | Shopping lists — view, add, check/uncheck/delete items |
-| `mealie_organizer` | List and create tags, categories, tools, foods, units |
+| `mealie_organizer` | List, create, update, delete tags, categories, tools, foods, and units. Search for foods and units |
 
 ## Configuration
 

--- a/extensions/pi-mealie/README.md
+++ b/extensions/pi-mealie/README.md
@@ -7,7 +7,7 @@ Mealie recipe manager API integration for pi.
 | Tool | Description |
 |------|-------------|
 | `mealie_recipes` | Browse, search, get, create, update, delete, and scrape recipes |
-| `mealie_mealplans` | View meals today/week/date, add and remove entries |
+| `mealie_mealplans` | View meals today/week/date, add and remove entries. Auto-updates recipe `lastMade` when adding a recipe to today/past dates |
 | `mealie_shopping` | Shopping lists — view, add, check/uncheck/delete items |
 | `mealie_organizer` | List and create tags, categories, tools, foods, units |
 

--- a/extensions/pi-mealie/package-lock.json
+++ b/extensions/pi-mealie/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@e9n/pi-mealie",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@e9n/pi-mealie",
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@mariozechner/pi-coding-agent": "^0.65.2",

--- a/extensions/pi-mealie/package.json
+++ b/extensions/pi-mealie/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-mealie",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Mealie recipe manager API integration for pi — recipes, meal plans, and shopping lists",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-mealie/src/tools/mealplans.ts
+++ b/extensions/pi-mealie/src/tools/mealplans.ts
@@ -175,6 +175,25 @@ export function registerMealplansTool(pi: ExtensionAPI) {
 						if (params.note) body.note = params.note;
 
 						const entry = await mealie.post<MealPlanEntry>("/households/mealplans", body, signal);
+
+						// Update recipe's lastMade when meal plan date is today or past,
+						// and is more recent than the current lastMade
+						if (params.recipeSlug) {
+							const today = toLocalISODate(new Date());
+							if (params.date <= today) {
+								try {
+									validatePathSegment(params.recipeSlug, "recipeSlug");
+									const recipe = await mealie.get<{ lastMade: string | null }>(`/recipes/${params.recipeSlug}`, undefined, signal);
+									const currentLastMade = recipe?.lastMade ? recipe.lastMade.slice(0, 10) : null;
+									if (!currentLastMade || params.date > currentLastMade) {
+										await mealie.patch(`/recipes/${params.recipeSlug}/last-made`, { timestamp: params.date + "T12:00:00Z" }, signal);
+									}
+								} catch {
+									// Best-effort — don't fail the meal plan add if last-made update fails
+								}
+							}
+						}
+
 						return { content: [{ type: "text", text: "Meal added to " + params.date + ":\n\n" + formatEntry(entry) }], details: {} };
 					}
 

--- a/extensions/pi-mealie/src/tools/mealplans.ts
+++ b/extensions/pi-mealie/src/tools/mealplans.ts
@@ -193,10 +193,10 @@ export function registerMealplansTool(pi: ExtensionAPI) {
 								const currentLastMade = recipe.lastMade ? recipe.lastMade.slice(0, 10) : null;
 								if (!currentLastMade || params.date > currentLastMade) {
 									try {
-										await mealie.patch(`/recipes/${params.recipeSlug}/last-made`, { timestamp: params.date + "T12:00:00" }, signal);
+										await mealie.patch(`/recipes/${recipe.slug}/last-made`, { timestamp: params.date + "T12:00:00" }, signal);
 									} catch (err) {
 										// Best-effort — don't fail the meal plan add if last-made update fails
-										console.warn('Failed to update lastMade for', params.recipeSlug, err);
+										console.warn('Failed to update lastMade for', recipe.slug, err);
 									}
 								}
 							}

--- a/extensions/pi-mealie/src/tools/mealplans.ts
+++ b/extensions/pi-mealie/src/tools/mealplans.ts
@@ -21,14 +21,22 @@ function validatePathSegment(value: string, name: string): void {
 	}
 }
 
-/** Resolve a recipe slug to its UUID by fetching the recipe detail. */
-async function resolveRecipeId(slug: string, signal?: AbortSignal): Promise<string> {
+/** Recipe data returned by the Mealie API. */
+interface RecipeSummary {
+	id: string;
+	name: string;
+	slug: string;
+	lastMade: string | null;
+}
+
+/** Resolve a recipe slug by fetching the recipe detail. Returns the full recipe object. */
+async function resolveRecipe(slug: string, signal?: AbortSignal): Promise<RecipeSummary> {
 	validatePathSegment(slug, "recipeSlug");
-	const recipe = await mealie.get<{ id: string; name: string; slug: string }>(`/recipes/${slug}`, undefined, signal);
+	const recipe = await mealie.get<RecipeSummary>(`/recipes/${slug}`, undefined, signal);
 	if (!recipe?.id) {
 		throw new Error(`Recipe not found for slug "${slug}"`);
 	}
-	return recipe.id;
+	return recipe;
 }
 
 interface MealPlanEntry {
@@ -163,10 +171,11 @@ export function registerMealplansTool(pi: ExtensionAPI) {
 							date: params.date,
 							entryType: params.entryType || "dinner",
 						};
+						let recipe: RecipeSummary | undefined;
 						if (params.recipeSlug) {
-							// Resolve slug → recipe UUID (Mealie API requires recipe_id, not slug)
-							const recipeId = await resolveRecipeId(params.recipeSlug, signal);
-							body.recipeId = recipeId;
+							// Resolve slug → recipe detail (Mealie API requires recipe_id, not slug)
+							recipe = await resolveRecipe(params.recipeSlug, signal);
+							body.recipeId = recipe.id;
 						} else if (params.title) {
 							body.title = params.title;
 						} else {
@@ -177,19 +186,18 @@ export function registerMealplansTool(pi: ExtensionAPI) {
 						const entry = await mealie.post<MealPlanEntry>("/households/mealplans", body, signal);
 
 						// Update recipe's lastMade when meal plan date is today or past,
-						// and is more recent than the current lastMade
-						if (params.recipeSlug) {
+						// and is more recent than the current lastMade (reuses recipe from resolveRecipe above)
+						if (recipe) {
 							const today = toLocalISODate(new Date());
 							if (params.date <= today) {
-								try {
-									validatePathSegment(params.recipeSlug, "recipeSlug");
-									const recipe = await mealie.get<{ lastMade: string | null }>(`/recipes/${params.recipeSlug}`, undefined, signal);
-									const currentLastMade = recipe?.lastMade ? recipe.lastMade.slice(0, 10) : null;
-									if (!currentLastMade || params.date > currentLastMade) {
-										await mealie.patch(`/recipes/${params.recipeSlug}/last-made`, { timestamp: params.date + "T12:00:00Z" }, signal);
+								const currentLastMade = recipe.lastMade ? recipe.lastMade.slice(0, 10) : null;
+								if (!currentLastMade || params.date > currentLastMade) {
+									try {
+										await mealie.patch(`/recipes/${params.recipeSlug}/last-made`, { timestamp: params.date + "T12:00:00" }, signal);
+									} catch (err) {
+										// Best-effort — don't fail the meal plan add if last-made update fails
+										console.warn('Failed to update lastMade for', params.recipeSlug, err);
 									}
-								} catch {
-									// Best-effort — don't fail the meal plan add if last-made update fails
 								}
 							}
 						}

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -125,7 +125,7 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 			name: Type.Optional(Type.String({ description: "Recipe name (for create/update)" })),
 			description: Type.Optional(Type.String({ description: "Recipe description" })),
 			recipeYield: Type.Optional(Type.String({ description: "Yield display text (e.g. '4 servings', '2-3 wraps')" })),
-			servings: Type.Optional(Type.Number({ description: "Number of servings (numeric, e.g. 4). Used for recipe scaling. Defaults to 0 if not set." })),
+			servings: Type.Optional(Type.Number({ description: "Number of servings (numeric, e.g. 4). Used for recipe scaling. Defaults to 0 if not set.", minimum: 0 })),
 			prepTime: Type.Optional(Type.String({ description: "Prep time (e.g. '15 Minutes')" })),
 			cookTime: Type.Optional(Type.String({ description: "Cook time (e.g. '30 Minutes')" })),
 			totalTime: Type.Optional(Type.String({ description: "Total time (e.g. '45 Minutes')" })),
@@ -399,7 +399,7 @@ function formatDetail(r: RecipeDetail): string {
 	lines.push(`**Slug:** ${r.slug}`);
 	if (r.description) lines.push(`\n${r.description}`);
 	if (r.recipeYield) lines.push(`**Yield:** ${r.recipeYield}`);
-	if (r.recipeServings) lines.push(`**Servings:** ${r.recipeServings}`);
+	if (r.recipeServings != null) lines.push(`**Servings:** ${r.recipeServings}`);
 	if (r.prepTime) lines.push(`**Prep Time:** ${r.prepTime}`);
 	if (r.cookTime) lines.push(`**Cook Time:** ${r.cookTime}`);
 	if (r.totalTime) lines.push(`**Total Time:** ${r.totalTime}`);

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -73,6 +73,7 @@ interface RecipeDetail {
 	slug: string;
 	description: string | null;
 	recipeYield: string | null;
+	recipeServings: number;
 	prepTime: string | null;
 	cookTime: string | null;
 	totalTime: string | null;
@@ -123,7 +124,8 @@ export function registerRecipesTool(pi: ExtensionAPI) {
 			query: Type.Optional(Type.String({ description: "Search query (for search action)" })),
 			name: Type.Optional(Type.String({ description: "Recipe name (for create/update)" })),
 			description: Type.Optional(Type.String({ description: "Recipe description" })),
-			recipeYield: Type.Optional(Type.String({ description: "Yield / servings (e.g. '4 servings', '2-3 wraps')" })),
+			recipeYield: Type.Optional(Type.String({ description: "Yield display text (e.g. '4 servings', '2-3 wraps')" })),
+			servings: Type.Optional(Type.Number({ description: "Number of servings (numeric, e.g. 4). Used for recipe scaling. Defaults to 0 if not set." })),
 			prepTime: Type.Optional(Type.String({ description: "Prep time (e.g. '15 Minutes')" })),
 			cookTime: Type.Optional(Type.String({ description: "Cook time (e.g. '30 Minutes')" })),
 			totalTime: Type.Optional(Type.String({ description: "Total time (e.g. '45 Minutes')" })),
@@ -298,6 +300,7 @@ async function resolveOrganizerName(path: string, name: string, signal?: AbortSi
  *  Resolves tag, category, food, and unit names to full Mealie objects to avoid 422 errors and duplicates. */
 async function buildRecipeBody(params: {
 	recipeYield?: string;
+	servings?: number;
 	prepTime?: string;
 	cookTime?: string;
 	totalTime?: string;
@@ -310,6 +313,7 @@ async function buildRecipeBody(params: {
 	const body: Record<string, unknown> = {};
 
 	if (params.recipeYield !== undefined) body.recipeYield = params.recipeYield;
+	if (params.servings !== undefined) body.recipeServings = params.servings;
 	if (params.prepTime !== undefined) body.prepTime = params.prepTime;
 	if (params.cookTime !== undefined) body.cookTime = params.cookTime;
 	if (params.totalTime !== undefined) body.totalTime = params.totalTime;
@@ -395,6 +399,7 @@ function formatDetail(r: RecipeDetail): string {
 	lines.push(`**Slug:** ${r.slug}`);
 	if (r.description) lines.push(`\n${r.description}`);
 	if (r.recipeYield) lines.push(`**Yield:** ${r.recipeYield}`);
+	if (r.recipeServings) lines.push(`**Servings:** ${r.recipeServings}`);
 	if (r.prepTime) lines.push(`**Prep Time:** ${r.prepTime}`);
 	if (r.cookTime) lines.push(`**Cook Time:** ${r.cookTime}`);
 	if (r.totalTime) lines.push(`**Total Time:** ${r.totalTime}`);


### PR DESCRIPTION
## Feature

When adding a recipe to the meal plan for today or a past date, automatically update the recipe's `lastMade` field via `PATCH /recipes/{slug}/last-made`.

### Logic
- Only triggers when `recipeSlug` is provided (not for note/title entries)
- Only when `date <= today` (future dates never touch `lastMade`)
- Fetches current `lastMade`, compares as date strings (YYYY-MM-DD)
- Only PATCHes if the new date is more recent than current `lastMade`
- Best-effort: failures don't block the meal plan add

### API used
`PATCH /api/recipes/{slug}/last-made` with body `{ timestamp: "ISO datetime" }` — dedicated Mealie endpoint.

Designed by Aivena.

Closes td-8ccea1