### PR TITLE
feat(pi-github): add PR thread resolution tools for agentic fix workflow

### DIFF
--- a/extensions/pi-github/AGENTS.md
+++ b/extensions/pi-github/AGENTS.md
@@ -1,40 +1,54 @@
 ---
 name: pi-github
-description: GitHub integration extension for pi — PR management, issue tracking, CI status, and review workflows via gh CLI commands
+description: GitHub integration extension for pi — PR management, issue tracking, CI status, and review workflows via gh CLI commands + PR thread tools
 ---
 
 ## Overview
 
-Commands-only extension providing rich GitHub workflows via the `gh` CLI. No LLM tool — all interactions are triggered by the user from the TUI. Every command is registered under both a short `/gh-*` alias and a long `/github-*` alias. Key workflows: listing PRs/issues/notifications, creating PRs, showing review feedback, fixing unresolved review threads (with agentic implementation loop), merging PRs with branch cleanup, and checking CI status.
+Commands + tools extension providing rich GitHub workflows via the `gh` CLI.
+Every command is registered under both a short `/gh-*` alias and a long
+`/github-*` alias. Key workflows: listing PRs/issues/notifications, creating PRs,
+showing review feedback, fixing unresolved review threads (with agentic
+implementation loop and dedicated resolution tools), merging PRs with branch
+cleanup, and checking CI status.
 
-**Stack:** TypeScript · `gh` CLI · `execFile` (no SDK) · GraphQL (for PR thread resolution)
+**Stack:** TypeScript · `gh` CLI · `execFile` (no SDK) · GraphQL (for PR
+thread resolution) · `@sinclair/typebox` (tool parameter schemas)
 
 ## Architecture
 
 ```
 src/
-├── index.ts     # Entry — registers all commands, handles lifecycle (cwd, session resets)
-├── commands.ts  # All standard /gh-* commands (prs, issues, status, notifications, pr-create, pr-review, actions)
-├── pr-fix.ts    # /gh-pr-fix — fetches unresolved review threads via GraphQL, launches agentic fix loop
-├── pr-merge.ts  # /gh-pr-merge — squash/merge PR, post summary comment, delete branches, pull base
-├── gh.ts        # gh CLI wrapper: gh(), ghJson(), ghGraphql(), gitExec(), getCurrentBranch(), getRepoSlug()
-└── logger.ts    # Extension logger
+├── index.ts          # Entry — registers commands + tools, handles lifecycle
+├── commands.ts       # Standard /gh-* commands (prs, issues, status, notifications, pr-create, pr-review, actions)
+├── pr-fix.ts         # /gh-pr-fix — fetches unresolved threads, sends prompt to agent
+├── pr-fix-tools.ts   # LLM tools: github_review_thread_reply, github_resolve_review_thread, github_post_pr_comment
+├── pr-merge.ts       # /gh-pr-merge — squash/merge PR, post summary, delete branches
+├── gh.ts             # gh CLI wrapper: gh(), ghJson(), ghGraphql(), gitExec(), getCurrentBranch(), getRepoSlug()
+└── logger.ts         # Extension logger
 prompts/
-└── gh-pr-fix.md # Prompt template injected into the agentic PR-fix flow
+└── gh-pr-fix.md      # Prompt template injected into the PR-fix agentic flow
 ```
 
 ## Key Files
 
-- `src/index.ts` — Calls `registerCommands`, `registerPrFixCommand`, `registerPrMergeCommand`; tracks `cwd` across `session_start`, `session_switch`, `session_fork`.
+- `src/index.ts` — Calls `registerCommands`, `registerPrFixCommand`, `registerPrMergeCommand`, `registerPrFixTools`; tracks `cwd` across `session_start`, `session_switch`, `session_fork`.
 - `src/commands.ts` — `registerDualCommand` helper; registers: `gh-prs`, `gh-issues`, `gh-status`, `gh-notifications`, `gh-pr-create`, `gh-pr-review`, `gh-actions`.
 - `src/pr-fix.ts` — GraphQL query for unresolved review threads; presents threads to agent; agent reads, fixes, commits, pushes, resolves.
+- `src/pr-fix-tools.ts` — **New** — Registers three LLM tools for reliable thread resolution: `github_review_thread_reply` (addPullRequestReviewThreadReply GraphQL), `github_resolve_review_thread` (resolveReviewThread GraphQL, idempotent), `github_post_pr_comment` (gh pr comment wrapper).
 - `src/pr-merge.ts` — Fetches PR metadata, squash-merges (configurable), posts summary comment, deletes remote + local branch, pulls base.
 - `src/gh.ts` — All `gh`/`git` subprocess calls. 30s timeout, 5 MB buffer.
 - `prompts/gh-pr-fix.md` — Registered as a prompt template; injected into the PR-fix agentic flow with thread context.
 
 ## Tools
 
-None — this extension registers no LLM tools.
+Three LLM tools for the agentic PR-fix workflow:
+
+| Tool | Parameters | What it does |
+|------|------------|--------------|
+| `github_review_thread_reply` | `thread_id`, `message` | Replies to a PR review thread via `addPullRequestReviewThreadReply` |
+| `github_resolve_review_thread` | `thread_id` | Resolves a PR review thread via `resolveReviewThread` (idempotent) |
+| `github_post_pr_comment` | `owner`, `repo`, `pr_number`, `body` | Posts a top-level comment on the PR via `gh pr comment` |
 
 ## Commands
 
@@ -68,4 +82,5 @@ None.
 - `cwd` is captured per-session and passed to all `gh`/`git` subprocess calls.
 - `resetPrFixState()` is called on `session_switch` / `session_fork` / `session_shutdown` to clear mid-flight state.
 - `prompts/gh-pr-fix.md` uses frontmatter `description` and a `$@` placeholder for injected thread context.
+- `pr-fix-tools.ts` returns structured markdown (`content` array + `details` object) following extension conventions.
 - No `console.log` — use the logger.

--- a/extensions/pi-github/package-lock.json
+++ b/extensions/pi-github/package-lock.json
@@ -12,7 +12,8 @@
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
-        "@mariozechner/pi-coding-agent": "*"
+        "@mariozechner/pi-coding-agent": "*",
+        "@sinclair/typebox": "*"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/extensions/pi-github/package.json
+++ b/extensions/pi-github/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-github/prompts/gh-pr-fix.md
+++ b/extensions/pi-github/prompts/gh-pr-fix.md
@@ -11,11 +11,11 @@ Fix the unresolved review threads on this PR. For each thread:
    - ⚪ **SUGGESTION** — fix only if trivial. Otherwise skip and note it in your report.
 4. Apply the fix surgically (edit only what's needed — do not refactor surrounding code)
 5. Verify the fix compiles (`tsc --noEmit` or equivalent)
-6. **Leave a GitHub comment on the thread** describing what was done:
+6. **Reply to the review thread** using the `github_review_thread_reply` tool describing what was done:
    - If fixed: briefly describe the change made and why it resolves the concern
    - If `WONTFIX`: explain why the fix was not applied
    - If skipped (SUGGESTION): note that it has been logged to the backlog
-7. **Resolve the thread on GitHub** if the fix was applied or a `WONTFIX` was given. Leave threads open only if the fix is partial or requires further discussion.
+7. **Resolve the thread on GitHub** using the `github_resolve_review_thread` tool if the fix was applied or a `WONTFIX` was given. Leave threads open only if the fix is partial or requires further discussion.
 
 **Do not re-fix threads already marked resolved or where a previous `WONTFIX` was accepted by the reviewer.**
 
@@ -23,6 +23,7 @@ After all threads are handled:
 
 8. Stage, commit (use a descriptive conventional commit message referencing the PR), and push to the current branch
 9. Verify the push succeeded
+10. **Post a summary comment on the PR** using the `github_post_pr_comment` tool with a table of what was fixed, WONTFIX'd, or skipped
 
 Report a summary to the user that includes:
 - What was fixed per thread (one bullet each), with its classification (BLOCKER/WARNING/SUGGESTION)

--- a/extensions/pi-github/src/index.ts
+++ b/extensions/pi-github/src/index.ts
@@ -20,6 +20,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { SettingsManager, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { registerCommands, setSessionCwd } from "./commands.ts";
 import { registerPrFixCommand } from "./pr-fix.ts";
+import { registerPrFixTools } from "./pr-fix-tools.ts";
 import { registerPrMergeCommand } from "./pr-merge.ts";
 import { createLogger } from "./logger.ts";
 import { setDefaultOwner } from "./repo-ref.ts";
@@ -48,6 +49,7 @@ export default function (pi: ExtensionAPI) {
 	registerCommands(pi, log);
 	registerPrFixCommand(pi, log, () => cwd);
 	registerPrMergeCommand(pi, log, () => cwd);
+	registerPrFixTools(pi);
 
 	// ── Lifecycle ─────────────────────────────────────────────
 

--- a/extensions/pi-github/src/pr-fix-tools.ts
+++ b/extensions/pi-github/src/pr-fix-tools.ts
@@ -12,7 +12,7 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { ghGraphql, ghJson } from "./gh.ts";
+import { ghGraphql, ghJson, gh } from "./gh.ts";
 
 const REPLY_MUTATION = `
 mutation($threadId: ID!, $body: String!) {
@@ -59,7 +59,7 @@ export function registerPrFixTools(pi: ExtensionAPI): void {
 
       if (!result) {
         return {
-          content: [{ type: "text" as const, text: "❌ Failed to reply to review thread. The gh GraphQL call returned no response." }],
+          content: [{ type: "text" as const, text: "❌ Failed to reply to review thread. The gh GraphQL call returned no response. Check gh auth status, network connectivity, or rate limits." }],
           details: { ok: false, thread_id },
         };
       }
@@ -104,7 +104,7 @@ export function registerPrFixTools(pi: ExtensionAPI): void {
 
       if (!result) {
         return {
-          content: [{ type: "text" as const, text: "❌ Failed to resolve review thread. The gh GraphQL call returned no response." }],
+          content: [{ type: "text" as const, text: "❌ Failed to resolve review thread. The gh GraphQL call returned no response. Check gh auth status, network connectivity, or rate limits." }],
           details: { ok: false, thread_id },
         };
       }
@@ -136,27 +136,27 @@ export function registerPrFixTools(pi: ExtensionAPI): void {
     parameters: Type.Object({
       owner: Type.String({ description: "Repository owner (e.g. espennilsen)" }),
       repo: Type.String({ description: "Repository name (e.g. pi)" }),
-      pr_number: Type.Number({ description: "Pull request number", minimum: 1 }),
+      pr_number: Type.Integer({ description: "Pull request number", minimum: 1 }),
       body: Type.String({ description: "Comment body (supports markdown)", minLength: 1 }),
     }) as any,
 
     async execute(_toolCallId, params: any) {
       const { owner, repo, pr_number, body } = params;
 
-      const result = await ghJson<any>(
+      const result = await gh(
         ["pr", "comment", String(pr_number), "-R", `${owner}/${repo}`, "--body", body],
       );
 
-      if (result === null) {
+      if (!result.ok) {
         return {
-          content: [{ type: "text" as const, text: "❌ Failed to post PR comment. The gh CLI call failed." }],
+          content: [{ type: "text" as const, text: `❌ Failed to post PR comment. The gh CLI call failed: ${result.stderr}` }],
           details: { ok: false, owner, repo, pr_number },
         };
       }
 
       return {
         content: [{ type: "text" as const, text: `✅ Posted comment on PR #${pr_number}.` }],
-        details: { ok: true, owner, repo, pr_number, url: result?.url },
+        details: { ok: true, owner, repo, pr_number },
       };
     },
   });

--- a/extensions/pi-github/src/pr-fix-tools.ts
+++ b/extensions/pi-github/src/pr-fix-tools.ts
@@ -1,0 +1,163 @@
+/**
+ * pi-github — PR review thread tools for the agentic fix workflow.
+ *
+ * Registered as LLM tools so agents can reply to, resolve, and comment on
+ * PR review threads reliably instead of constructing raw GraphQL/CLI commands.
+ *
+ * Tools:
+ *   - github_review_thread_reply  — reply to a review thread
+ *   - github_resolve_review_thread — mark a review thread as resolved
+ *   - github_post_pr_comment    — post a top-level PR comment
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { ghGraphql, ghJson } from "./gh.ts";
+
+const REPLY_MUTATION = `
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $threadId,
+    body: $body
+  }) { comment { id } }
+}`;
+
+const RESOLVE_MUTATION = `
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { isResolved }
+  }
+}`;
+
+export function registerPrFixTools(pi: ExtensionAPI): void {
+  // ── Tool 1: Reply to a review thread ──────────────────────────
+
+  pi.registerTool({
+    name: "github_review_thread_reply",
+    label: "GitHub Review Thread Reply",
+    description:
+      "Reply to an unresolved PR review thread on GitHub. " +
+      "Requires the GraphQL thread ID from the review thread (e.g. PRRT_kw...). " +
+      "Use this after fixing code to tell the reviewer what was changed.",
+    parameters: Type.Object({
+      thread_id: Type.String({
+        description: "GraphQL review thread ID (e.g. PRRT_kwDOROE4Hs58DgAS)",
+      }),
+      message: Type.String({
+        description: "Reply body — brief description of the fix",
+        minLength: 1,
+      }),
+    }) as any,
+
+    async execute(_toolCallId, params: any) {
+      const { thread_id, message } = params;
+
+      const result = await ghGraphql<any>(REPLY_MUTATION, {
+        threadId: thread_id,
+        body: message,
+      });
+
+      if (!result) {
+        return {
+          content: [{ type: "text" as const, text: "❌ Failed to reply to review thread. The gh GraphQL call returned no response." }],
+          details: { ok: false, thread_id },
+        };
+      }
+
+      if (result.errors) {
+        const errors = JSON.stringify(result.errors, null, 2);
+        return {
+          content: [{ type: "text" as const, text: `❌ Failed to reply to review thread.\n\nGraphQL errors:\n\`\`\`json\n${errors}\n\`\`\`` }],
+          details: { ok: false, thread_id, errors: result.errors },
+        };
+      }
+
+      const commentId = result.data?.addPullRequestReviewThreadReply?.comment?.id;
+      return {
+        content: [{ type: "text" as const, text: `✅ Replied to review thread. Comment ID: \`${commentId ?? "unknown"}\`` }],
+        details: { ok: true, thread_id, commentId },
+      };
+    },
+  });
+
+  // ── Tool 2: Resolve a review thread ─────────────────────────────
+
+  pi.registerTool({
+    name: "github_resolve_review_thread",
+    label: "GitHub Resolve Review Thread",
+    description:
+      "Mark a PR review thread as resolved on GitHub. " +
+      "Requires the GraphQL thread ID from the review thread (e.g. PRRT_kw...). " +
+      "Idempotent — resolving an already-resolved thread is a no-op.",
+    parameters: Type.Object({
+      thread_id: Type.String({
+        description: "GraphQL review thread ID (e.g. PRRT_kwDOROE4Hs58DgAS)",
+      }),
+    }) as any,
+
+    async execute(_toolCallId, params: any) {
+      const { thread_id } = params;
+
+      const result = await ghGraphql<any>(RESOLVE_MUTATION, {
+        threadId: thread_id,
+      });
+
+      if (!result) {
+        return {
+          content: [{ type: "text" as const, text: "❌ Failed to resolve review thread. The gh GraphQL call returned no response." }],
+          details: { ok: false, thread_id },
+        };
+      }
+
+      if (result.errors) {
+        const errors = JSON.stringify(result.errors, null, 2);
+        return {
+          content: [{ type: "text" as const, text: `❌ Failed to resolve review thread.\n\nGraphQL errors:\n\`\`\`json\n${errors}\n\`\`\`` }],
+          details: { ok: false, thread_id, errors: result.errors },
+        };
+      }
+
+      const isResolved = result.data?.resolveReviewThread?.thread?.isResolved;
+      return {
+        content: [{ type: "text" as const, text: `✅ Review thread ${isResolved ? "resolved" : "status unchanged"}.` }],
+        details: { ok: true, thread_id, isResolved },
+      };
+    },
+  });
+
+  // ── Tool 3: Post a PR comment ────────────────────────────────
+
+  pi.registerTool({
+    name: "github_post_pr_comment",
+    label: "GitHub Post PR Comment",
+    description:
+      "Post a top-level comment on a GitHub pull request. " +
+      "Use this for summary comments after fixing review feedback.",
+    parameters: Type.Object({
+      owner: Type.String({ description: "Repository owner (e.g. espennilsen)" }),
+      repo: Type.String({ description: "Repository name (e.g. pi)" }),
+      pr_number: Type.Number({ description: "Pull request number", minimum: 1 }),
+      body: Type.String({ description: "Comment body (supports markdown)", minLength: 1 }),
+    }) as any,
+
+    async execute(_toolCallId, params: any) {
+      const { owner, repo, pr_number, body } = params;
+
+      const result = await ghJson<any>(
+        ["pr", "comment", String(pr_number), "-R", `${owner}/${repo}`, "--body", body],
+      );
+
+      if (result === null) {
+        return {
+          content: [{ type: "text" as const, text: "❌ Failed to post PR comment. The gh CLI call failed." }],
+          details: { ok: false, owner, repo, pr_number },
+        };
+      }
+
+      return {
+        content: [{ type: "text" as const, text: `✅ Posted comment on PR #${pr_number}.` }],
+        details: { ok: true, owner, repo, pr_number, url: result?.url },
+      };
+    },
+  });
+}

--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -206,16 +206,26 @@ function formatThreadsForAgent(threads: ReviewThread[], prInfo: PrInfo, localPat
 	lines.push("```");
 	lines.push("");
 	lines.push("**After pushing, for each addressed thread:**");
-	lines.push("1. Reply to the thread with a short summary of the fix:");
-	lines.push("```bash");
-	lines.push(`gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: "THREAD_ID", body: "Fixed — <brief description of what was done>"}) { comment { id } } }'`);
+	lines.push("1. Reply to the thread with a short summary of the fix using the `github_review_thread_reply` tool:");
 	lines.push("```");
-	lines.push("2. Then resolve the thread:");
-	lines.push("```bash");
-	lines.push(`gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'`);
+	lines.push(`tool: github_review_thread_reply`);
+	lines.push(`  thread_id: "THREAD_ID"`);
+	lines.push(`  message: "Fixed — <brief description of what was done>"`);
+	lines.push("```");
+	lines.push("2. Then resolve the thread using the `github_resolve_review_thread` tool:");
+	lines.push("```");
+	lines.push(`tool: github_resolve_review_thread`);
+	lines.push(`  thread_id: "THREAD_ID"`);
 	lines.push("```");
 	lines.push("");
-	lines.push(`**Finally, post a summary comment on the PR:** \`gh pr comment ${prInfo.number} -R ${repoSlug} --body '...'\``);
+	lines.push("**Finally, post a summary comment on the PR using the `github_post_pr_comment` tool:**");
+	lines.push("```");
+	lines.push(`tool: github_post_pr_comment`);
+	lines.push(`  owner: "${prInfo.owner}"`);
+	lines.push(`  repo: "${prInfo.repo}"`);
+	lines.push(`  pr_number: ${prInfo.number}`);
+	lines.push(`  body: "..."`);
+	lines.push("```");
 
 	return lines.join("\n");
 }

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -21,7 +21,12 @@ operations. All commands also work as `/github-*` variants.
 - `gh` CLI installed and authenticated
 - For repo-scoped commands: run from a git repo, or specify the repo
 
-## Commands
+## Commands + Agent Tools
+
+The `pi-github` extension provides `/gh-*` commands for user-initiated operations
+and LLM tools for agentic workflows (PR review thread resolution).
+
+### Commands
 
 | Command | What it does |
 |---------|-------------|
@@ -34,6 +39,14 @@ operations. All commands also work as `/github-*` variants.
 | `/gh-pr-review [number\|repo#N\|URL]` | Show PR review feedback |
 | `/gh-pr-fix [number\|repo#N\|URL]` | Fix unresolved review threads |
 | `/gh-pr-merge [number\|repo#N\|URL] [--squash\|--merge\|--rebase]` | Merge PR + full cleanup |
+
+### PR Thread Tools (for agents fixing review feedback)
+
+| Tool | Purpose |
+|------|---------|
+| `github_review_thread_reply` | Reply to a PR review thread (`thread_id`, `message`) |
+| `github_resolve_review_thread` | Mark a review thread as resolved (`thread_id`) |
+| `github_post_pr_comment` | Post a summary comment on a PR (`owner`, `repo`, `pr_number`, `body`) |
 
 ## Repo Reference Syntax
 

--- a/skills/github/references/pr-fix-parallel.md
+++ b/skills/github/references/pr-fix-parallel.md
@@ -85,10 +85,13 @@ Each worker follows this sequence:
 6. Commit and push:
      git commit -m "fix: address review feedback — <summary>"
      git push origin <branch>
-7. Resolve auto-fixed threads:
+7. Resolve auto-fixed threads using the tools (preferred) or scripts:
+     tool: github_review_thread_reply (thread_id, message)
+     tool: github_resolve_review_thread (thread_id)
+     # Or fallback to shell scripts:
      bash scripts/reply-thread.sh "THREAD_ID" "Fixed — <description>"
      bash scripts/resolve-thread.sh "THREAD_ID"
-8. Post summary comment:
+8. Post summary comment using `github_post_pr_comment` tool (preferred) or:
      gh pr comment <N> -R <owner/repo> --body '<summary table>'
 9. Report back to orchestrator:
      send_message("orchestrator", "PR #97: fixed 5/7 threads, pushed.

--- a/skills/github/references/pr-fix.md
+++ b/skills/github/references/pr-fix.md
@@ -61,7 +61,18 @@ git push origin <branch>
 
 ### Step 6: Resolve threads
 
-For each fixed thread, reply then resolve:
+For each fixed thread, reply then resolve using the registered tools:
+
+```
+tool: github_review_thread_reply
+  thread_id: "THREAD_ID"
+  message: "Fixed — <description>"
+
+tool: github_resolve_review_thread
+  thread_id: "THREAD_ID"
+```
+
+Or use the shell scripts (legacy, still work):
 
 ```bash
 bash scripts/reply-thread.sh "THREAD_ID" "Fixed — <description>"


### PR DESCRIPTION
Register three LLM tools so agents can reliably resolve review threads instead of constructing raw GraphQL/CLI commands by hand.

- `github_review_thread_reply` — reply to a review thread
- `github_resolve_review_thread` — mark a review thread as resolved (idempotent)
- `github_post_pr_comment` — post a summary comment on a PR

Updates `/gh-pr-fix` prompt and skill references to优先 use these tools.
Adds `@sinclair/typebox` as a peerDependency.

Closes the gap where the github PR fix skill did not mark threads as resolved after code fixes were pushed.