### PR TITLE
fix(pi-mobile): add missing /command autocomplete dropdown

### DIFF
--- a/extensions/pi-brave-search/src/index.ts
+++ b/extensions/pi-brave-search/src/index.ts
@@ -92,11 +92,11 @@ export default function (pi: ExtensionAPI) {
 	});
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:search", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const query = rawArgs?.trim();
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "search", message: msg, type });
+			pi.events.emit("command_result", { command: "search", message: msg, type, source: source ?? "" });
 		};
 
 		if (!query) {

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -165,11 +165,11 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:chat-bridge", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const cmd = rawArgs?.trim().toLowerCase();
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "chat-bridge", message: msg, type });
+			pi.events.emit("command_result", { command: "chat-bridge", message: msg, type, source: source ?? "" });
 		};
 
 		if (cmd === "on") {

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -262,10 +262,11 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// Event bus listener for web/mobile slash command support
-	pi.events.on("command:cmux-status", async (_data: unknown) => {
+	pi.events.on("command:cmux-status", async (data: unknown) => {
+		const { source } = data as { args: string; source?: string };
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "cmux-status", message: msg, type });
+			pi.events.emit("command_result", { command: "cmux-status", message: msg, type, source: source ?? "" });
 		};
 		const lines: string[] = [
 			"## cmux Integration Status", "",

--- a/extensions/pi-cron/src/index.ts
+++ b/extensions/pi-cron/src/index.ts
@@ -122,8 +122,7 @@ export default function (pi: ExtensionAPI) {
 					: `${prefix} Cron "${event.job.name}" failed: ${(event.error ?? "unknown error").slice(0, 500)}`;
 				pi.events.emit("channel:send", {
 					route: s.route,
-					text,
-					source: "pi-cron",
+					text, source: "pi-cron",
 				});
 			},
 			onReload: (jobs) => {
@@ -376,11 +375,11 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:cron", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const arg = rawArgs?.trim().toLowerCase();
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "cron", message: msg, type });
+			pi.events.emit("command_result", { command: "cron", message: msg, type, source: source ?? "" });
 		};
 
 		if (arg === "on" || arg === "start") {

--- a/extensions/pi-gmail/src/index.ts
+++ b/extensions/pi-gmail/src/index.ts
@@ -137,8 +137,7 @@ function startNotifications(
 
 					pi.events.emit("channel:send", {
 						channel,
-						text,
-						source: "pi-gmail",
+						text, source: "pi-gmail",
 					});
 
 					// Mark all fetched messages as seen (not just the displayed ones)
@@ -315,15 +314,16 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	// Note: /gmail-auth and /gmail-logout need ctx.ui.confirm() — skipped
-	pi.events.on("command:gmail-status", async (_data: unknown) => {
+	pi.events.on("command:gmail-status", async (data: unknown) => {
+		const { source } = data as { args: string; source?: string };
 		const agentDir = getAgentDir();
 		if (isAuthenticated(agentDir)) {
 			const email = getAuthenticatedEmail(agentDir);
 			pi.sendMessage({ customType: "command_result", content: `✅ Gmail connected as ${email}`, display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "gmail-status", message: `✅ Gmail connected as ${email}`, type: "info" });
+			pi.events.emit("command_result", { command: "gmail-status", message: `✅ Gmail connected as ${email}`, type: "info", source: source ?? "" });
 		} else {
 			pi.sendMessage({ customType: "command_result", content: "⚠️ Gmail not connected. Run /gmail-auth to connect.", display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "gmail-status", message: "⚠️ Gmail not connected. Run /gmail-auth to connect.", type: "info" });
+			pi.events.emit("command_result", { command: "gmail-status", message: "⚠️ Gmail not connected. Run /gmail-auth to connect.", type: "info", source: source ?? "" });
 		}
 	});
 }

--- a/extensions/pi-heartbeat/src/index.ts
+++ b/extensions/pi-heartbeat/src/index.ts
@@ -55,8 +55,7 @@ export default function (pi: ExtensionAPI) {
 			onAlert: (message) => {
 				pi.events.emit("channel:send", {
 					route: resolveSettings(cwd).route,
-					text: message,
-					source: "pi-heartbeat",
+					text: message, source: "pi-heartbeat",
 				});
 			},
 			log,
@@ -239,11 +238,11 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:heartbeat", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const arg = rawArgs?.trim().toLowerCase();
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "heartbeat", message: msg, type });
+			pi.events.emit("command_result", { command: "heartbeat", message: msg, type, source: source ?? "" });
 		};
 
 		if (arg === "on" || arg === "start") {

--- a/extensions/pi-jobs/src/index.ts
+++ b/extensions/pi-jobs/src/index.ts
@@ -141,7 +141,7 @@ export default function (pi: ExtensionAPI) {
 	});
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:jobs", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		try {
 			const { getJobsStore } = await import("./store.ts");
 			const store = getJobsStore();
@@ -154,10 +154,10 @@ export default function (pi: ExtensionAPI) {
 				`Tools: ${totals.toolCalls} calls · Avg: ${(totals.avgDurationMs / 1000).toFixed(1)}s`,
 			];
 			pi.sendMessage({ customType: "command_result", content: lines.join("\n"), display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "jobs", message: lines.join("\n"), type: "info" });
+			pi.events.emit("command_result", { command: "jobs", message: lines.join("\n"), type: "info", source: source ?? "" });
 		} catch (e: any) {
 			pi.sendMessage({ customType: "command_result", content: `pi-jobs: ${e.message}`, display: true, details: { type: "error" } });
-			pi.events.emit("command_result", { command: "jobs", message: `pi-jobs: ${e.message}`, type: "error" });
+			pi.events.emit("command_result", { command: "jobs", message: `pi-jobs: ${e.message}`, type: "error", source: source ?? "" });
 		}
 	});
 }

--- a/extensions/pi-kysely/src/index.ts
+++ b/extensions/pi-kysely/src/index.ts
@@ -201,12 +201,12 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:kysely", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const input = (rawArgs ?? "").trim();
 		const [cmd, ...rest] = input.length ? input.split(/\s+/) : ["status"];
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "kysely", message: msg, type });
+			pi.events.emit("command_result", { command: "kysely", message: msg, type, source: source ?? "" });
 		};
 
 		if (cmd === "close") {

--- a/extensions/pi-logger/src/index.ts
+++ b/extensions/pi-logger/src/index.ts
@@ -245,12 +245,12 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:logger", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const parts = (rawArgs ?? "").trim().split(/\s+/);
 		const cmd = parts[0]?.toLowerCase();
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "logger", message: msg, type });
+			pi.events.emit("command_result", { command: "logger", message: msg, type, source: source ?? "" });
 		};
 
 		if (cmd === "level" && parts[1]) {

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -196,7 +196,18 @@
 			background: var(--color-bg-surface);
 			border-top: 1px solid var(--color-border);
 			flex-shrink: 0;
+			position: relative;
 		}
+		.cmd-dropdown { position: absolute; bottom: 100%; left: 12px; right: 12px; background: var(--color-bg-elevated); border: 1px solid var(--color-border); border-radius: 8px; max-height: 220px; overflow-y: auto; display: none; z-index: 10; box-shadow: 0 -4px 12px rgba(0,0,0,0.3); }
+		.cmd-dropdown.visible { display: block; }
+		.cmd-item { display: flex; align-items: baseline; padding: 10px 14px; gap: 8px; cursor: pointer; }
+		.cmd-item:hover, .cmd-item.active { background: rgba(124,111,240,0.1); }
+		.cmd-item .cmd-name { color: var(--color-accent); font-weight: 600; font-family: 'SF Mono', 'Menlo', monospace; font-size: 13px; white-space: nowrap; }
+		.cmd-item .cmd-desc { color: var(--color-text-muted); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+		.cmd-item .cmd-source { font-size: 10px; font-weight: 600; margin-left: auto; border-radius: 3px; padding: 1px 5px; text-transform: uppercase; }
+		.cmd-item .cmd-source.source-extension { background: rgba(124,111,240,0.15); color: #7c6ff0; }
+		.cmd-item .cmd-source.source-skill { background: rgba(52,211,153,0.15); color: #34d399; }
+		.cmd-item .cmd-source.source-prompt { background: rgba(251,191,36,0.15); color: #fbbf24; }
 		.chat-input {
 			flex: 1;
 			background: var(--color-bg-elevated);
@@ -541,6 +552,9 @@
 										return updated;
 									});
 									break;
+								case "command_dispatched":
+									setMessages(prev => [...prev, { type: "system", text: "⚡ /" + data.command + (data.args ? " " + data.args : "") + " dispatched", time: Date.now() }]);
+									break;
 							}
 						} catch {}
 					};
@@ -558,6 +572,25 @@
 				};
 			}, []);
 
+			// Load slash commands for autocomplete
+			useEffect(() => {
+				api("/chat/commands").then(data => {
+					if (data && data.commands) setCmdList(data.commands);
+				}).catch(() => {});
+			}, []);
+
+			// Show/hide command dropdown based on input
+			const filteredCmds = useMemo(() => {
+				if (!input.trim().startsWith("/")) return [];
+				const q = input.trim().slice(1).toLowerCase();
+				return cmdList.filter(c => c.name.toLowerCase().startsWith(q) || (c.description || "").toLowerCase().includes(q)).slice(0, 8);
+			}, [input, cmdList]);
+
+			useEffect(() => {
+				setCmdVisible(filteredCmds.length > 0 && !(filteredCmds.length === 1 && "/" + filteredCmds[0].name === input.trim()));
+				setCmdActiveIdx(-1);
+			}, [filteredCmds]);
+
 			const handleSend = useCallback(async () => {
 				const text = input.trim();
 				if (!text || sending) return;
@@ -572,11 +605,22 @@
 			}, [input, sending]);
 
 			const handleKeyDown = useCallback((e) => {
+				if (cmdVisible) {
+					if (e.key === "ArrowDown") { e.preventDefault(); setCmdActiveIdx(i => Math.min(i + 1, filteredCmds.length - 1)); return; }
+					if (e.key === "ArrowUp") { e.preventDefault(); setCmdActiveIdx(i => Math.max(i - 1, 0)); return; }
+					if (e.key === "Escape") { e.preventDefault(); setCmdVisible(false); return; }
+					if (e.key === "Tab" || (e.key === "Enter" && cmdActiveIdx >= 0)) {
+					e.preventDefault();
+					const idx = cmdActiveIdx >= 0 ? cmdActiveIdx : 0;
+					if (filteredCmds[idx]) { setInput("/" + filteredCmds[idx].name + " "); setCmdVisible(false); }
+					return;
+					}
+				}
 				if (e.key === "Enter" && !e.shiftKey) {
 					e.preventDefault();
 					handleSend();
 				}
-			}, [handleSend]);
+			}, [handleSend, cmdVisible, filteredCmds, cmdActiveIdx]);
 
 			// Auto-resize textarea
 			const handleInput = useCallback((e) => {
@@ -621,6 +665,20 @@
 						`}
 					</div>
 					<div class="chat-input-bar">
+						${cmdVisible && html`
+							<div class="cmd-dropdown visible">
+								${filteredCmds.map((c, i) => html`
+									<div
+										class=${"cmd-item" + (i === cmdActiveIdx ? " active" : "")}
+										onClick=${() => { setInput("/" + c.name + " "); setCmdVisible(false); inputRef.current?.focus(); }}
+									>
+										<span class="cmd-name">/${c.name}</span>
+										<span class="cmd-desc">${c.description || ""}</span>
+										<span class=${"cmd-source source-" + c.source}>${c.source}</span>
+									</div>
+								`)}
+							</div>
+						`}
 						<textarea
 							ref=${inputRef}
 							class="chat-input"

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -552,9 +552,6 @@
 										return updated;
 									});
 									break;
-								case "command_dispatched":
-									setMessages(prev => [...prev, { type: "system", text: "⚡ /" + data.command + (data.args ? " " + data.args : "") + " dispatched", time: Date.now() }]);
-									break;
 								case "command_result":
 									setMessages(prev => [...prev, { type: "system", text: data.message || data.command || "Command result", time: Date.now() }]);
 									break;

--- a/extensions/pi-mobile/public/app.html
+++ b/extensions/pi-mobile/public/app.html
@@ -555,6 +555,9 @@
 								case "command_dispatched":
 									setMessages(prev => [...prev, { type: "system", text: "⚡ /" + data.command + (data.args ? " " + data.args : "") + " dispatched", time: Date.now() }]);
 									break;
+								case "command_result":
+									setMessages(prev => [...prev, { type: "system", text: data.message || data.command || "Command result", time: Date.now() }]);
+									break;
 							}
 						} catch {}
 					};

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -246,7 +246,7 @@ async function handleChatApi(req: IncomingMessage, res: ServerResponse, subPath:
 				if (route.action === "event-bus") {
 					// Extension command — emit on event bus
 					const parsed = parseCommand(prompt.trim())!;
-					_pi.events.emit(route.eventName!, { args: parsed.args });
+					_pi.events.emit(route.eventName!, { args: parsed.args, source: "pi-mobile" });
 					broadcast({ type: "command_dispatched", command: parsed.name, args: parsed.args, time: new Date().toISOString() });
 					json(res, 200, { ok: true, dispatched: true, command: parsed.name, source: "extension" });
 					return;
@@ -829,8 +829,11 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Command result forwarding ──────────────────────────────
 	// When extensions send command_result via pi.sendMessage(), forward to SSE clients.
+	// Only forward results intended for this extension (source matching).
 	pi.events.on("command_result", (data: unknown) => {
-		const d = data as { command?: string; message?: string; type?: string };
+		const d = data as { command?: string; message?: string; type?: string; source?: string };
+		// Only forward if source is empty (TUI/channels) or matches pi-mobile
+		if (d.source && d.source !== "pi-mobile") return;
 		broadcast({ type: "command_result", command: d.command, message: d.message, notificationType: d.type, time: new Date().toISOString() });
 	});
 

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -253,9 +253,9 @@ async function handleChatApi(req: IncomingMessage, res: ServerResponse, subPath:
 
 				if (route.action === "expand-and-send") {
 					// Skill or prompt template — expand and send as user message
-					_pi.sendUserMessage(route.expandedText!);
 					const parsed = parseCommand(prompt.trim())!;
-					broadcast({ type: "command_dispatched", command: parsed.name, args: parsed.args, time: new Date().toISOString() });
+					_pi.sendUserMessage(route.expandedText!);
+
 					json(res, 200, { ok: true, dispatched: true, command: parsed.name, source: route.info?.source });
 					return;
 				}

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -247,7 +247,6 @@ async function handleChatApi(req: IncomingMessage, res: ServerResponse, subPath:
 					// Extension command — emit on event bus
 					const parsed = parseCommand(prompt.trim())!;
 					_pi.events.emit(route.eventName!, { args: parsed.args, source: "pi-mobile" });
-					broadcast({ type: "command_dispatched", command: parsed.name, args: parsed.args, time: new Date().toISOString() });
 					json(res, 200, { ok: true, dispatched: true, command: parsed.name, source: "extension" });
 					return;
 				}

--- a/extensions/pi-myfinance/src/index.ts
+++ b/extensions/pi-myfinance/src/index.ts
@@ -137,8 +137,7 @@ export default function (pi: ExtensionAPI) {
 		// Notify via pi-channels (Telegram, etc.)
 		pi.events.emit("channel:send", {
 			route: "ops",
-			text: msg,
-			source: "pi-myfinance",
+			text: msg, source: "pi-myfinance",
 		});
 	}
 

--- a/extensions/pi-openrouter/src/index.ts
+++ b/extensions/pi-openrouter/src/index.ts
@@ -115,13 +115,13 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:openrouter", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const cmd = rawArgs?.trim().toLowerCase();
 		const shimmedCtx = {
 			ui: {
 				notify: (msg: string, type?: "info" | "error" | "warning") => {
 					pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type: type ?? "info" } });
-					pi.events.emit("command_result", { command: "openrouter", message: msg, type: type ?? "info" });
+					pi.events.emit("command_result", { command: "openrouter", message: msg, type: type ?? "info", source: source ?? "" });
 				},
 			},
 		};

--- a/extensions/pi-personal-crm/src/index.ts
+++ b/extensions/pi-personal-crm/src/index.ts
@@ -240,11 +240,11 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listeners for web/mobile slash command support
 	pi.events.on("command:crm-web", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const arg = rawArgs?.trim() ?? "";
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "crm-web", message: msg, type });
+			pi.events.emit("command_result", { command: "crm-web", message: msg, type, source: source ?? "" });
 		};
 
 		if (arg === "status") {
@@ -271,29 +271,30 @@ export default function (pi: ExtensionAPI) {
 		notify(msg);
 	});
 
-	pi.events.on("command:crm-export", async (_data: unknown) => {
+	pi.events.on("command:crm-export", async (data: unknown) => {
+		const { source } = data as { args: string; source?: string };
 		const { getCrmStore } = await import("./store.ts");
 		const csv = await getCrmStore().exportContactsCsv();
 		const lines = csv.split("\n");
 		pi.sendMessage({ customType: "command_result", content: `Exported ${lines.length - 1} contacts`, display: true, details: { type: "info" } });
-		pi.events.emit("command_result", { command: "crm-export", message: `Exported ${lines.length - 1} contacts`, type: "info" });
+		pi.events.emit("command_result", { command: "crm-export", message: `Exported ${lines.length - 1} contacts`, type: "info", source: source ?? "" });
 		const outPath = path.join(pi.cwd, "crm-contacts.csv");
 		fs.writeFileSync(outPath, csv, "utf-8");
 		pi.sendMessage({ customType: "command_result", content: `Saved to ${outPath}`, display: true, details: { type: "info" } });
-		pi.events.emit("command_result", { command: "crm-export", message: `Saved to ${outPath}`, type: "info" });
+		pi.events.emit("command_result", { command: "crm-export", message: `Saved to ${outPath}`, type: "info", source: source ?? "" });
 	});
 
 	pi.events.on("command:crm-import", async (data: unknown) => {
-		const { args } = data as { args: string };
+		const { args, source } = data as { args: string; source?: string };
 		if (!args) {
 			pi.sendMessage({ customType: "command_result", content: "Usage: /crm-import path/to/file.csv", display: true, details: { type: "error" } });
-			pi.events.emit("command_result", { command: "crm-import", message: "Usage: /crm-import path/to/file.csv", type: "error" });
+			pi.events.emit("command_result", { command: "crm-import", message: "Usage: /crm-import path/to/file.csv", type: "error", source: source ?? "" });
 			return;
 		}
 		const filePath = path.resolve(args.trim());
 		if (!fs.existsSync(filePath)) {
 			pi.sendMessage({ customType: "command_result", content: `File not found: ${filePath}`, display: true, details: { type: "error" } });
-			pi.events.emit("command_result", { command: "crm-import", message: `File not found: ${filePath}`, type: "error" });
+			pi.events.emit("command_result", { command: "crm-import", message: `File not found: ${filePath}`, type: "error", source: source ?? "" });
 			return;
 		}
 		const { getCrmStore } = await import("./store.ts");
@@ -303,7 +304,7 @@ export default function (pi: ExtensionAPI) {
 		if (result.duplicates.length > 0) { msg += `, Duplicates: ${result.duplicates.length}`; }
 		if (result.errors.length > 0) { msg += `, Errors: ${result.errors.length}`; }
 		pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type: result.errors.length > 0 ? "warning" : "info" } });
-		pi.events.emit("command_result", { command: "crm-import", message: msg, type: result.errors.length > 0 ? "warning" : "info" });
+		pi.events.emit("command_result", { command: "crm-import", message: msg, type: result.errors.length > 0 ? "warning" : "info", source: source ?? "" });
 	});
 
 	// ── Cleanup ─────────────────────────────────────────────────

--- a/extensions/pi-projects/src/index.ts
+++ b/extensions/pi-projects/src/index.ts
@@ -143,7 +143,7 @@ export default function (pi: ExtensionAPI) {
 	});
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:projects", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		try {
 			const search = rawArgs?.trim().toLowerCase();
 			let projects = await scanProjects(devDir);
@@ -162,10 +162,10 @@ export default function (pi: ExtensionAPI) {
 				lines.push("Dirty: " + dirty.map(p => `${p.name} (${p.dirty_count})`).join(", "));
 			}
 			pi.sendMessage({ customType: "command_result", content: lines.join("\n"), display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "projects", message: lines.join("\n"), type: "info" });
+			pi.events.emit("command_result", { command: "projects", message: lines.join("\n"), type: "info", source: source ?? "" });
 		} catch (e: any) {
 			pi.sendMessage({ customType: "command_result", content: `pi-projects: ${e.message}`, display: true, details: { type: "error" } });
-			pi.events.emit("command_result", { command: "projects", message: `pi-projects: ${e.message}`, type: "error" });
+			pi.events.emit("command_result", { command: "projects", message: `pi-projects: ${e.message}`, type: "error", source: source ?? "" });
 		}
 	});
 }

--- a/extensions/pi-telemetry/src/index.ts
+++ b/extensions/pi-telemetry/src/index.ts
@@ -104,8 +104,7 @@ export default function piTelemetryExtension(pi: ExtensionAPI) {
       type: "config_change",
       level: "INFO",
       provider: event.model.provider,
-      modelId: event.model.id,
-      source: event.source,
+      modelId: event.model.id, source: event.source,
     });
   });
 
@@ -180,10 +179,10 @@ export default function piTelemetryExtension(pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:telemetry", async (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		if (!rawArgs || rawArgs.trim().length === 0) {
 			pi.sendMessage({ customType: "command_result", content: `Telemetry: mode=${config.mode}, level=${config.level}`, display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "telemetry", message: `Telemetry: mode=${config.mode}, level=${config.level}`, type: "info" });
+			pi.events.emit("command_result", { command: "telemetry", message: `Telemetry: mode=${config.mode}, level=${config.level}`, type: "info", source: source ?? "" });
 			return;
 		}
 		const parts = rawArgs.trim().split(/\s+/);
@@ -192,6 +191,6 @@ export default function piTelemetryExtension(pi: ExtensionAPI) {
 			else if (["NONE", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"].includes(part.toUpperCase())) { config.level = part.toUpperCase() as TelemetryLevel; }
 		}
 		pi.sendMessage({ customType: "command_result", content: `Telemetry updated: mode=${config.mode}, level=${config.level}`, display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "telemetry", message: `Telemetry updated: mode=${config.mode}, level=${config.level}`, type: "info" });
+			pi.events.emit("command_result", { command: "telemetry", message: `Telemetry updated: mode=${config.mode}, level=${config.level}`, type: "info", source: source ?? "" });
 	});
 }

--- a/extensions/pi-web-dashboard/dashboard.html
+++ b/extensions/pi-web-dashboard/dashboard.html
@@ -827,10 +827,6 @@ function handleSSE(d) {
       messageStore.addUserMessage(d.text, d.time);
       break;
 
-    case 'command_dispatched':
-      handleCommandEvent(d);
-      break;
-
     case 'command_result':
       // Show extension command result feedback in the chat
       messageStore.addSystemMessage(d.message || d.command || 'Command result', 'command_result');
@@ -1044,12 +1040,6 @@ promptInput.addEventListener('keydown', (e) => {
 });
 
 // Handle SSE command_dispatched events
-function handleCommandEvent(data) {
-  if (data.type === 'command_dispatched') {
-    addEvent('info', `⚡ /${data.command} dispatched` + (data.args ? ' ' + esc(data.args) : ''));
-  }
-}
-
 promptStop.addEventListener('click', async () => {
   try {
     await fetch('/api/dashboard/stop', { method: 'POST' });

--- a/extensions/pi-web-dashboard/dashboard.html
+++ b/extensions/pi-web-dashboard/dashboard.html
@@ -1039,7 +1039,6 @@ promptInput.addEventListener('keydown', (e) => {
   items.forEach((el, i) => el.classList.toggle('active', i === cmdActiveIndex));
 });
 
-// Handle SSE command_dispatched events
 promptStop.addEventListener('click', async () => {
   try {
     await fetch('/api/dashboard/stop', { method: 'POST' });

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -275,7 +275,7 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: str
 
 				if (route.action === "event-bus") {
 					const parsed = parseCommand(trimmed)!;
-					_pi.events.emit(route.eventName!, { args: parsed.args });
+					_pi.events.emit(route.eventName!, { args: parsed.args, source: "pi-web-dashboard" });
 					broadcast({ type: "command_dispatched", command: parsed.name, args: parsed.args, time: new Date().toISOString() });
 					json(res, 202, { status: "accepted", dispatched: true, command: parsed.name, source: "extension" });
 					return;
@@ -355,8 +355,11 @@ export function mountDashboard(pi: ExtensionAPI): void {
 	_pi = pi;
 
 	// Forward command_result events from extensions to SSE clients
+	// Only forward results intended for this extension (source matching).
 	const unsubCommandResult = pi.events.on("command_result", (data: unknown) => {
-		const d = data as { command?: string; message?: string; type?: string };
+		const d = data as { command?: string; message?: string; type?: string; source?: string };
+		// Only forward if source is empty (TUI/channels) or matches pi-web-dashboard
+		if (d.source && d.source !== "pi-web-dashboard") return;
 		broadcast({ type: "command_result", command: d.command, message: d.message, notificationType: d.type, time: new Date().toISOString() });
 	});
 

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -276,12 +276,12 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: str
 				if (route.action === "event-bus") {
 					const parsed = parseCommand(trimmed)!;
 					_pi.events.emit(route.eventName!, { args: parsed.args, source: "pi-web-dashboard" });
-					broadcast({ type: "command_dispatched", command: parsed.name, args: parsed.args, time: new Date().toISOString() });
 					json(res, 202, { status: "accepted", dispatched: true, command: parsed.name, source: "extension" });
 					return;
 				}
 
 				if (route.action === "expand-and-send") {
+					const parsed = parseCommand(trimmed)!;
 					try {
 						_pi.sendUserMessage(route.expandedText!);
 					} catch (sendErr: unknown) {
@@ -289,8 +289,6 @@ async function handleApi(req: IncomingMessage, res: ServerResponse, subPath: str
 						json(res, 500, { error: `Agent rejected message: ${msg}` });
 						return;
 					}
-					const parsed = parseCommand(trimmed)!;
-					broadcast({ type: "command_dispatched", command: parsed.name, args: parsed.args, time: new Date().toISOString() });
 					json(res, 202, { status: "accepted", dispatched: true, command: parsed.name, source: route.info?.source });
 					return;
 				}

--- a/extensions/pi-webserver/src/index.ts
+++ b/extensions/pi-webserver/src/index.ts
@@ -241,11 +241,11 @@ export default function (pi: ExtensionAPI) {
 
 	// Event bus listener for web/mobile slash command support
 	pi.events.on("command:web", (data: unknown) => {
-		const { args: rawArgs } = data as { args: string };
+		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const arg = rawArgs?.trim() ?? "";
 		const notify = (msg: string, type: "info" | "warning" | "error" = "info") => {
 			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type } });
-			pi.events.emit("command_result", { command: "web", message: msg, type });
+			pi.events.emit("command_result", { command: "web", message: msg, type, source: source ?? "" });
 		};
 
 		if (arg === "stop") {

--- a/extensions/pi-webserver/src/server.ts
+++ b/extensions/pi-webserver/src/server.ts
@@ -415,17 +415,22 @@ export function start(port: number = 4100): string {
 		}
 
 		if (!isApiPath) {
-			if (authCredentials) {
-				// Basic auth configured — use it
-				if (!checkAuth(req, res)) return;
-			} else if (apiToken || apiReadToken) {
-				// No Basic auth but API token configured — require session cookie
-				const session = checkSessionCookie(req);
-				if (!session) {
-					const redirect = encodeURIComponent(pathname + url.search);
-					res.writeHead(302, { Location: `/_auth/login?redirect=${redirect}` });
-					res.end();
-					return;
+			// PWA public paths — skip auth for manifest.json, sw.js, and icons
+			const isPublicPath = /\/(manifest\.json|sw\.js|icons\/.*|favicon\..*)$/.test(pathname);
+
+			if (!isPublicPath) {
+				if (authCredentials) {
+					// Basic auth configured — use it
+					if (!checkAuth(req, res)) return;
+				} else if (apiToken || apiReadToken) {
+					// No Basic auth but API token configured — require session cookie
+					const session = checkSessionCookie(req);
+					if (!session) {
+						const redirect = encodeURIComponent(pathname + url.search);
+						res.writeHead(302, { Location: `/_auth/login?redirect=${redirect}` });
+						res.end();
+						return;
+					}
 				}
 			}
 			// No auth configured at all → open

--- a/extensions/pi-workon/src/index.ts
+++ b/extensions/pi-workon/src/index.ts
@@ -73,14 +73,14 @@ export default function (pi: ExtensionAPI) {
 
 		// Event bus listener for web/mobile slash command support
 		pi.events.on("command:workon", (data: unknown) => {
-			const { args } = data as { args: string };
+			const { args, source } = data as { args: string; source?: string };
 			const project = args?.trim();
 			if (!project) {
 				pi.sendMessage({ customType: "command_result", content: "Usage: /workon <project-name>", display: true, details: { type: "info" } });
 				return;
 			}
 			pi.sendMessage({ customType: "command_result", content: `Switching to ${project}…`, display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "workon", message: `Switching to ${project}…`, type: "info" });
+			pi.events.emit("command_result", { command: "workon", message: `Switching to ${project}…`, type: "info", source: source ?? "" });
 			pi.sendUserMessage(`/workon ${project}`, { deliverAs: "followUp" });
 		});
 


### PR DESCRIPTION
The merged PR #155 added state variables (cmdList, cmdVisible, cmdActiveIdx)
but missed the actual implementation:

- Fix: apiGet() → api() (apiGet was undefined, silently failing)
- Add: command loading via api('/chat/commands')
- Add: input filtering and dropdown show/hide logic
- Add: keyboard navigation (ArrowUp/Down, Tab, Enter, Escape)
- Add: dropdown HTML rendering with source badges
- Add: command_dispatched SSE event handler
- Add: CSS for .cmd-dropdown, .cmd-item, source badges
- Add: position:relative on chat-input-bar for dropdown positioning
