### PR TITLE
docs: update CHANGELOG.md for all extensions touched by PR #156

### DIFF
--- a/extensions/pi-brave-search/CHANGELOG.md
+++ b/extensions/pi-brave-search/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-brave-search/CHANGELOG.md
+++ b/extensions/pi-brave-search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-brave-search/package-lock.json
+++ b/extensions/pi-brave-search/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-brave-search",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-brave-search",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/extensions/pi-brave-search/package.json
+++ b/extensions/pi-brave-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-brave-search",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.2.0] - 2026-03-06
 
 ### Added

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-channels/package-lock.json
+++ b/extensions/pi-channels/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-channels",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-channels",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@slack/socket-mode": "^2.0.5",

--- a/extensions/pi-channels/package.json
+++ b/extensions/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-channels",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Two-way channel extension for pi — route messages between agents and Telegram, webhooks, and custom adapters",
   "keywords": [
     "pi-package"

--- a/extensions/pi-cmux/CHANGELOG.md
+++ b/extensions/pi-cmux/CHANGELOG.md
@@ -10,13 +10,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
-
-## [0.1.0] - 2026-02-18
-
-### Added
-
-- Initial release
-- OpenRouter provider with OAuth PKCE authentication via `/login openrouter-oauth`
-- Dynamic model discovery from OpenRouter API with local caching
-- Glob-pattern model filtering via `pi-openrouter.models` setting (default: all models)
-- `/openrouter refresh` command to fetch latest models from API

--- a/extensions/pi-cmux/CHANGELOG.md
+++ b/extensions/pi-cmux/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-cmux/package-lock.json
+++ b/extensions/pi-cmux/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-cmux",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-cmux",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/extensions/pi-cmux/package.json
+++ b/extensions/pi-cmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-cmux",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "cmux terminal app integration for pi — notifications, pane management, screen reading, and browser automation",
   "type": "module",
   "keywords": [

--- a/extensions/pi-cron/CHANGELOG.md
+++ b/extensions/pi-cron/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.2.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-cron/CHANGELOG.md
+++ b/extensions/pi-cron/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-cron/package-lock.json
+++ b/extensions/pi-cron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-cron",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-cron",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/extensions/pi-cron/package.json
+++ b/extensions/pi-cron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-cron",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cron scheduler extension for pi — schedule recurring prompts as isolated subprocesses",
   "keywords": [
     "pi-package"

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- `/gmail-status` command handler now forwards the `source` field for web/mobile result routing
+
 ## [0.2.0] - 2026-03-06
 
 ### Changed

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-gmail/package-lock.json
+++ b/extensions/pi-gmail/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-gmail",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-gmail",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/extensions/pi-gmail/package.json
+++ b/extensions/pi-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-gmail",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Gmail extension for pi — read, search, compose, and send emails via Gmail API",
   "type": "module",
   "keywords": [

--- a/extensions/pi-heartbeat/CHANGELOG.md
+++ b/extensions/pi-heartbeat/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-heartbeat/CHANGELOG.md
+++ b/extensions/pi-heartbeat/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-heartbeat/package-lock.json
+++ b/extensions/pi-heartbeat/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-heartbeat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-heartbeat",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/extensions/pi-heartbeat/package.json
+++ b/extensions/pi-heartbeat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-heartbeat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Periodic health check extension for pi — runs a heartbeat prompt as an isolated subprocess",
   "type": "module",
   "keywords": [

--- a/extensions/pi-jobs/CHANGELOG.md
+++ b/extensions/pi-jobs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-jobs/CHANGELOG.md
+++ b/extensions/pi-jobs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-jobs/package-lock.json
+++ b/extensions/pi-jobs/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@e9n/pi-jobs",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@e9n/pi-jobs",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"better-sqlite3": "^12.6.2"

--- a/extensions/pi-jobs/package.json
+++ b/extensions/pi-jobs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-jobs",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Agent run tracking extension for pi — job history, cost analysis, and session telemetry",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-kysely/CHANGELOG.md
+++ b/extensions/pi-kysely/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-kysely/CHANGELOG.md
+++ b/extensions/pi-kysely/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-kysely/package-lock.json
+++ b/extensions/pi-kysely/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-kysely",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-kysely",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "*",

--- a/extensions/pi-kysely/package.json
+++ b/extensions/pi-kysely/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-kysely",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Shared Kysely database registry for pi — multi-dialect SQL with table-level RBAC",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-logger/CHANGELOG.md
+++ b/extensions/pi-logger/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-logger/CHANGELOG.md
+++ b/extensions/pi-logger/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-logger/package-lock.json
+++ b/extensions/pi-logger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-logger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-logger",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/extensions/pi-logger/package.json
+++ b/extensions/pi-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-logger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Event bus logger for pi — writes structured JSONL logs from bus events",
   "type": "module",
   "keywords": [

--- a/extensions/pi-mobile/CHANGELOG.md
+++ b/extensions/pi-mobile/CHANGELOG.md
@@ -15,7 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   - Prompt templates (e.g. `/implement`) are expanded with argument substitution (`$1`, `$@`, `$ARGUMENTS`) and sent as a user message
   - Unknown `/commands` fall through as literal text
 - **`GET /api/mobile/chat/commands`** endpoint — returns available slash commands from `pi.getCommands()` for autocomplete UIs
-- **`command_dispatched` SSE event** — broadcast when a slash command is routed, so mobile UIs can show feedback
+- **Autocomplete dropdown** — typing `/` shows a filtered list of commands with source badges (extension, skill, prompt) and keyboard navigation (Arrow keys, Tab, Enter, Escape)
+- **`command_result` SSE event** — mobile UI now receives and displays command results from event bus handlers
+- **Command result filtering** — `command_result` forwarding now filters by source (only forwards results intended for pi-mobile)
+
+### Fixed
+
+- Removed dead `command_dispatched` SSE broadcasts that no client handled
+- `parseCommand()` is now correctly scoped in the `expand-and-send` code path (was previously only in `event-bus` block)
 
 ## [0.1.0] - 2026-02-17
 

--- a/extensions/pi-mobile/CHANGELOG.md
+++ b/extensions/pi-mobile/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [0.2.0] - 2026-04-26
+## [0.3.0] - 2026-04-26
 
 ### Added
 

--- a/extensions/pi-mobile/package-lock.json
+++ b/extensions/pi-mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@e9n/pi-mobile",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@e9n/pi-mobile",
-			"version": "0.2.0",
+			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"typescript": "^5.9.3"

--- a/extensions/pi-mobile/package.json
+++ b/extensions/pi-mobile/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-mobile",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "PWA mobile app for Pi agents — mounts on pi-webserver at /mobile",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-openrouter/CHANGELOG.md
+++ b/extensions/pi-openrouter/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-openrouter/package-lock.json
+++ b/extensions/pi-openrouter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-openrouter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-openrouter",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/extensions/pi-openrouter/package.json
+++ b/extensions/pi-openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-openrouter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenRouter provider with OAuth PKCE and dynamic model filtering",
   "type": "module",
   "license": "MIT",
@@ -10,9 +10,18 @@
     "url": "https://github.com/espennilsen/pi",
     "directory": "extensions/pi-openrouter"
   },
-  "keywords": ["pi", "openrouter", "llm", "ai", "oauth", "provider"],
+  "keywords": [
+    "pi",
+    "openrouter",
+    "llm",
+    "ai",
+    "oauth",
+    "provider"
+  ],
   "pi": {
-    "extensions": ["./src/index.ts"]
+    "extensions": [
+      "./src/index.ts"
+    ]
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
@@ -25,5 +34,10 @@
   "devDependencies": {
     "typescript": "^5.9.3"
   },
-  "files": ["CHANGELOG.md", "README.md", "package.json", "src"]
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-personal-crm/CHANGELOG.md
+++ b/extensions/pi-personal-crm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers (`/crm-web`, `/crm-export`, `/crm-import`) now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.2.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-personal-crm/CHANGELOG.md
+++ b/extensions/pi-personal-crm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-personal-crm/package-lock.json
+++ b/extensions/pi-personal-crm/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@e9n/pi-personal-crm",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@e9n/pi-personal-crm",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"better-sqlite3": "^12.6.2"

--- a/extensions/pi-personal-crm/package.json
+++ b/extensions/pi-personal-crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-personal-crm",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Personal CRM extension for pi — contacts, companies, interactions, and reminders",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-projects/CHANGELOG.md
+++ b/extensions/pi-projects/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-projects/CHANGELOG.md
+++ b/extensions/pi-projects/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-projects/package-lock.json
+++ b/extensions/pi-projects/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@e9n/pi-projects",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@e9n/pi-projects",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"better-sqlite3": "^12.6.2"

--- a/extensions/pi-projects/package.json
+++ b/extensions/pi-projects/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-projects",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Project tracking extension for pi — auto-discovers git repos with health status dashboard",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-telemetry/CHANGELOG.md
+++ b/extensions/pi-telemetry/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [1.0.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-telemetry/CHANGELOG.md
+++ b/extensions/pi-telemetry/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.0.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-telemetry/package.json
+++ b/extensions/pi-telemetry/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@e9n/pi-telemetry",
 	"license": "MIT",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"type": "module",
 	"scripts": {
 		"clean": "echo 'nothing to clean'",

--- a/extensions/pi-web-dashboard/CHANGELOG.md
+++ b/extensions/pi-web-dashboard/CHANGELOG.md
@@ -15,7 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   - Prompt templates (e.g. `/implement`) are expanded with argument substitution (`$1`, `$@`, `$ARGUMENTS`) and sent as a user message
   - Unknown `/commands` fall through as literal text
 - **`GET /api/dashboard/commands`** endpoint — returns available slash commands from `pi.getCommands()` for autocomplete UIs
-- **`command_dispatched` SSE event** — broadcast when a slash command is routed, so dashboard UIs can show feedback
+- **Autocomplete dropdown** — typing `/` shows a filtered list of commands with source badges (extension, skill, prompt) and keyboard navigation (Arrow keys, Tab, Enter, Escape)
+- **`command_result` SSE event** — dashboard UI now receives and displays command results from event bus handlers
+
+### Fixed
+
+- Removed dead `command_dispatched` SSE broadcasts that no client handled
+- `parseCommand()` is now correctly scoped in the `expand-and-send` code path (was previously only in `event-bus` block)
+- Removed orphaned "Handle SSE command_dispatched events" comment
 
 ## [0.1.0] - 2026-02-17 (7839f93)
 

--- a/extensions/pi-web-dashboard/CHANGELOG.md
+++ b/extensions/pi-web-dashboard/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [0.2.0] - 2026-04-26
+## [0.3.0] - 2026-04-26
 
 ### Added
 

--- a/extensions/pi-web-dashboard/package-lock.json
+++ b/extensions/pi-web-dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@e9n/pi-web-dashboard",
-	"version": "0.1.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@e9n/pi-web-dashboard",
-			"version": "0.1.0",
+			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"typescript": "^5.9.3"

--- a/extensions/pi-web-dashboard/package.json
+++ b/extensions/pi-web-dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-web-dashboard",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Live agent dashboard for pi — SSE streaming, session view, and prompt submission",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `/chat/commands` API endpoint to list available slash commands for autocomplete UIs
+- `broadcast()` SSE helper for emitting events to connected dashboard clients
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.0] - 2026-04-26
 
 ### Added
 

--- a/extensions/pi-webserver/package.json
+++ b/extensions/pi-webserver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@e9n/pi-webserver",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Shared HTTP server for pi — authenticated web host with extension mount points",
 	"type": "module",
 	"keywords": [

--- a/extensions/pi-workon/CHANGELOG.md
+++ b/extensions/pi-workon/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.1.1] - 2026-04-26
 
 ### Changed
 

--- a/extensions/pi-workon/CHANGELOG.md
+++ b/extensions/pi-workon/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
+
 ## [0.1.0] - 2026-02-17 (7839f93)
 
 ### Added

--- a/extensions/pi-workon/package-lock.json
+++ b/extensions/pi-workon/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@e9n/pi-workon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@e9n/pi-workon",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/extensions/pi-workon/package.json
+++ b/extensions/pi-workon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-workon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Project context switching and initialization for pi — switch projects, detect stacks, scaffold AGENTS.md",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
- 13 extensions with event bus source passthrough: added [Unreleased] ### Changed
- pi-mobile: added autocomplete, command_result, filtering, fixed dead broadcasts and parseCommand scoping
- pi-web-dashboard: added autocomplete, command_result, fixed dead broadcasts, parseCommand scoping, orphaned comment
- pi-webserver: added /chat/commands endpoint and broadcast() helper
- pi-cmux: created missing CHANGELOG.md
- pi-personal-crm: noted all 3 commands updated
- pi-gmail: noted gmail-status only (others need ctx.ui.confirm)
