### PR TITLE
fix(pi-channels): truncate Telegram bot command descriptions to 256 chars

### DIFF
--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -79,7 +79,9 @@ export default function (pi: ExtensionAPI) {
 		await registry.startListening();
 
 		// Sync bot commands with platforms (e.g. Telegram /command menu)
-		const botCommands = getAllCommands().map(c => ({ command: c.name, description: c.description }));
+		// Telegram limits descriptions to 256 chars — truncate if needed
+		const truncate = (desc: string) => desc.length > 256 ? desc.slice(0, 253) + "..." : desc;
+		const botCommands = getAllCommands().map(c => ({ command: c.name, description: truncate(c.description) }));
 		await registry.syncBotCommands(botCommands);
 
 		const startErrors = registry.getErrors().filter(e => e.error.startsWith("Failed to start"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where bot commands with longer descriptions would fail to synchronize with Telegram. The system now automatically ensures descriptions comply with the platform's character limits, preventing sync failures and allowing all commands to be properly registered regardless of description length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->