### PR TITLE
Fix A2A completion message timing — fire after task saved to store

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -138,8 +138,10 @@ export class PiAgentExecutor implements AgentExecutor {
 	private lastTaskDurationMs?: number;
 	/** Last completed/failed task status for telemetry reporting. */
 	private lastTaskStatus?: "completed" | "failed";
-	/** Optional callback invoked after each task completes or fails. */
+	/** Optional callback invoked after each task completes or fails (before saving result). */
 	onTaskFinished?: () => void;
+	/** Optional callback invoked after task result is successfully saved to TaskStore. */
+	onTaskResultSaved?: (taskId: string, success: boolean) => void;
 
 	constructor(
 		log: LogFn,
@@ -781,6 +783,9 @@ export class PiAgentExecutor implements AgentExecutor {
 			await this.saveTaskResult(taskId, contextId, result, loopMetadata);
 			this.taskContexts.delete(taskId);
 			this.inputRoundCounts.delete(taskId);
+			
+			// Notify that result has been persisted
+			this.onTaskResultSaved?.(taskId, result.ok);
 		} catch (err: unknown) {
 			this.activeTaskId = null;
 			this.activeLoopMetadata = null;
@@ -812,6 +817,9 @@ export class PiAgentExecutor implements AgentExecutor {
 			const parkedTimeout = this.parkedInputTimeouts.get(taskId);
 			if (parkedTimeout) clearTimeout(parkedTimeout);
 			this.parkedInputTimeouts.delete(taskId);
+			
+			// Notify that result has been persisted (even on error)
+			this.onTaskResultSaved?.(taskId, false);
 		} finally {
 			// Clean up timeout handle to prevent timer leak
 			if (timeoutHandle) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -321,16 +321,6 @@ export default function (pi: ExtensionAPI) {
 				pendingNonce = null;
 
 				if (response) {
-					// Show completion in chat — result is saved to the task store,
-					// callers retrieve it via tasks/get polling
-					pi.sendMessage(
-						{
-							customType: "a2a-task-completed",
-							content: `✅ **A2A task completed** (${fmtDuration(durationMs)}) — result saved to task store`,
-							display: true,
-						},
-						{ triggerTurn: false },
-					);
 					resolve({ ok: true, response, durationMs });
 				} else {
 					lastTurnStatus = "failed";
@@ -569,6 +559,26 @@ export default function (pi: ExtensionAPI) {
 			updateStatusLine();
 			if (hubAgentId) {
 				sendTelemetry(config).catch(() => {});
+			}
+		};
+
+		// Show completion message after task result is saved to the store.
+		// This fires AFTER saveTaskResult() completes, ensuring the message
+		// accurately reflects that the result is persisted.
+		executor.onTaskResultSaved = (taskId: string, success: boolean) => {
+			if (pendingResolve && pendingNonce) {
+				// Find the matching A2A request to get the duration
+				const durationMs = Date.now() - pendingStartTime;
+				const status = success ? "completed" : "failed";
+				const emoji = success ? "✅" : "❌";
+				pi.sendMessage(
+					{
+						customType: "a2a-task-completed",
+						content: `${emoji} **A2A task ${status}** (${fmtDuration(durationMs)}) — result saved to task store (task: ${taskId.slice(0, 8)}…)`,
+						display: true,
+					},
+					{ triggerTurn: false },
+				);
 			}
 		};
 		pushNotificationStore = new SQLitePushNotificationStore(taskStore.getDb(), log);

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -108,6 +108,14 @@ export default function (pi: ExtensionAPI) {
 	/** Captured from session_start for use in async callbacks. */
 	let sessionCtx: ExtensionContext | null = null;
 
+	/**
+	 * Active A2A task context — captured when processMessage is called and
+	 * cleared after onTaskResultSaved fires. This is separate from pendingResolve
+	 * because agent_end clears pendingResolve/pendingNonce before the executor's
+	 * onTaskResultSaved callback fires.
+	 */
+	let activeA2aTask: { nonce: string; startTime: number; taskId?: string } | null = null;
+
 	// ── Powerbar segment ──────────────────────────────────────
 
 	pi.events.emit("powerbar:register-segment", {
@@ -256,6 +264,9 @@ export default function (pi: ExtensionAPI) {
 			pendingStartTime = start;
 			pendingNonce = nonce;
 
+			// Capture active A2A task context for onTaskResultSaved callback
+			activeA2aTask = { nonce, startTime: start };
+
 			// Inject into the main conversation — triggers a full agent turn.
 			// The nonce in details lets agent_end correlate this turn's response.
 			pi.sendMessage(
@@ -319,6 +330,8 @@ export default function (pi: ExtensionAPI) {
 				pendingResolve = null;
 				pendingReject = null;
 				pendingNonce = null;
+				// Note: activeA2aTask is NOT cleared here — it's cleared by
+				// onTaskResultSaved after the task result is saved to the store.
 
 				if (response) {
 					resolve({ ok: true, response, durationMs });
@@ -526,6 +539,8 @@ export default function (pi: ExtensionAPI) {
 		if (isRunning()) {
 			await stopServer(log);
 		}
+		// Clear active A2A task context
+		activeA2aTask = null;
 
 		const { config, warnings } = loadConfig(cwd);
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
@@ -565,10 +580,11 @@ export default function (pi: ExtensionAPI) {
 		// Show completion message after task result is saved to the store.
 		// This fires AFTER saveTaskResult() completes, ensuring the message
 		// accurately reflects that the result is persisted.
+		// Uses activeA2aTask context (not pendingResolve/pendingNonce) because
+		// agent_end clears those before this callback fires.
 		executor.onTaskResultSaved = (taskId: string, success: boolean) => {
-			if (pendingResolve && pendingNonce) {
-				// Find the matching A2A request to get the duration
-				const durationMs = Date.now() - pendingStartTime;
+			if (activeA2aTask) {
+				const durationMs = Date.now() - activeA2aTask.startTime;
 				const status = success ? "completed" : "failed";
 				const emoji = success ? "✅" : "❌";
 				pi.sendMessage(
@@ -579,6 +595,10 @@ export default function (pi: ExtensionAPI) {
 					},
 					{ triggerTurn: false },
 				);
+				// Update activeA2aTask with taskId for better logging
+				activeA2aTask.taskId = taskId;
+				// Clear activeA2aTask after message is sent
+				activeA2aTask = null;
 			}
 		};
 		pushNotificationStore = new SQLitePushNotificationStore(taskStore.getDb(), log);
@@ -827,6 +847,8 @@ export default function (pi: ExtensionAPI) {
 		if (isRunning()) {
 			await stopServer(log);
 		}
+		// Clear active A2A task context
+		activeA2aTask = null;
 	});
 
 	// ── Clarification Response Poller ─────────────────────────

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -571,7 +571,10 @@ export default function (pi: ExtensionAPI) {
 		// send telemetry so the hub sees "idle" immediately — agent_end
 		// fires before the executor clears activeTaskId, so this callback
 		// is the earliest reliable point where executor.isBusy() is false.
+		// Capture sessionToken to prevent stale callbacks after restart
+		const taskFinishedSession = sessionToken;
 		executor.onTaskFinished = () => {
+			if (sessionToken !== taskFinishedSession) return;
 			updateStatusLine();
 			if (hubAgentId) {
 				sendTelemetry(config).catch(() => {});
@@ -583,7 +586,11 @@ export default function (pi: ExtensionAPI) {
 		// accurately reflects that the result is persisted.
 		// Uses activeA2aTask context (not pendingResolve/pendingNonce) because
 		// agent_end clears those before this callback fires.
+		// Capture sessionToken to prevent stale callbacks from affecting new session
+		const resultSavedSession = sessionToken;
 		executor.onTaskResultSaved = (taskId: string, success: boolean) => {
+			// Bail out if session restarted while callback was pending
+			if (sessionToken !== resultSavedSession) return;
 			if (activeA2aTask) {
 				const durationMs = Date.now() - activeA2aTask.startTime;
 				const status = success ? "completed" : "failed";

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -527,6 +527,9 @@ export default function (pi: ExtensionAPI) {
 		}
 		hubAgentId = null;
 		staticRegistry = null;
+		// Clear active A2A task context BEFORE aborting executor to prevent
+		// stale onTaskResultSaved callbacks from firing in the new session
+		activeA2aTask = null;
 		if (executor) {
 			executor.abortAll();
 			executor = null;
@@ -539,8 +542,6 @@ export default function (pi: ExtensionAPI) {
 		if (isRunning()) {
 			await stopServer(log);
 		}
-		// Clear active A2A task context
-		activeA2aTask = null;
 
 		const { config, warnings } = loadConfig(cwd);
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
@@ -835,6 +836,9 @@ export default function (pi: ExtensionAPI) {
 		hubAgentId = null;
 		staticRegistry = null;
 
+		// Clear active A2A task context BEFORE aborting executor to prevent
+		// stale onTaskResultSaved callbacks from firing after shutdown
+		activeA2aTask = null;
 		if (executor) {
 			executor.abortAll();
 			executor = null;
@@ -847,8 +851,6 @@ export default function (pi: ExtensionAPI) {
 		if (isRunning()) {
 			await stopServer(log);
 		}
-		// Clear active A2A task context
-		activeA2aTask = null;
 	});
 
 	// ── Clarification Response Poller ─────────────────────────


### PR DESCRIPTION
- Add onTaskResultSaved callback to PiAgentExecutor that fires after
  saveTaskResult() completes (both success and failure paths)
- Move completion message from agent_end handler to onTaskResultSaved
  callback, ensuring message accurately reflects persistence
- Add task ID to completion message for better traceability
- Remove premature completion message that fired before DB save


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Task completion notifications are now emitted only after task results are persisted, improving reliability.
* **New Features**
  * Added an optional callback that fires after a task result is saved; completion signaling now uses this callback to report outcomes.
  * Completion messages show success/failure emoji, include task duration and a truncated task ID.
* **Bug Fixes**
  * Active task context is explicitly cleared on restart/shutdown to avoid stale state; finished callbacks are gated to ignore stale sessions.
* **Documentation**
  * Clarified lifecycle timing: the "task finished" hook runs before the result is saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->