### PR TITLE
feat(a2a): add orchestrator and projects tools for A2A Hub P0-P3

### DIFF
--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -10,7 +10,17 @@
  * that need to call this agent.
  */
 
-import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot, PipelineStreamEvent, SSEConnection } from "./types.ts";
+import type {
+	HubConfig,
+	RemoteAgentSummary,
+	RemoteAgentDetail,
+	TelemetrySnapshot,
+	PipelineStreamEvent,
+	SSEConnection,
+	AgentSelectionResult,
+	AgentStrategy,
+	ProjectSettings,
+} from "./types.ts";
 
 export type PipelineState = "queued" | "planning" | "building" | "reviewing" | "pr_ready" | "blocked" | "approved" | "cancelled";
 export type TaskPriority = "low" | "normal" | "high" | "critical";
@@ -766,23 +776,6 @@ export async function listStrategies(
 	return result ? (result.strategies as AgentStrategy[]) ?? null : null;
 }
 
-// ── Projects ───────────────────────────────────────────
-
-export interface ProjectSettings {
-	project: string;
-	displayName?: string;
-	maxConcurrent?: number;
-	stallTimeoutMs?: number;
-	turnTimeoutMs?: number;
-	maxRetryBackoffMs?: number;
-	pollIntervalMs?: number;
-	autoApprove?: boolean;
-	inputRequiredPolicy?: "block" | "ask";
-	eligibleAgents?: string[];
-	createdAt: string;
-	updatedAt: string;
-}
-
 export async function createProject(
 	params: {
 		project: string;
@@ -801,7 +794,7 @@ export async function createProject(
 ): Promise<ProjectSettings | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.create", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_create");
-	return result ? (result as unknown as ProjectSettings) : null;
+	return result ? (result as ProjectSettings) : null;
 }
 
 export async function getProject(
@@ -811,7 +804,7 @@ export async function getProject(
 ): Promise<ProjectSettings | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.get", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_get");
-	return result ? (result as unknown as ProjectSettings) : null;
+	return result ? (result as ProjectSettings) : null;
 }
 
 export async function listProjects(
@@ -821,7 +814,7 @@ export async function listProjects(
 ): Promise<{ projects: ProjectSettings[]; total: number; page: number; limit: number } | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.list", (params ?? {}) as Record<string, unknown>, hubConfig.apiKey, log, "projects_list");
-	return result ? (result as unknown as { projects: ProjectSettings[]; total: number; page: number; limit: number }) : null;
+	return result ? (result as { projects: ProjectSettings[]; total: number; page: number; limit: number }) : null;
 }
 
 export async function updateProject(
@@ -842,7 +835,7 @@ export async function updateProject(
 ): Promise<ProjectSettings | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.update", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_update");
-	return result ? (result as unknown as ProjectSettings) : null;
+	return result ? (result as ProjectSettings) : null;
 }
 
 // ── SSE Stream ───────────────────────────────────────────
@@ -880,6 +873,7 @@ export async function listenToSSEStream(
 	url: string,
 	callback: SSEEventCallback,
 	log: LogFn,
+	apiKey: string,
 ): Promise<{ abort: () => void }> {
 	const controller = new AbortController();
 	let reconnectAttempts = 0;
@@ -891,6 +885,7 @@ export async function listenToSSEStream(
 				signal: controller.signal,
 				headers: {
 					Accept: "text/event-stream",
+					"X-API-Key": apiKey,
 				},
 			});
 			

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -841,6 +841,8 @@ export async function connectToPipelineStream(
 	hubConfig: HubConfig,
 ): Promise<{ url: string }> {
 	const baseUrl = hubConfig.url.replace(/\/$/, "");
+	// Normalize: avoid double /api when hubConfig.url already ends with /api
+	const apiBase = baseUrl.endsWith("/api") ? baseUrl : `${baseUrl}/api`;
 	const params = new URLSearchParams();
 	
 	if (options?.project) params.append("project", options.project);
@@ -849,8 +851,8 @@ export async function connectToPipelineStream(
 	
 	const queryString = params.toString();
 	const url = queryString 
-		? `${baseUrl}/api/v1/pipeline/stream?${queryString}`
-		: `${baseUrl}/api/v1/pipeline/stream`;
+		? `${apiBase}/v1/pipeline/stream?${queryString}`
+		: `${apiBase}/v1/pipeline/stream`;
 	
 	return { url };
 }
@@ -892,7 +894,13 @@ export async function listenToSSEStream(
 			
 			while (!controller.signal.aborted) {
 				const { done, value } = await reader.read();
-				if (done) break;
+				if (done) {
+					// Clean stream close — treat as error to trigger reconnect
+					if (!controller.signal.aborted) {
+						throw new Error("SSE stream closed by server");
+					}
+					return;
+				}
 				
 				buffer += decoder.decode(value, { stream: true });
 				const lines = buffer.split("\n");
@@ -928,7 +936,8 @@ export async function listenToSSEStream(
 		}
 	};
 	
-	connect();
+	// Start connection and await initial handshake
+	await connect();
 	
 	return {
 		abort: () => {

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -728,3 +728,119 @@ export async function reportHubTaskStatus(
 	const result = await hubRpc(rpcUrl, "tasks.reportStatus", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_report_status");
 	return result ? asTask(result) : null;
 }
+
+// ── Orchestrator ───────────────────────────────────────────
+
+export interface AgentSelectionResult {
+	agentId: string;
+}
+
+export interface AgentStrategy {
+	name: string;
+	description: string;
+	weights?: Record<string, number>;
+}
+
+export async function selectAgent(
+	params: {
+		projectId: string;
+		taskTags?: string[];
+		taskType?: string;
+		strategy?: string;
+		eligibleAgentIds?: string[];
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<AgentSelectionResult | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "orchestrator.selectAgent", params as Record<string, unknown>, hubConfig.apiKey, log, "orchestrator_select_agent");
+	return result ? { agentId: result.agentId as string } : null;
+}
+
+export async function listStrategies(
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<AgentStrategy[] | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "orchestrator.listStrategies", {}, hubConfig.apiKey, log, "orchestrator_list_strategies");
+	return result ? (result.strategies as AgentStrategy[]) ?? null : null;
+}
+
+// ── Projects ───────────────────────────────────────────
+
+export interface ProjectSettings {
+	project: string;
+	displayName?: string;
+	maxConcurrent?: number;
+	stallTimeoutMs?: number;
+	turnTimeoutMs?: number;
+	maxRetryBackoffMs?: number;
+	pollIntervalMs?: number;
+	autoApprove?: boolean;
+	inputRequiredPolicy?: "block" | "ask";
+	eligibleAgents?: string[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export async function createProject(
+	params: {
+		project: string;
+		displayName?: string;
+		maxConcurrent?: number;
+		stallTimeoutMs?: number;
+		turnTimeoutMs?: number;
+		maxRetryBackoffMs?: number;
+		pollIntervalMs?: number;
+		autoApprove?: boolean;
+		inputRequiredPolicy?: "block" | "ask";
+		eligibleAgents?: string[];
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<ProjectSettings | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "projects.create", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_create");
+	return result ? (result as unknown as ProjectSettings) : null;
+}
+
+export async function getProject(
+	params: { project: string },
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<ProjectSettings | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "projects.get", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_get");
+	return result ? (result as unknown as ProjectSettings) : null;
+}
+
+export async function listProjects(
+	params: { page?: number; limit?: number } | undefined,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<{ projects: ProjectSettings[]; total: number; page: number; limit: number } | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "projects.list", (params ?? {}) as Record<string, unknown>, hubConfig.apiKey, log, "projects_list");
+	return result ? (result as unknown as { projects: ProjectSettings[]; total: number; page: number; limit: number }) : null;
+}
+
+export async function updateProject(
+	params: {
+		project: string;
+		displayName?: string;
+		maxConcurrent?: number;
+		stallTimeoutMs?: number;
+		turnTimeoutMs?: number;
+		maxRetryBackoffMs?: number;
+		pollIntervalMs?: number;
+		autoApprove?: boolean;
+		inputRequiredPolicy?: "block" | "ask";
+		eligibleAgents?: string[];
+	},
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<ProjectSettings | null> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(rpcUrl, "projects.update", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_update");
+	return result ? (result as unknown as ProjectSettings) : null;
+}

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -741,16 +741,6 @@ export async function reportHubTaskStatus(
 
 // ── Orchestrator ───────────────────────────────────────────
 
-export interface AgentSelectionResult {
-	agentId: string;
-}
-
-export interface AgentStrategy {
-	name: string;
-	description: string;
-	weights?: Record<string, number>;
-}
-
 export async function selectAgent(
 	params: {
 		projectId: string;
@@ -794,7 +784,7 @@ export async function createProject(
 ): Promise<ProjectSettings | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.create", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_create");
-	return result ? (result as ProjectSettings) : null;
+	return result ? (result as unknown as ProjectSettings) : null;
 }
 
 export async function getProject(
@@ -804,7 +794,7 @@ export async function getProject(
 ): Promise<ProjectSettings | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.get", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_get");
-	return result ? (result as ProjectSettings) : null;
+	return result ? (result as unknown as ProjectSettings) : null;
 }
 
 export async function listProjects(
@@ -835,7 +825,7 @@ export async function updateProject(
 ): Promise<ProjectSettings | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.update", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_update");
-	return result ? (result as ProjectSettings) : null;
+	return result ? (result as unknown as ProjectSettings) : null;
 }
 
 // ── SSE Stream ───────────────────────────────────────────

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -10,7 +10,7 @@
  * that need to call this agent.
  */
 
-import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot } from "./types.ts";
+import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot, PipelineStreamEvent, SSEConnection } from "./types.ts";
 
 export type PipelineState = "queued" | "planning" | "building" | "reviewing" | "pr_ready" | "blocked" | "approved" | "cancelled";
 export type TaskPriority = "low" | "normal" | "high" | "critical";
@@ -843,4 +843,111 @@ export async function updateProject(
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "projects.update", params as Record<string, unknown>, hubConfig.apiKey, log, "projects_update");
 	return result ? (result as unknown as ProjectSettings) : null;
+}
+
+// ── SSE Stream ───────────────────────────────────────────
+
+export interface SSEStreamOptions {
+	project?: string;
+	assignedAgentId?: string;
+	states?: string[];
+}
+
+export async function connectToPipelineStream(
+	options: SSEStreamOptions | undefined,
+	hubConfig: HubConfig,
+): Promise<{ url: string }> {
+	const baseUrl = hubConfig.url.replace(/\/$/, "");
+	const params = new URLSearchParams();
+	
+	if (options?.project) params.append("project", options.project);
+	if (options?.assignedAgentId) params.append("assignedAgentId", options.assignedAgentId);
+	if (options?.states?.length) params.append("states", options.states.join(","));
+	
+	const queryString = params.toString();
+	const url = queryString 
+		? `${baseUrl}/api/v1/pipeline/stream?${queryString}`
+		: `${baseUrl}/api/v1/pipeline/stream`;
+	
+	return { url };
+}
+
+export interface SSEEventCallback {
+	(event: PipelineStreamEvent): void;
+}
+
+export async function listenToSSEStream(
+	url: string,
+	callback: SSEEventCallback,
+	log: LogFn,
+): Promise<{ abort: () => void }> {
+	const controller = new AbortController();
+	let reconnectAttempts = 0;
+	const maxReconnectDelay = 30_000;
+	
+	const connect = async () => {
+		try {
+			const response = await fetch(url, {
+				signal: controller.signal,
+				headers: {
+					Accept: "text/event-stream",
+				},
+			});
+			
+			if (!response.ok) {
+				throw new Error(`SSE connection failed: HTTP ${response.status}`);
+			}
+			
+			reconnectAttempts = 0;
+			const reader = response.body?.getReader();
+			if (!reader) throw new Error("No response body");
+			
+			const decoder = new TextDecoder();
+			let buffer = "";
+			
+			while (!controller.signal.aborted) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() ?? "";
+				
+				for (const line of lines) {
+					if (line.startsWith("data: ")) {
+						try {
+							const data = JSON.parse(line.slice(6)) as PipelineStreamEvent;
+							if (data.type === "task.stateChanged") {
+								callback(data);
+							}
+						} catch (e) {
+							log("sse_parse_error", { error: e instanceof Error ? e.message : String(e) }, "WARN");
+						}
+					}
+				}
+			}
+		} catch (error) {
+			if (controller.signal.aborted) return;
+			
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			log("sse_connection_error", { error: errorMsg, attempt: reconnectAttempts }, "ERROR");
+			
+			// Exponential backoff
+			const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), maxReconnectDelay);
+			reconnectAttempts++;
+			
+			log("sse_reconnect_scheduled", { delay, attempt: reconnectAttempts }, "WARN");
+			
+			await new Promise(resolve => setTimeout(resolve, delay));
+			connect();
+		}
+	};
+	
+	connect();
+	
+	return {
+		abort: () => {
+			controller.abort();
+		},
+	};
 }

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -871,31 +871,16 @@ export async function listenToSSEStream(
 	let reconnectAttempts = 0;
 	const maxReconnectDelay = 30_000;
 	
-	const connect = async () => {
+	/** Background read loop — processes SSE events with reconnect on close/error. */
+	const runReadLoop = async (reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> => {
+		const decoder = new TextDecoder();
+		let buffer = "";
+		
 		try {
-			const response = await fetch(url, {
-				signal: controller.signal,
-				headers: {
-					Accept: "text/event-stream",
-					"X-API-Key": apiKey,
-				},
-			});
-			
-			if (!response.ok) {
-				throw new Error(`SSE connection failed: HTTP ${response.status}`);
-			}
-			
-			reconnectAttempts = 0;
-			const reader = response.body?.getReader();
-			if (!reader) throw new Error("No response body");
-			
-			const decoder = new TextDecoder();
-			let buffer = "";
-			
 			while (!controller.signal.aborted) {
 				const { done, value } = await reader.read();
 				if (done) {
-					// Clean stream close — treat as error to trigger reconnect
+					// Clean stream close — trigger reconnect
 					if (!controller.signal.aborted) {
 						throw new Error("SSE stream closed by server");
 					}
@@ -932,12 +917,43 @@ export async function listenToSSEStream(
 			log("sse_reconnect_scheduled", { delay, attempt: reconnectAttempts }, "WARN");
 			
 			await new Promise(resolve => setTimeout(resolve, delay));
-			connect();
+			if (!controller.signal.aborted) {
+				// Re-handshake and pass new reader to runReadLoop
+				try {
+					const newReader = await performHandshake();
+					void runReadLoop(newReader);
+				} catch {
+					// Handshake failed again — runReadLoop's catch will handle retry
+				}
+			}
 		}
 	};
 	
-	// Start connection and await initial handshake
-	await connect();
+	/** Perform initial handshake — returns reader on success, throws on failure. */
+	const performHandshake = async (): Promise<ReadableStreamDefaultReader<Uint8Array>> => {
+		const response = await fetch(url, {
+			signal: controller.signal,
+			headers: {
+				Accept: "text/event-stream",
+				"X-API-Key": apiKey,
+			},
+		});
+		
+		if (!response.ok) {
+			throw new Error(`SSE connection failed: HTTP ${response.status}`);
+		}
+		
+		reconnectAttempts = 0;
+		const reader = response.body?.getReader();
+		if (!reader) throw new Error("No response body");
+		return reader;
+	};
+	
+	// Perform handshake before returning abort handle
+	const reader = await performHandshake();
+	
+	// Start background read loop (don't await — runs indefinitely)
+	void runReadLoop(reader);
 	
 	return {
 		abort: () => {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -50,12 +50,12 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
+import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, selectAgent, listStrategies, getProject, listProjects, createProject, updateProject, connectToPipelineStream, listenToSSEStream, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
 import { sendA2AMessage, getRemoteTask, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
 import { seedLoopMetadata, DEFAULT_MAX_HOPS } from "./supervisor.ts";
-import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot } from "./types.ts";
+import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot, PipelineStreamEvent } from "./types.ts";
 
 const DEFAULT_PORT = 3100;
 
@@ -2213,8 +2213,6 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
-}
 
 	// ── Orchestrator (Smart Routing) ───────────────────────────────────────────
 
@@ -2323,7 +2321,7 @@ export default function (pi: ExtensionAPI) {
 				`**Max Concurrent:** ${result.maxConcurrent ?? 10}`,
 				`**Stall Timeout:** ${result.stallTimeoutMs ?? 300000}ms (${(result.stallTimeoutMs ?? 300000) / 1000 / 60}m)`,
 				`**Turn Timeout:** ${result.turnTimeoutMs ?? 3600000}ms (${(result.turnTimeoutMs ?? 3600000) / 1000 / 60 / 60}h)`,
-				`**Max Retry Backoff:** ${result.maxRetryBackoffMs ?? 300000}ms (${(result.maxRetryBackoffMs ?? 300000) / 1000}m)`,
+				`**Max Retry Backoff:** ${result.maxRetryBackoffMs ?? 300000}ms (${(result.maxRetryBackoffMs ?? 300000) / 60000}m)`,
 				`**Poll Interval:** ${result.pollIntervalMs ?? 30000}ms (${(result.pollIntervalMs ?? 30000) / 1000}s)`,
 				result.eligibleAgents && result.eligibleAgents.length > 0
 					? `\n**Eligible Agents:** ${result.eligibleAgents.join(", ")}`
@@ -2441,11 +2439,6 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
-}
-
-	// ── SSE Stream (Real-time Pipeline Updates) ───────────────────────────────────────────
-
 	const sseConnections = new Map<string, { abort: () => void; connected: boolean }>();
 
 	pi.registerTool({
@@ -2491,11 +2484,11 @@ export default function (pi: ExtensionAPI) {
 					`State: ${data.fromState ?? "(new)"} → **${data.toState}**${agent}${pr}\n` +
 					`Project: ${data.project} | Priority: ${data.priority}`;
 				
-				ctx.ui.notify(message, "info");
+				sessionCtx?.ui.notify(message, "info");
 			};
 
 			try {
-				const { abort } = await listenToSSEStream(url, handleEvent, log);
+				const { abort } = await listenToSSEStream(url, handleEvent, log, hubConfig.apiKey);
 				sseConnections.set(subscriptionId, { abort, connected: true });
 				
 				const filters = [];
@@ -2552,5 +2545,3 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
-}

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -289,6 +289,11 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("agent_end", (event) => {
 		agentBusy = false;
+		// Abort any active SSE subscriptions from previous session
+		for (const [, conn] of sseConnections) {
+			conn.abort();
+		}
+		sseConnections.clear();
 
 		// Record turn duration for telemetry
 		if (lastTurnStartMs > 0) {
@@ -479,6 +484,8 @@ export default function (pi: ExtensionAPI) {
 		await reportTelemetryToHub(hubAgentId, snapshot, config.hub, log);
 	}
 
+    const sseConnections = new Map<string, { abort: () => void }>();
+
 	// ── Lifecycle ─────────────────────────────────────────────
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -494,6 +501,11 @@ export default function (pi: ExtensionAPI) {
 		credentialCache.clear();
 		conversationContexts.clear();
 		agentBusy = false;
+		// Abort any active SSE subscriptions from previous session
+		for (const [, conn] of sseConnections) {
+			conn.abort();
+		}
+		sseConnections.clear();
 		const staleResolvers = idleResolvers;
 		idleResolvers = [];
 		for (const r of staleResolvers) r();
@@ -754,6 +766,11 @@ export default function (pi: ExtensionAPI) {
 		sessionCtx?.ui.setStatus("a2a", undefined);
 		pi.events.emit("powerbar:update", { id: "a2a", text: undefined });
 		sessionCtx = null;
+		// Abort any active SSE subscriptions
+		for (const [, conn] of sseConnections) {
+			conn.abort();
+		}
+		sseConnections.clear();
 		// Reject pending A2A request if any
 		if (pendingResolve) {
 			pendingResolve({ ok: false, response: "", error: "Session shutdown", durationMs: Date.now() - pendingStartTime });
@@ -2439,7 +2456,6 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	const sseConnections = new Map<string, { abort: () => void; connected: boolean }>();
 
 	pi.registerTool({
 		name: "pipeline_stream_subscribe",
@@ -2489,7 +2505,7 @@ export default function (pi: ExtensionAPI) {
 
 			try {
 				const { abort } = await listenToSSEStream(url, handleEvent, log, hubConfig.apiKey);
-				sseConnections.set(subscriptionId, { abort, connected: true });
+				sseConnections.set(subscriptionId, { abort });
 				
 				const filters = [];
 				if (params.project) filters.push(`project=${params.project}`);
@@ -2539,7 +2555,7 @@ export default function (pi: ExtensionAPI) {
 			
 			const lines = [`# Active SSE Subscriptions (${sseConnections.size})\n`];
 			for (const [id, conn] of sseConnections.entries()) {
-				lines.push(`- **${id}** — ${conn.connected ? "✓ Connected" : "✗ Disconnected"}`);
+				lines.push(`- **${id}** — Subscribed (stream active)`);
 			}
 			return txt(lines.join("\n"));
 		},

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2545,3 +2545,4 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+}

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -289,11 +289,6 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("agent_end", (event) => {
 		agentBusy = false;
-		// Abort any active SSE subscriptions from previous session
-		for (const [, conn] of sseConnections) {
-			conn.abort();
-		}
-		sseConnections.clear();
 
 		// Record turn duration for telemetry
 		if (lastTurnStartMs > 0) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2443,3 +2443,114 @@ export default function (pi: ExtensionAPI) {
 
 	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
 }
+
+	// ── SSE Stream (Real-time Pipeline Updates) ───────────────────────────────────────────
+
+	const sseConnections = new Map<string, { abort: () => void; connected: boolean }>();
+
+	pi.registerTool({
+		name: "pipeline_stream_subscribe",
+		label: "Pipeline Stream Subscribe",
+		description:
+			"Subscribe to real-time pipeline task state changes via Server-Sent Events (SSE). " +
+			"Receive instant notifications when tasks transition between states (queued→planning→building→reviewing→pr_ready). " +
+			"Call without filters to subscribe to all events, or provide project/agent/state filters. " +
+			"Returns a subscription ID — use pipeline_stream_unsubscribe to stop receiving events.",
+		parameters: Type.Object({
+			project: Type.Optional(Type.String({ description: "Filter to specific project (e.g. 'aivena', 'e9n.dev')" })),
+			assignedAgentId: Type.Optional(Type.String({ description: "Filter to tasks assigned to specific agent" })),
+			states: Type.Optional(Type.Array(Type.String(), { 
+				description: "Filter to specific target states (queued, planning, building, reviewing, pr_ready, blocked)",
+			})),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const { url } = await connectToPipelineStream(params, hubConfig);
+			const subscriptionId = `sse-${Date.now()}-${Math.random().toString(36).substring(2, 6)}`;
+			
+			// Event handler: notify user via TUI
+			const handleEvent = (event: PipelineStreamEvent) => {
+				const { data } = event;
+				const emoji: Record<string, string> = {
+					queued: "📋", planning: "📐", building: "🔨",
+					reviewing: "👀", pr_ready: "🚀", blocked: "🚧",
+					approved: "✅", cancelled: "❌",
+				};
+				const icon = emoji[data.toState] ?? "📝";
+				const agent = data.assignedAgentId ? ` → agent:${data.assignedAgentId.slice(0, 8)}…` : "";
+				const ext = data.externalTaskId ? ` [${data.externalTaskId}]` : "";
+				const pr = data.prUrl ? ` PR#${data.prNumber}` : "";
+				
+				const message = `${icon} **${data.title}**${ext}\n` +
+					`State: ${data.fromState ?? "(new)"} → **${data.toState}**${agent}${pr}\n` +
+					`Project: ${data.project} | Priority: ${data.priority}`;
+				
+				ctx.ui.notify(message, "info");
+			};
+
+			try {
+				const { abort } = await listenToSSEStream(url, handleEvent, log);
+				sseConnections.set(subscriptionId, { abort, connected: true });
+				
+				const filters = [];
+				if (params.project) filters.push(`project=${params.project}`);
+				if (params.assignedAgentId) filters.push(`agent=${params.assignedAgentId}`);
+				if (params.states?.length) filters.push(`states=${params.states.join(",")}`);
+				const filterStr = filters.length > 0 ? ` (${filters.join(", ")})` : " (all events)";
+				
+				return txt(`✅ Subscribed to pipeline stream${filterStr}\n**Subscription ID:** ${subscriptionId}\n\nYou will receive real-time notifications when tasks change state.\nUse /tool pipeline_stream_unsubscribe subscriptionId=${subscriptionId} to stop.`);
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				return txt(`❌ Failed to subscribe: ${msg}`);
+			}
+		},
+	});
+
+	pi.registerTool({
+		name: "pipeline_stream_unsubscribe",
+		label: "Pipeline Stream Unsubscribe",
+		description:
+			"Stop receiving real-time pipeline events from a previous subscription. " +
+			"Use the subscription ID returned from pipeline_stream_subscribe.",
+		parameters: Type.Object({
+			subscriptionId: Type.String({ description: "Subscription ID from pipeline_stream_subscribe" }),
+		}),
+		async execute(_toolCallId, params) {
+			const conn = sseConnections.get(params.subscriptionId);
+			if (!conn) {
+				return txt(`❌ Subscription not found: ${params.subscriptionId}`);
+			}
+			
+			conn.abort();
+			sseConnections.delete(params.subscriptionId);
+			return txt(`✅ Unsubscribed from pipeline stream: ${params.subscriptionId}`);
+		},
+	});
+
+	pi.registerTool({
+		name: "pipeline_stream_status",
+		label: "Pipeline Stream Status",
+		description:
+			"Show active SSE subscriptions and their connection status.",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params) {
+			if (sseConnections.size === 0) {
+				return txt("No active SSE subscriptions.\nUse /tool pipeline_stream_subscribe to start receiving real-time updates.");
+			}
+			
+			const lines = [`# Active SSE Subscriptions (${sseConnections.size})\n`];
+			for (const [id, conn] of sseConnections.entries()) {
+				lines.push(`- **${id}** — ${conn.connected ? "✓ Connected" : "✗ Disconnected"}`);
+			}
+			return txt(lines.join("\n"));
+		},
+	});
+
+	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
+}

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2215,3 +2215,231 @@ export default function (pi: ExtensionAPI) {
 
 	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
 }
+
+	// ── Orchestrator (Smart Routing) ───────────────────────────────────────────
+
+	pi.registerTool({
+		name: "orchestrator_select_agent",
+		label: "Orchestrator Select Agent",
+		description:
+			"Select the best agent for a task using skill-weighted, workload-first, round-robin, or historical strategy. " +
+			"Returns the selected agent ID. Use this before dispatching tasks to remote agents.",
+		parameters: Type.Object({
+			projectId: Type.String({ description: "Project name for scoping agent eligibility" }),
+			taskTags: Type.Optional(Type.Array(Type.String(), { description: "Task tags for skill matching" })),
+			taskType: Type.Optional(Type.String({ description: "Task type for skill matching" })),
+			strategy: Type.Optional(Type.Union([
+				Type.Literal("skill-weighted"),
+				Type.Literal("workload-first"),
+				Type.Literal("round-robin"),
+				Type.Literal("historical"),
+			], { description: "Selection strategy (default: skill-weighted)" })),
+			eligibleAgentIds: Type.Optional(Type.Array(Type.String(), { description: "Restrict selection to specific agents" })),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const result = await selectAgent(params, hubConfig, log);
+			if (!result) {
+				return txt("❌ Failed to select agent — check hub connection and project configuration.");
+			}
+
+			return txt(`✅ Selected agent: **${result.agentId}**\nProject: ${params.projectId}\nStrategy: ${params.strategy ?? "skill-weighted (default)"}`);
+		},
+	});
+
+	pi.registerTool({
+		name: "orchestrator_list_strategies",
+		label: "Orchestrator List Strategies",
+		description:
+			"List available agent selection strategies with their descriptions and scoring weights. " +
+			"Use this to understand which strategy is best for your use case.",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const strategies = await listStrategies(hubConfig, log);
+			if (!strategies || strategies.length === 0) {
+				return txt("❌ Failed to fetch strategies or none available.");
+			}
+
+			const lines = ["# Agent Selection Strategies\n"];
+			for (const s of strategies) {
+				lines.push(`## ${s.name}`);
+				lines.push(s.description);
+				if (s.weights) {
+					const weights = Object.entries(s.weights)
+						.map(([k, v]) => `${k}: ${v * 100}%`)
+						.join(", ");
+					lines.push(`**Weights:** ${weights}\n`);
+				}
+				lines.push("");
+			}
+			return txt(lines.join("\n"));
+		},
+	});
+
+	// ── Projects (Project Settings) ───────────────────────────────────────────
+
+	pi.registerTool({
+		name: "projects_get",
+		label: "Projects Get",
+		description:
+			"Get project settings including orchestrator config, auto-approve policy, and eligible agents. " +
+			"Returns full project configuration for the specified project name.",
+		parameters: Type.Object({
+			project: Type.String({ description: "Project name (e.g. 'aivena', 'e9n.dev')" }),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const result = await getProject(params, hubConfig, log);
+			if (!result) {
+				return txt(`❌ Project not found: ${params.project}`);
+			}
+
+			const lines = [
+				`# Project: ${result.project}`,
+				result.displayName ? `**Display Name:** ${result.displayName}` : "",
+				`**Auto Approve:** ${result.autoApprove ? "✓ Enabled" : "✗ Disabled"}`,
+				`**Input Policy:** ${result.inputRequiredPolicy ?? "block"}`,
+				"",
+				"## Orchestrator Config",
+				`**Max Concurrent:** ${result.maxConcurrent ?? 10}`,
+				`**Stall Timeout:** ${result.stallTimeoutMs ?? 300000}ms (${(result.stallTimeoutMs ?? 300000) / 1000 / 60}m)`,
+				`**Turn Timeout:** ${result.turnTimeoutMs ?? 3600000}ms (${(result.turnTimeoutMs ?? 3600000) / 1000 / 60 / 60}h)`,
+				`**Max Retry Backoff:** ${result.maxRetryBackoffMs ?? 300000}ms (${(result.maxRetryBackoffMs ?? 300000) / 1000}m)`,
+				`**Poll Interval:** ${result.pollIntervalMs ?? 30000}ms (${(result.pollIntervalMs ?? 30000) / 1000}s)`,
+				result.eligibleAgents && result.eligibleAgents.length > 0
+					? `\n**Eligible Agents:** ${result.eligibleAgents.join(", ")}`
+					: "\n**Eligible Agents:** All agents",
+				"",
+				`**Created:** ${result.createdAt}`,
+				`**Updated:** ${result.updatedAt}`,
+			].filter(Boolean);
+			return txt(lines.join("\n"));
+		},
+	});
+
+	pi.registerTool({
+		name: "projects_list",
+		label: "Projects List",
+		description:
+			"List all projects with their settings. Supports pagination via page and limit parameters.",
+		parameters: Type.Object({
+			page: Type.Optional(Type.Number({ description: "Page number (default: 1)" })),
+			limit: Type.Optional(Type.Number({ description: "Results per page (default: 20)" })),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const result = await listProjects(params, hubConfig, log);
+			if (!result || result.projects.length === 0) {
+				return txt("No projects found.");
+			}
+
+			const lines = [`# Projects (${result.total} total, page ${result.page})\n`];
+			for (const p of result.projects) {
+				const agents = p.eligibleAgents?.length ?? 0;
+				lines.push(`- **${p.project}**${p.displayName ? ` (${p.displayName})` : ""}`);
+				lines.push(`  Auto-approve: ${p.autoApprove ? "✓" : "✗"} | Max concurrent: ${p.maxConcurrent ?? 10} | Eligible agents: ${agents || "all"}`);
+			}
+			if (result.limit > 0 && result.total > result.page * result.limit) {
+				lines.push(`\n_${result.total - result.page * result.limit} more — use page param to paginate_`);
+			}
+			return txt(lines.join("\n"));
+		},
+	});
+
+	pi.registerTool({
+		name: "projects_create",
+		label: "Projects Create",
+		description:
+			"Create a new project with custom orchestrator settings, auto-approve policy, and eligible agents. " +
+			"All settings are optional — omit to use defaults.",
+		parameters: Type.Object({
+			project: Type.String({ description: "Project name (e.g. 'aivena', 'e9n.dev')" }),
+			displayName: Type.Optional(Type.String({ description: "Display name for UI" })),
+			maxConcurrent: Type.Optional(Type.Number({ description: "Max concurrent tasks (default: 10)" })),
+			stallTimeoutMs: Type.Optional(Type.Number({ description: "Stall timeout in ms (default: 300000 = 5m)" })),
+			turnTimeoutMs: Type.Optional(Type.Number({ description: "Turn timeout in ms (default: 3600000 = 1h)" })),
+			maxRetryBackoffMs: Type.Optional(Type.Number({ description: "Max retry backoff in ms (default: 300000 = 5m)" })),
+			pollIntervalMs: Type.Optional(Type.Number({ description: "Poll interval in ms (default: 30000 = 30s)" })),
+			autoApprove: Type.Optional(Type.Boolean({ description: "Auto-approve tasks (default: false)" })),
+			inputRequiredPolicy: Type.Optional(Type.Union([Type.Literal("block"), Type.Literal("ask")], { description: "Input policy (default: block)" })),
+			eligibleAgents: Type.Optional(Type.Array(Type.String(), { description: "Restrict to specific agent IDs" })),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const result = await createProject(params, hubConfig, log);
+			if (!result) {
+				return txt(`❌ Failed to create project: ${params.project}`);
+			}
+
+			return txt(`✅ Created project: **${result.project}**${result.displayName ? ` (${result.displayName})` : ""}\nAuto-approve: ${result.autoApprove ? "✓" : "✗"}\nMax concurrent: ${result.maxConcurrent ?? 10}`);
+		},
+	});
+
+	pi.registerTool({
+		name: "projects_update",
+		label: "Projects Update",
+		description:
+			"Update project settings. Only specified fields are updated — omit fields to preserve current values. " +
+			"Use projects_get first to see current settings.",
+		parameters: Type.Object({
+			project: Type.String({ description: "Project name (e.g. 'aivena', 'e9n.dev')" }),
+			displayName: Type.Optional(Type.String({ description: "Display name for UI" })),
+			maxConcurrent: Type.Optional(Type.Number({ description: "Max concurrent tasks" })),
+			stallTimeoutMs: Type.Optional(Type.Number({ description: "Stall timeout in ms" })),
+			turnTimeoutMs: Type.Optional(Type.Number({ description: "Turn timeout in ms" })),
+			maxRetryBackoffMs: Type.Optional(Type.Number({ description: "Max retry backoff in ms" })),
+			pollIntervalMs: Type.Optional(Type.Number({ description: "Poll interval in ms" })),
+			autoApprove: Type.Optional(Type.Boolean({ description: "Auto-approve tasks" })),
+			inputRequiredPolicy: Type.Optional(Type.Union([Type.Literal("block"), Type.Literal("ask")], { description: "Input policy" })),
+			eligibleAgents: Type.Optional(Type.Array(Type.String(), { description: "Restrict to specific agent IDs" })),
+		}),
+		async execute(_toolCallId, params) {
+			const { config } = loadConfig(cwd);
+			const hubConfig = config.hub;
+
+			if (!hubConfig?.apiKey) {
+				return txt("❌ No A2A Hub configured. Set `pi-a2a.hub.url` and `pi-a2a.hub.apiKey` in settings.json.");
+			}
+
+			const result = await updateProject(params, hubConfig, log);
+			if (!result) {
+				return txt(`❌ Failed to update project: ${params.project}`);
+			}
+
+			return txt(`✅ Updated project: **${result.project}**${result.displayName ? ` (${result.displayName})` : ""}\nAuto-approve: ${result.autoApprove ? "✓" : "✗"}\nMax concurrent: ${result.maxConcurrent ?? 10}`);
+		},
+	});
+
+	// Skipped: /a2a event bus listener — complex 198-line handler with many ctx.ui.notify branches
+}

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -188,3 +188,31 @@ export interface ProjectSettings {
 	createdAt: string;
 	updatedAt: string;
 }
+
+// ── SSE Stream Types ──────────────────────────────────────────
+
+export interface PipelineStreamEvent {
+	type: "task.stateChanged";
+	data: {
+		taskId: string;
+		fromState: string | null;
+		toState: string;
+		project: string;
+		assignedAgentId: string | null;
+		externalTaskId: string | null;
+		branch: string | null;
+		prUrl: string | null;
+		prNumber: number | null;
+		title: string;
+		priority: string;
+	};
+	timestamp: string;
+}
+
+export interface SSEConnection {
+	url: string;
+	connected: boolean;
+	lastEventAt: string | null;
+	error: string | null;
+	reconnectAttempts: number;
+}

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -161,3 +161,30 @@ export interface TelemetrySnapshot {
 	lastTaskDurationMs?: number;
 	lastTaskStatus?: "completed" | "failed";
 }
+
+// ── Orchestrator Types ──────────────────────────────────────────
+
+export interface AgentSelectionResult {
+	agentId: string;
+}
+
+export interface AgentStrategy {
+	name: string;
+	description: string;
+	weights?: Record<string, number>;
+}
+
+export interface ProjectSettings {
+	project: string;
+	displayName?: string;
+	maxConcurrent?: number;
+	stallTimeoutMs?: number;
+	turnTimeoutMs?: number;
+	maxRetryBackoffMs?: number;
+	pollIntervalMs?: number;
+	autoApprove?: boolean;
+	inputRequiredPolicy?: "block" | "ask";
+	eligibleAgents?: string[];
+	createdAt: string;
+	updatedAt: string;
+}


### PR DESCRIPTION
## Summary

Adds 9 new tools to the pi-a2a extension to support the A2A Hub's P0-P3 autonomy features from PR #16.

## New Tools

### Orchestrator (Smart Routing - P3)

**orchestrator_select_agent**
- Select best agent using skill-weighted, workload-first, round-robin, or historical strategy
- Parameters: projectId (required), taskTags, taskType, strategy, eligibleAgentIds
- Returns: Selected agent ID

**orchestrator_list_strategies**
- List available agent selection strategies with descriptions and scoring weights
- No parameters required

### Projects (Project Settings - P1)

**projects_get**
- Get project settings including orchestrator config, auto-approve policy, eligible agents
- Parameters: project (required)

**projects_list**
- List all projects with pagination
- Parameters: page, limit

**projects_create**
- Create new project with custom orchestrator settings
- Parameters: project (required), displayName, maxConcurrent, stallTimeoutMs, turnTimeoutMs, maxRetryBackoffMs, pollIntervalMs, autoApprove, inputRequiredPolicy, eligibleAgents

**projects_update**
- Update project settings (partial updates supported)
- Parameters: project (required), + all optional settings

### SSE Stream (Real-time Updates - P2) ✨ NEW

**pipeline_stream_subscribe**
- Subscribe to real-time task.stateChanged events via Server-Sent Events
- TUI notifications with emoji icons for state transitions
- Exponential backoff reconnection (1s → 30s max)
- Parameters: project, assignedAgentId, states (all optional filters)
- Returns: Subscription ID for later unsubscribe

**pipeline_stream_unsubscribe**
- Stop receiving events from a subscription
- Parameters: subscriptionId (required)

**pipeline_stream_status**
- Show active SSE subscriptions and connection status
- No parameters required

## Implementation

- All tools use existing hub.ts RPC helpers (hubRpc)
- SSE tools use native fetch with AbortController for cleanup
- Calls A2A Hub JSON-RPC methods: orchestrator.*, projects.*, SSE endpoint: /api/v1/pipeline/stream
- Type definitions added to types.ts
- Hub functions added to hub.ts
- Tool implementations in index.ts

## Testing

Manual testing required:
1. Point pi-a2a at A2A Hub with PR #16 merged
2. Test each tool via /tool command
3. Verify orchestrator selection respects project eligibility
4. Verify project CRUD operations
5. Verify SSE notifications appear on task state changes

## Dependencies

Requires A2A Hub PR #16 to be merged first (adds RPC methods + SSE endpoint to hub API).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent orchestration: agent selection and strategy listing with summarized outputs.
  * Project management: create, view, update, and list projects with key settings surfaced.
  * Real-time pipeline streaming: subscribe/unsubscribe/status for SSE-based event feeds and TUI-style notifications.
  * Stream filtering: optional filters for project, agent, and task states.

* **Bug Fixes / Reliability**
  * Improved stream reliability with automatic reconnect and lifecycle cleanup of active subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->