### PR TITLE
feat(pi-channels): message history with SQLite logging, TUI popup, and channel_history tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pi-debug.log
 .pilot
 models.json
 package/
+.worktrees/

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -47,6 +47,12 @@ export function loadConfig(cwd: string): ChannelConfig {
 	const projectCh = project?.[SETTINGS_KEY] ?? {};
 
 	// Project overrides global (shallow merge of adapters + routes + bridge)
+	// messageRetentionDays: project overrides global if set, otherwise default 30
+	const messageRetentionDays =
+		(projectCh.messageRetentionDays as number | undefined) ??
+		(globalCh.messageRetentionDays as number | undefined) ??
+		30;
+
 	const merged: ChannelConfig = {
 		adapters: {
 			...(globalCh.adapters ?? {}),
@@ -60,6 +66,7 @@ export function loadConfig(cwd: string): ChannelConfig {
 			...(globalCh.bridge ?? {}),
 			...(projectCh.bridge ?? {}),
 		} as ChannelConfig["bridge"],
+		messageRetentionDays,
 	};
 
 	// Env vars override settings.json values

--- a/extensions/pi-channels/src/events.ts
+++ b/extensions/pi-channels/src/events.ts
@@ -18,12 +18,19 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { ChannelRegistry } from "./registry.ts";
 import type { ChannelAdapter, ChannelMessage, IncomingMessage } from "./types.ts";
 import type { ChatBridge } from "./bridge/bridge.ts";
+import type { MessageHistory } from "./history.ts";
 
 /** Reference to the active bridge, set by index.ts after construction. */
 let activeBridge: ChatBridge | null = null;
+/** Reference to the message history, set by index.ts after construction. */
+let activeHistory: MessageHistory | null = null;
 
 export function setBridge(bridge: ChatBridge | null): void {
 	activeBridge = bridge;
+}
+
+export function setHistory(history: MessageHistory): void {
+	activeHistory = history;
 }
 
 export function registerChannelEvents(pi: ExtensionAPI, registry: ChannelRegistry): void {
@@ -32,6 +39,9 @@ export function registerChannelEvents(pi: ExtensionAPI, registry: ChannelRegistr
 
 	registry.setOnIncoming(async (message: IncomingMessage) => {
 		pi.events.emit("channel:receive", message);
+
+		// Log to message history (fire-and-forget)
+		activeHistory?.logIncoming(message, message.adapter);
 
 		// Route to bridge if active
 		if (activeBridge?.isActive()) {

--- a/extensions/pi-channels/src/history.ts
+++ b/extensions/pi-channels/src/history.ts
@@ -126,8 +126,9 @@ export class MessageHistory {
 		return result.rows as unknown as MessageRow[];
 	}
 
-	/** Delete messages older than retentionDays. */
+	/** Delete messages older than retentionDays. 0 or negative = keep forever. */
 	async cleanup(): Promise<number> {
+		if (this.retentionDays <= 0) return 0;
 		const sql = `DELETE FROM ${TABLE_NAME} WHERE created_at < datetime('now', ?)`;
 		const result = await this.queryRaw(sql, [`-${this.retentionDays} days`]);
 		return result.numAffectedRows ?? 0;
@@ -155,16 +156,20 @@ export class MessageHistory {
 	// ── Internal ─────────────────────────────────────────────
 
 	private async queryRaw(sql: string, params: unknown[] = []): Promise<{ rows: Record<string, unknown>[]; numAffectedRows?: number }> {
+		const TIMEOUT_MS = 10_000;
 		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => reject(new Error("History query timed out (kysely not responding)")), TIMEOUT_MS);
 			try {
 				this.events.emit("kysely:query", {
 					actor: "pi-channels",
 					input: { sql, params },
 					reply: (result: { rows: Record<string, unknown>[]; numAffectedRows?: number }) => {
+						clearTimeout(timeout);
 						resolve(result);
 					},
 				} as any);
 			} catch (err) {
+				clearTimeout(timeout);
 				reject(err);
 			}
 		});

--- a/extensions/pi-channels/src/history.ts
+++ b/extensions/pi-channels/src/history.ts
@@ -1,0 +1,176 @@
+/**
+ * pi-channels — Message history module.
+ *
+ * Logs all incoming/outgoing messages to a SQLite table via pi-kysely.
+ * Supports querying, retention cleanup, and TUI display.
+ *
+ * Table: pi-channels__messages
+ *
+ * Config: messageRetentionDays in pi-channels settings (default: 30)
+ */
+
+import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { ChannelMessage, IncomingMessage } from "./types.ts";
+
+export const TABLE_NAME = "pi-channels__messages";
+
+export interface MessageRow {
+	id: number;
+	adapter: string;
+	direction: "in" | "out";
+	sender: string | null;
+	recipient: string | null;
+	text: string | null;
+	metadata: string | null;
+	created_at: string;
+}
+
+export interface HistoryQuery {
+	adapter?: string;
+	direction?: "in" | "out";
+	limit?: number;
+	offset?: number;
+	since?: string; // ISO datetime string
+}
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	adapter TEXT NOT NULL,
+	direction TEXT NOT NULL CHECK(direction IN ('in', 'out')),
+	sender TEXT,
+	recipient TEXT,
+	text TEXT,
+	metadata TEXT,
+	created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_messages_adapter ON ${TABLE_NAME}(adapter);
+CREATE INDEX IF NOT EXISTS idx_messages_created ON ${TABLE_NAME}(created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_direction ON ${TABLE_NAME}(direction);
+`;
+
+const INSERT_SQL = `INSERT INTO ${TABLE_NAME} (adapter, direction, sender, recipient, text, metadata) VALUES (?, ?, ?, ?, ?, ?)`;
+
+export class MessageHistory {
+	private events: EventBus;
+	private retentionDays: number;
+	private initialized = false;
+	private logErrors: ((event: string, data: unknown, level?: string) => void) | null = null;
+
+	constructor(events: EventBus, retentionDays: number = 30) {
+		this.events = events;
+		this.retentionDays = retentionDays;
+	}
+
+	setErrorLogger(log: (event: string, data: unknown, level?: string) => void): void {
+		this.logErrors = log;
+	}
+
+	/** Create table and run initial cleanup. Call after kysely is ready. */
+	async init(): Promise<void> {
+		if (this.initialized) return;
+
+		// Create schema (each statement separately — SQLite doesn't handle multi-statement well)
+		const statements = SCHEMA_SQL.split(";").map(s => s.trim()).filter(Boolean);
+		for (const stmt of statements) {
+			await this.execute(stmt);
+		}
+
+		// Run initial cleanup
+		await this.cleanup();
+
+		this.initialized = true;
+	}
+
+	/** Log an incoming message (fire-and-forget). */
+	logIncoming(msg: IncomingMessage, adapterName: string): void {
+		if (!this.initialized) return;
+		const meta = JSON.stringify(msg.metadata ?? {});
+		this.execute(INSERT_SQL, [adapterName, "in", msg.sender, null, msg.text, meta])
+			.catch(() => {}); // best-effort
+	}
+
+	/** Log an outgoing message (fire-and-forget). */
+	logOutgoing(msg: ChannelMessage, adapterName: string): void {
+		if (!this.initialized) return;
+		const meta = JSON.stringify(msg.metadata ?? {});
+		this.execute(INSERT_SQL, [adapterName, "out", null, msg.recipient, msg.text ?? null, meta])
+			.catch(() => {}); // best-effort
+	}
+
+	/** Query message history. */
+	async query(filters: HistoryQuery = {}): Promise<MessageRow[]> {
+		const conditions: string[] = [];
+		const params: unknown[] = [];
+
+		if (filters.adapter) {
+			conditions.push("adapter = ?");
+			params.push(filters.adapter);
+		}
+		if (filters.direction) {
+			conditions.push("direction = ?");
+			params.push(filters.direction);
+		}
+		if (filters.since) {
+			conditions.push("created_at >= ?");
+			params.push(filters.since);
+		}
+
+		const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+		const limit = filters.limit ?? 50;
+		const offset = filters.offset ?? 0;
+		const sql = `SELECT * FROM ${TABLE_NAME} ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`;
+		params.push(limit, offset);
+
+		const result = await this.queryRaw(sql, params);
+		return result.rows as unknown as MessageRow[];
+	}
+
+	/** Delete messages older than retentionDays. */
+	async cleanup(): Promise<number> {
+		const sql = `DELETE FROM ${TABLE_NAME} WHERE created_at < datetime('now', ?)`;
+		const result = await this.queryRaw(sql, [`-${this.retentionDays} days`]);
+		return result.numAffectedRows ?? 0;
+	}
+
+	/** Count messages (for stats). */
+	async count(filters: HistoryQuery = {}): Promise<number> {
+		const conditions: string[] = [];
+		const params: unknown[] = [];
+
+		if (filters.adapter) {
+			conditions.push("adapter = ?");
+			params.push(filters.adapter);
+		}
+		if (filters.direction) {
+			conditions.push("direction = ?");
+			params.push(filters.direction);
+		}
+
+		const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+		const result = await this.queryRaw(`SELECT COUNT(*) as cnt FROM ${TABLE_NAME} ${where}`, params);
+		return Number(result.rows[0]?.cnt ?? 0);
+	}
+
+	// ── Internal ─────────────────────────────────────────────
+
+	private async queryRaw(sql: string, params: unknown[] = []): Promise<{ rows: Record<string, unknown>[]; numAffectedRows?: number }> {
+		return new Promise((resolve, reject) => {
+			try {
+				this.events.emit("kysely:query", {
+					actor: "pi-channels",
+					input: { sql, params },
+					reply: (result: { rows: Record<string, unknown>[]; numAffectedRows?: number }) => {
+						resolve(result);
+					},
+				} as any);
+			} catch (err) {
+				reject(err);
+			}
+		});
+	}
+
+	private async execute(sql: string, params: unknown[] = []): Promise<void> {
+		await this.queryRaw(sql, params);
+	}
+}

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -53,6 +53,7 @@ async function waitForKysely(pi: ExtensionAPI): Promise<void> {
 			if (!resolved) {
 				resolved = true;
 				clearTimeout(timeout);
+				pi.events.off("kysely:ready", done);
 				resolve();
 			}
 		};
@@ -268,7 +269,7 @@ export default function (pi: ExtensionAPI) {
 
 	// ── LLM tool ──────────────────────────────────────────────
 
-	registerChannelTool(pi, registry);
+	// Tool registered in session_start after history is available (line ~170)
 
 	// ── Command: /channel-history ─────────────────────────────
 

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -21,11 +21,12 @@
 import type { ExtensionAPI, SlashCommandInfo } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "./config.ts";
 import { ChannelRegistry } from "./registry.ts";
-import { registerChannelEvents, setBridge } from "./events.ts";
+import { registerChannelEvents, setBridge, setHistory } from "./events.ts";
 import { registerChannelTool } from "./tool.ts";
 import { ChatBridge } from "./bridge/bridge.ts";
 import { getAllCommands, type SlashCommandInfo as ChannelSlashCommand } from "./bridge/commands.ts";
 import { createLogger } from "./logger.ts";
+import { MessageHistory, type MessageRow } from "./history.ts";
 
 /** Convert pi's SlashCommandInfo to the bridge's simplified format. */
 function toChannelSlashCommands(commands: SlashCommandInfo[]): ChannelSlashCommand[] {
@@ -40,11 +41,102 @@ function toChannelSlashCommands(commands: SlashCommandInfo[]): ChannelSlashComma
 	}));
 }
 
+/** Wait for pi-kysely to be ready (or timeout after 10s). */
+async function waitForKysely(pi: ExtensionAPI): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(new Error("Timed out waiting for pi-kysely"));
+		}, 10_000);
+
+		let resolved = false;
+		const done = () => {
+			if (!resolved) {
+				resolved = true;
+				clearTimeout(timeout);
+				resolve();
+			}
+		};
+
+		// Try probing — if already ready, the reply callback fires synchronously
+		pi.events.emit("kysely:info", {
+			reply: (_info: unknown) => done(),
+		});
+
+		// Also listen for the ready event in case it hasn't fired yet
+		pi.events.on("kysely:ready", done);
+	});
+}
+
+/** Show message history in a TUI overlay popup. */
+async function showHistoryPopup(ctx: any, rows: MessageRow[]): Promise<void> {
+	const { matchesKey, Key, truncateToWidth } = await import("@mariozechner/pi-tui");
+
+	const arrow = (d: string) => (d === "in" ? "←" : "→");
+	const source = (row: MessageRow) =>
+		row.direction === "in" ? (row.sender || "?") : (row.recipient || "?");
+
+	const maxVisible = 15;
+	let scrollOffset = 0;
+
+	const component = {
+		invalidate() {},
+		render(width: number): string[] {
+			const maxWidth = Math.min(width, 100);
+			const lines: string[] = [];
+			lines.push(truncateToWidth(`📨 Channel History (${rows.length} messages)`, maxWidth));
+			lines.push("");
+
+			const start = scrollOffset;
+			const end = Math.min(start + maxVisible, rows.length);
+
+			for (let i = start; i < end; i++) {
+				const row = rows[i];
+				const ts = row.created_at?.replace("T", " ").slice(5, 16) ?? "?";
+				const preview = (row.text ?? "").slice(0, 80).replace(/\n/g, " ");
+				let line = `${ts} ${arrow(row.direction)}[${row.adapter}] ${source(row)}: ${preview}`;
+				if (row.direction === "in") line = `\x1b[34m${line}\x1b[0m`;
+				lines.push(truncateToWidth(line, maxWidth));
+			}
+
+			if (rows.length > maxVisible) {
+				lines.push("");
+				lines.push(truncateToWidth(
+					`${start + 1}-${end} of ${rows.length}  ↑↓ scroll  esc close`,
+					maxWidth,
+				));
+			}
+
+			return lines;
+		},
+		handleInput(data: string): void {
+			if (matchesKey(data, Key.up) && scrollOffset > 0) {
+				scrollOffset--;
+			} else if (matchesKey(data, Key.down) && scrollOffset < rows.length - maxVisible) {
+				scrollOffset++;
+			}
+		},
+	};
+
+	await new Promise<void>((resolve) => {
+		const origHandleInput = component.handleInput;
+		component.handleInput = (data: string) => {
+			if (matchesKey(data, Key.escape)) {
+				handle.close();
+				resolve();
+				return;
+			}
+			origHandleInput.call(component, data);
+		};
+		const handle = ctx.ui.custom(component, { overlay: true });
+	});
+}
+
 export default function (pi: ExtensionAPI) {
 	const log = createLogger(pi);
 	const registry = new ChannelRegistry();
 	registry.setLogger(log);
 	let bridge: ChatBridge | null = null;
+	let history: MessageHistory | null = null;
 
 	// ── Flag: --chat-bridge ───────────────────────────────────
 
@@ -63,6 +155,19 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event: any, ctx: any) => {
 		const config = loadConfig(ctx.cwd);
 		registry.setModelRegistry(ctx.modelRegistry);
+
+		// Initialize message history (waits for pi-kysely to be ready)
+		const retentionDays = config.messageRetentionDays ?? 30;
+		history = new MessageHistory(pi.events, retentionDays);
+		history.setErrorLogger(log);
+		await waitForKysely(pi).then(() => history!.init());
+		registry.setHistory(history);
+		setHistory(history);
+		log("history-init", { retentionDays });
+
+		// Register channel_history tool (now that history is ready)
+		registerChannelTool(pi, registry, history);
+
 		await registry.loadConfig(config, ctx.cwd);
 
 		const errors = registry.getErrors();
@@ -165,7 +270,57 @@ export default function (pi: ExtensionAPI) {
 
 	registerChannelTool(pi, registry);
 
-	// Event bus listener for web/mobile slash command support
+	// ── Command: /channel-history ─────────────────────────────
+
+	pi.registerCommand("channel-history", {
+		description: "View message history across channels: /channel-history [adapter] [limit]",
+		getArgumentCompletions: (prefix: string) => {
+			const adapters = registry.list().filter(i => i.type === "adapter").map(i => i.name);
+			return adapters
+				.filter(a => a.startsWith(prefix))
+				.map(a => ({ value: a, label: a }));
+		},
+		handler: async (args: string | undefined, ctx: any) => {
+			if (!history) {
+				ctx.ui.notify("Message history not ready yet.", "warning");
+				return;
+			}
+
+			const parts = (args ?? "").trim().split(/\s+/);
+			const adapter = parts[0] || undefined;
+			const limit = parts[1] ? parseInt(parts[1], 10) : 20;
+
+			const rows = await history.query({ adapter, limit: Math.min(limit, 100) });
+
+			if (rows.length === 0) {
+				ctx.ui.notify("No messages found.", "info");
+				return;
+			}
+
+			// Show in overlay popup
+			showHistoryPopup(ctx, rows);
+		},
+	});
+
+	// ── Shortcut: ctrl+shift+h → channel history ──────────────
+
+	pi.registerShortcut("ctrl+shift+h", {
+		description: "Show channel message history",
+		handler: async (ctx: any) => {
+			if (!history) {
+				ctx.ui.notify("Message history not ready yet.", "warning");
+				return;
+			}
+			const rows = await history.query({ limit: 30 });
+			if (rows.length === 0) {
+				ctx.ui.notify("No messages found.", "info");
+				return;
+			}
+			showHistoryPopup(ctx, rows);
+		},
+	});
+
+	// ── Event bus listener ────────────────────────────────────
 	pi.events.on("command:chat-bridge", async (data: unknown) => {
 		const { args: rawArgs, source } = data as { args: string; source?: string };
 		const cmd = rawArgs?.trim().toLowerCase();

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -4,6 +4,7 @@
 
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelConfig, AdapterDirection, OnIncomingMessage, IncomingMessage } from "./types.ts";
+import type { MessageHistory } from "./history.ts";
 import { createTelegramAdapter } from "./adapters/telegram.ts";
 import { createWebhookAdapter } from "./adapters/webhook.ts";
 import { createSlackAdapter } from "./adapters/slack.ts";
@@ -46,12 +47,20 @@ export class ChannelRegistry {
 
 	private log?: AdapterLogger;
 	private modelRegistry?: ModelRegistry;
+	private history?: MessageHistory;
 
 	/**
 	 * Set the callback for incoming messages (called by the extension entry).
 	 */
 	setOnIncoming(cb: OnIncomingMessage): void {
 		this.onIncoming = cb;
+	}
+
+	/**
+	 * Set message history for logging outgoing messages.
+	 */
+	setHistory(history: MessageHistory): void {
+		this.history = history;
 	}
 
 	/**
@@ -197,6 +206,7 @@ export class ChannelRegistry {
 
 		try {
 			await adapter.send({ ...message, adapter: adapterName, recipient });
+			this.history?.logOutgoing({ ...message, adapter: adapterName, recipient }, adapterName);
 			return { ok: true };
 		} catch (err: any) {
 			return { ok: false, error: err.message };
@@ -244,6 +254,10 @@ export class ChannelRegistry {
 
 		try {
 			await adapter.sendFile(recipient, filePath, fileName, caption);
+			this.history?.logOutgoing(
+				{ adapter: adapterName, recipient, text: `[FILE: ${fileName || filePath}]` },
+				adapterName,
+			);
 			return { ok: true };
 		} catch (err: any) {
 			return { ok: false, error: err.message };

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -14,6 +14,7 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ChannelRegistry } from "./registry.ts";
+import type { MessageHistory, HistoryQuery } from "./history.ts";
 
 interface ChannelToolParams {
 	action: "send" | "send_file" | "list" | "test";
@@ -36,7 +37,13 @@ function formatFileSize(bytes: number): string {
 	return `${(bytes / 1_048_576).toFixed(1)}MB`;
 }
 
-export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry): void {
+function truncateText(text: string | null, maxLen: number = 200): string {
+	if (!text) return "";
+	if (text.length <= maxLen) return text;
+	return text.slice(0, maxLen) + "…";
+}
+
+export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry, history?: MessageHistory): void {
 	pi.registerTool({
 		name: "notify",
 		label: "Channel",
@@ -228,4 +235,102 @@ export function registerChannelTool(pi: ExtensionAPI, registry: ChannelRegistry)
 			};
 		},
 	});
+
+	// ── channel_history tool ───────────────────────────────
+
+	if (history) {
+		pi.registerTool({
+			name: "channel_history",
+			label: "Channel History",
+			description:
+				"Query message history across all configured channel adapters (Telegram, Slack, etc.). " +
+				"Use this to check recent conversations, see what was sent/received, or debug message flow. " +
+				"Actions: query (search messages), stats (message counts).",
+			parameters: Type.Object({
+				action: StringEnum(
+					["query", "stats"] as const,
+					{ description: "What to do: query for recent messages, stats for counts by adapter" },
+				) as any,
+				adapter: Type.Optional(
+					Type.String({ description: "Filter by adapter name (e.g. 'slack', 'telegram')." }),
+				),
+				direction: Type.Optional(
+					StringEnum(
+						["in", "out"] as const,
+						{ description: "Filter by direction: in (received) or out (sent)." },
+					) as any,
+				),
+				limit: Type.Optional(
+					Type.Number({ description: "Max messages to return (default: 20, max: 100)." }),
+				),
+				since: Type.Optional(
+					Type.String({ description: "Only show messages since this ISO datetime (e.g. '2026-05-05T00:00:00')." }),
+				),
+			}) as any,
+
+			async execute(_toolCallId, _params) {
+				const params = _params as {
+					action: "query" | "stats";
+					adapter?: string;
+					direction?: "in" | "out";
+					limit?: number;
+					since?: string;
+				};
+
+				if (params.action === "stats") {
+					const adapters = registry
+						.list()
+						.filter((i) => i.type === "adapter")
+						.map((i) => i.name);
+
+					const lines: string[] = ["**Message counts by adapter:**"];
+					let total = 0;
+					for (const a of adapters) {
+						const count = await history!.count({ adapter: a });
+						lines.push(`- ${a}: ${count}`);
+						total += count;
+					}
+					lines.push(`\n**Total:** ${total}`);
+					return {
+						content: [{ type: "text" as const, text: lines.join("\n") }],
+						details: {},
+					};
+				}
+
+				// query
+				const filters: HistoryQuery = {
+					adapter: params.adapter,
+					direction: params.direction,
+					limit: Math.min(params.limit ?? 20, 100),
+					since: params.since,
+				};
+
+				const rows = await history!.query(filters);
+
+				if (rows.length === 0) {
+					return {
+						content: [{ type: "text" as const, text: "No messages found." }],
+						details: {},
+					};
+				}
+
+				const arrow = (d: string) => (d === "in" ? "←" : "→");
+				const source = (row: typeof rows[0]) =>
+					row.direction === "in" ? (row.sender || "?") : (row.recipient || "?");
+
+				const formatted = rows.map((row) => {
+					const ts = row.created_at?.replace("T", " ").slice(0, 19) ?? "?";
+					return `${ts} ${arrow(row.direction)} [${row.adapter}] ${source(row)}: ${truncateText(row.text, 150)}`;
+				});
+
+				return {
+					content: [{
+						type: "text" as const,
+						text: `**Channel History** (${rows.length} messages):\n${formatted.join("\n")}`,
+					}],
+					details: {},
+				};
+			},
+		});
+	}
 }

--- a/extensions/pi-channels/src/types.ts
+++ b/extensions/pi-channels/src/types.ts
@@ -195,6 +195,12 @@ export interface ChannelConfig {
 	routes?: Record<string, { adapter: string; recipient: string }>;
 	/** Chat bridge configuration. */
 	bridge?: BridgeConfig;
+	/**
+	 * Number of days to retain message history (default: 30).
+	 * Messages older than this are purged on startup and periodically.
+	 * Set to 0 to disable retention (keep forever).
+	 */
+	messageRetentionDays?: number;
 }
 
 // ── Bridge types ────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds persistent message history to pi-channels, logging all incoming/outgoing Slack and Telegram messages to a SQLite table via pi-kysely.

### Changes
- **New:** `MessageHistory` class (`src/history.ts`) — owns `pi-channels__messages` table
- **Schema registration** via `kysely:schema:register` (waits for pi-kysely ready)
- **Fire-and-forget logging** — incoming in `events.ts`, outgoing in `registry.send()/sendFile()`
- **Configurable retention** — `messageRetentionDays` setting (default: 30, 0 = forever)
- **`/channel-history` command** — scrollable TUI overlay popup with ↑↓ navigation
- **`ctrl+shift+h` shortcut** — quick access to history
- **`channel_history` LLM tool** — `query` (filtered by adapter/direction/since/limit) and `stats` actions

### Config
```json
{
  "pi-channels": {
    "messageRetentionDays": 30
  }
}
```

### To test
1. Send messages via Slack/Telegram
2. Press `ctrl+shift+h` or run `/channel-history` in TUI
3. Use `channel_history` tool to query from LLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added persistent message history with configurable retention settings (defaults to 30 days)
* Added `/channel-history` command to query and browse historical messages across all adapters
* Added keyboard shortcut (Ctrl+Shift+H) for quick access to the message history overlay
* Message history now logs all incoming and outgoing messages automatically

<!-- end of auto-generated comment: release notes by coderabbit.ai -->