### PR TITLE
td 1d3233/channel formatting

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -864,25 +864,6 @@ export class PiAgentExecutor implements AgentExecutor {
 			const existing = await this.taskStore.load(taskId);
 			const now = new Date().toISOString();
 
-			// Fire push notification asynchronously (don't block persistence)
-			if (this.hubConfig?.apiKey && this.hubAgentId) {
-				const toState = result.ok ? "completed" : "failed";
-				const fromState = existing?.status?.state as string | null || null;
-				const hubConfig = this.hubConfig;
-				const log = this.log;
-				const agentId = this.hubAgentId;
-				// Save result first, then send push in background
-				setImmediate(() => {
-					sendTaskStateChanged(
-						agentId, taskId, fromState, toState,
-						hubConfig, log,
-						result.ok ? { response: result.response.slice(0, 500) } : undefined,
-					).catch(err => {
-						log("push_notification_failed", { error: err instanceof Error ? err.message : String(err) }, "WARN");
-					});
-				});
-			}
-
 			const statusMessage = {
 				kind: "message" as const,
 				messageId: randomUUID(),
@@ -930,6 +911,22 @@ export class PiAgentExecutor implements AgentExecutor {
 				state: result.ok ? "completed" : "failed",
 				hadExisting: !!existing,
 			});
+
+			// Fire push notification after persistence succeeds (fire-and-forget)
+			if (this.hubConfig?.apiKey && this.hubAgentId) {
+				const toState = result.ok ? "completed" : "failed";
+				const fromState = existing?.status?.state as string | null || null;
+				const hubConfig = this.hubConfig;
+				const log = this.log;
+				const agentId = this.hubAgentId;
+				sendTaskStateChanged(
+					agentId, taskId, fromState, toState,
+					hubConfig, log,
+					result.ok ? { response: result.response.slice(0, 500) } : undefined,
+				).catch(err => {
+					log("push_notification_failed", { error: err instanceof Error ? err.message : String(err) }, "WARN");
+				});
+			}
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
 			this.log("task_result_save_error", { taskId, error: msg, attempt: 1 }, "ERROR");
@@ -954,6 +951,21 @@ export class PiAgentExecutor implements AgentExecutor {
 				};
 				await this.taskStore.save(fallbackTask);
 				this.log("task_result_saved_retry", { taskId, state: result.ok ? "completed" : "failed" });
+
+				// Fire push notification after retry-save succeeds
+				if (this.hubConfig?.apiKey && this.hubAgentId) {
+					const toState = result.ok ? "completed" : "failed";
+					const hubConfig = this.hubConfig;
+					const log = this.log;
+					const agentId = this.hubAgentId;
+					sendTaskStateChanged(
+						agentId, taskId, null, toState,
+						hubConfig, log,
+						result.ok ? { response: result.response.slice(0, 500) } : undefined,
+					).catch(err => {
+						log("push_notification_failed", { error: err instanceof Error ? err.message : String(err) }, "WARN");
+					});
+				}
 			} catch (retryErr: unknown) {
 				const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
 				this.log("task_result_save_error", { taskId, error: retryMsg, attempt: 2 }, "ERROR");

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -864,20 +864,22 @@ export class PiAgentExecutor implements AgentExecutor {
 			const existing = await this.taskStore.load(taskId);
 			const now = new Date().toISOString();
 
-			// Send push notification only when hub is configured AND agent is registered
+			// Fire push notification asynchronously (don't block persistence)
 			if (this.hubConfig?.apiKey && this.hubAgentId) {
 				const toState = result.ok ? "completed" : "failed";
 				const fromState = existing?.status?.state as string | null || null;
-				await sendTaskStateChanged(
-					this.hubAgentId,
-					taskId,
-					fromState,
-					toState,
-					this.hubConfig,
-					this.log,
-					result.ok ? { response: result.response.slice(0, 500) } : undefined,
-				).catch(err => {
-					this.log("push_notification_failed", { error: err instanceof Error ? err.message : String(err) }, "WARN");
+				const hubConfig = this.hubConfig;
+				const log = this.log;
+				const agentId = this.hubAgentId;
+				// Save result first, then send push in background
+				setImmediate(() => {
+					sendTaskStateChanged(
+						agentId, taskId, fromState, toState,
+						hubConfig, log,
+						result.ok ? { response: result.response.slice(0, 500) } : undefined,
+					).catch(err => {
+						log("push_notification_failed", { error: err instanceof Error ? err.message : String(err) }, "WARN");
+					});
 				});
 			}
 

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -1082,20 +1082,23 @@ export async function listenToSSEStream(
 			const errorMsg = error instanceof Error ? error.message : String(error);
 			log("sse_connection_error", { error: errorMsg, attempt: reconnectAttempts }, "ERROR");
 			
-			// Exponential backoff
-			const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), maxReconnectDelay);
-			reconnectAttempts++;
-			
-			log("sse_reconnect_scheduled", { delay, attempt: reconnectAttempts }, "WARN");
-			
-			await new Promise(resolve => setTimeout(resolve, delay));
-			if (!controller.signal.aborted) {
-				// Re-handshake and pass new reader to runReadLoop
+			// Retry loop with exponential backoff
+			while (!controller.signal.aborted) {
+				const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), maxReconnectDelay);
+				reconnectAttempts++;
+
+				log("sse_reconnect_scheduled", { delay, attempt: reconnectAttempts }, "WARN");
+
+				await new Promise(resolve => setTimeout(resolve, delay));
+				if (controller.signal.aborted) return;
+
 				try {
 					const newReader = await performHandshake();
 					void runReadLoop(newReader);
-				} catch {
-					// Handshake failed again — runReadLoop's catch will handle retry
+					return;
+				} catch (handshakeErr) {
+					const hsMsg = handshakeErr instanceof Error ? handshakeErr.message : String(handshakeErr);
+					log("sse_handshake_failed", { error: hsMsg, attempt: reconnectAttempts }, "ERROR");
 				}
 			}
 		}

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -10,7 +10,7 @@
  * that need to call this agent.
  */
 
-import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot, PushEventPayload, PushEventType, AgentSelectionResult, AgentStrategy, ProjectSettings, PipelineStreamEvent, SSEConnection } from "./types.ts";
+import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot, PushEventPayload, PushEventType, AgentSelectionResult, AgentStrategy, ProjectSettings, PipelineStreamEvent } from "./types.ts";
 
 export type PipelineState = "queued" | "planning" | "building" | "reviewing" | "pr_ready" | "blocked" | "approved" | "cancelled";
 export type TaskPriority = "low" | "normal" | "high" | "critical";

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2117,6 +2117,8 @@ export default function (pi: ExtensionAPI) {
 				const result = await registerWithHub(publicUrl, config.hub, log);
 				if (result) {
 					ctx.ui.notify(`Registered with hub: agentId=${result.agentId}, status=${result.status}`, "info");
+					hubAgentId = result.agentId;
+					executor?.setHubAgentId(result.agentId);
 					if (config.apiKey) {
 						await setCredentialOnHub(result.agentId, config.apiKey, config.hub, log);
 						ctx.ui.notify("Credential pushed to hub", "info");

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2167,6 +2167,12 @@ export default function (pi: ExtensionAPI) {
 					ctx.ui.notify(`Registered with hub: agentId=${result.agentId}, status=${result.status}`, "info");
 					hubAgentId = result.agentId;
 					executor?.setHubAgentId(result.agentId);
+
+					// Start telemetry heartbeat and send initial snapshot
+					if (telemetryInterval) clearInterval(telemetryInterval);
+					telemetryInterval = setInterval(() => { sendTelemetry(config).catch(() => {}); }, 30_000);
+					sendTelemetry(config).catch(() => {});
+
 					if (config.apiKey) {
 						await setCredentialOnHub(result.agentId, config.apiKey, config.hub, log);
 						ctx.ui.notify("Credential pushed to hub", "info");

--- a/extensions/pi-channels/src/adapters/slack.ts
+++ b/extensions/pi-channels/src/adapters/slack.ts
@@ -139,6 +139,8 @@ export async function createSlackAdapter(config: AdapterConfig, context: Adapter
 			channel: channelId,
 			text,
 			thread_ts: threadTs,
+			// Enable Slack mrkdwn formatting (bold, italic, code, links, lists)
+			mrkdwn: true,
 			// Unfurl links/media is off by default to keep responses clean
 			unfurl_links: false,
 			unfurl_media: false,

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -737,7 +737,7 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 				return;
 			}
 
-			// Split long messages at newlines
+			// Split long messages at newlines, keeping HTML tags/entities intact
 			let remaining = full;
 			while (remaining.length > 0) {
 				if (remaining.length <= MAX_LENGTH) {
@@ -745,7 +745,7 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 					break;
 				}
 				let splitAt = remaining.lastIndexOf("\n", MAX_LENGTH);
-				if (splitAt < MAX_LENGTH / 2) splitAt = MAX_LENGTH;
+				if (splitAt < MAX_LENGTH / 2) splitAt = safeHtmlSplit(remaining, MAX_LENGTH);
 				await sendTelegram(message.recipient, remaining.slice(0, splitAt));
 				remaining = remaining.slice(splitAt).replace(/^\n/, "");
 			}

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -157,7 +157,8 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 
 	async function sendTelegram(chatId: string, text: string): Promise<void> {
 		const body: Record<string, unknown> = { chat_id: chatId, text };
-		if (parseMode) body.parse_mode = parseMode;
+		// Always use HTML parse_mode — messages are pre-formatted by format.ts
+		body.parse_mode = parseMode || "HTML";
 
 		const res = await fetch(`${apiBase}/sendMessage`, {
 			method: "POST",

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -157,8 +157,8 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 
 	async function sendTelegram(chatId: string, text: string): Promise<void> {
 		const body: Record<string, unknown> = { chat_id: chatId, text };
-		// Always use HTML parse_mode — messages are pre-formatted by format.ts
-		body.parse_mode = parseMode || "HTML";
+		// Messages are pre-formatted by format.ts as Telegram HTML — hardcode HTML
+		body.parse_mode = "HTML";
 
 		const res = await fetch(`${apiBase}/sendMessage`, {
 			method: "POST",

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -714,18 +714,19 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 
 	/** HTML-safe split: finds > or ; boundary to avoid breaking tags/entities. */
 	function safeHtmlSplit(html: string, maxLen: number): number {
-		// Scan from maxLen-1 to avoid returning > maxLen chars
-		for (let i = maxLen - 1; i >= maxLen / 2; i--) {
+		const len = Math.min(maxLen, html.length);
+		// Scan backwards from len-1 for a safe boundary (> closes tag, ; closes entity)
+		for (let i = len - 1; i >= Math.floor(len / 2); i--) {
 			const ch = html[i];
 			if (ch === '>' || ch === ';') {
 				let safe = true;
-				for (let j = i + 1; j < maxLen; j++) {
+				for (let j = i + 1; j < len; j++) {
 					if (html[j] === '<' || html[j] === '&') { safe = false; break; }
 				}
 				if (safe) return i + 1;
 			}
 		}
-		return maxLen;
+		return len;
 	}
 
 	return {
@@ -753,16 +754,45 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 				return;
 			}
 
-			// Split long messages at newlines, keeping HTML tags/entities intact
+			// Split long messages at HTML-safe boundaries, falling back to plain text
+			// when a single HTML block (e.g., <pre>...</pre>) exceeds MAX_LENGTH.
 			let remaining = full;
 			while (remaining.length > 0) {
 				if (remaining.length <= MAX_LENGTH) {
 					await sendTelegram(message.recipient, remaining);
 					break;
 				}
-				let splitAt = remaining.lastIndexOf("\n", MAX_LENGTH);
-				if (splitAt < MAX_LENGTH / 2) splitAt = safeHtmlSplit(remaining, MAX_LENGTH);
-				await sendTelegram(message.recipient, remaining.slice(0, splitAt));
+
+				// Try HTML-aware split first
+				let splitAt = safeHtmlSplit(remaining, MAX_LENGTH);
+
+				// If HTML-safe split is too aggressive, fall back to newline split
+				if (splitAt < MAX_LENGTH / 2) {
+					const newlineAt = remaining.lastIndexOf("\n", MAX_LENGTH);
+					if (newlineAt >= MAX_LENGTH / 2) splitAt = newlineAt;
+				}
+
+				let chunk = remaining.slice(0, splitAt);
+
+				// Check if chunk has unbalanced opening HTML tags (e.g., <pre> without </pre>)
+				const openTagRe = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
+				const closeTagRe = /<\/([a-zA-Z][a-zA-Z0-9]*)>/g;
+				const openTags: string[] = [];
+				let match: RegExpExecArray | null;
+				while ((match = openTagRe.exec(chunk)) !== null) {
+					openTags.push(match[1]);
+				}
+				while ((match = closeTagRe.exec(chunk)) !== null) {
+					const idx = openTags.lastIndexOf(match[1]);
+					if (idx !== -1) openTags.splice(idx, 1);
+				}
+
+				if (openTags.length > 0) {
+					// Chunk has unbalanced tags — escape as plain text to avoid broken HTML
+					chunk = chunk.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+				}
+
+				await sendTelegram(message.recipient, chunk);
 				remaining = remaining.slice(splitAt).replace(/^\n/, "");
 			}
 		},

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -712,21 +712,57 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 
 	// ── Adapter ─────────────────────────────────────────────
 
-	/** HTML-safe split: finds > or ; boundary to avoid breaking tags/entities. */
-	function safeHtmlSplit(html: string, maxLen: number): number {
+	/** Find safe split point that doesn't break inside HTML tags or entities. */
+	function findSafeHtmlSplit(html: string, maxLen: number): number {
 		const len = Math.min(maxLen, html.length);
-		// Scan backwards from len-1 for a safe boundary (> closes tag, ; closes entity)
+
+		// Scan backwards from len-1 for a safe boundary
 		for (let i = len - 1; i >= Math.floor(len / 2); i--) {
 			const ch = html[i];
+
+			// Safe to split after closing tag or entity
 			if (ch === '>' || ch === ';') {
+				// Verify no opening < or & between i and len
 				let safe = true;
 				for (let j = i + 1; j < len; j++) {
 					if (html[j] === '<' || html[j] === '&') { safe = false; break; }
 				}
 				if (safe) return i + 1;
 			}
+
+			// Also safe to split before opening tag (don't cut inside <tag...>)
+			if (ch === '<' || ch === '&') {
+				return i;
+			}
 		}
+
+		// Fallback: return maxLen if no safe boundary found
 		return len;
+	}
+
+	/** Check if HTML has unclosed opening tags (e.g., <pre> without </pre>). */
+	function hasUnclosedHtmlTags(html: string): boolean {
+		const openTagRe = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
+		const closeTagRe = /<\/([a-zA-Z][a-zA-Z0-9]*)>/g;
+		const voidElements = new Set(['br', 'hr', 'img', 'input', 'meta', 'link']);
+
+		const openTags: string[] = [];
+		let match: RegExpExecArray | null;
+
+		while ((match = openTagRe.exec(html)) !== null) {
+			const tagName = match[1].toLowerCase();
+			if (!voidElements.has(tagName)) {
+				openTags.push(tagName);
+			}
+		}
+
+		while ((match = closeTagRe.exec(html)) !== null) {
+			const tagName = match[1].toLowerCase();
+			const idx = openTags.lastIndexOf(tagName);
+			if (idx !== -1) openTags.splice(idx, 1);
+		}
+
+		return openTags.length > 0;
 	}
 
 	return {
@@ -763,31 +799,19 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 					break;
 				}
 
-				// Try HTML-aware split first
-				let splitAt = safeHtmlSplit(remaining, MAX_LENGTH);
+				// Find safe split point that doesn't break HTML tags
+				let splitAt = findSafeHtmlSplit(remaining, MAX_LENGTH);
 
-				// If HTML-safe split is too aggressive, fall back to newline split
+				// If HTML-aware split is too aggressive, fall back to newline split
 				if (splitAt < MAX_LENGTH / 2) {
 					const newlineAt = remaining.lastIndexOf("\n", MAX_LENGTH);
 					if (newlineAt >= MAX_LENGTH / 2) splitAt = newlineAt;
 				}
 
 				let chunk = remaining.slice(0, splitAt);
+				const hasUnclosedTags = hasUnclosedHtmlTags(chunk);
 
-				// Check if chunk has unbalanced opening HTML tags (e.g., <pre> without </pre>)
-				const openTagRe = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
-				const closeTagRe = /<\/([a-zA-Z][a-zA-Z0-9]*)>/g;
-				const openTags: string[] = [];
-				let match: RegExpExecArray | null;
-				while ((match = openTagRe.exec(chunk)) !== null) {
-					openTags.push(match[1]);
-				}
-				while ((match = closeTagRe.exec(chunk)) !== null) {
-					const idx = openTags.lastIndexOf(match[1]);
-					if (idx !== -1) openTags.splice(idx, 1);
-				}
-
-				if (openTags.length > 0) {
+				if (hasUnclosedTags) {
 					// Chunk has unbalanced tags — escape as plain text to avoid broken HTML
 					chunk = chunk.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 				}

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -712,6 +712,21 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 
 	// ── Adapter ─────────────────────────────────────────────
 
+	/** HTML-safe split: finds > or ; boundary to avoid breaking tags/entities. */
+	function safeHtmlSplit(html: string, maxLen: number): number {
+		for (let i = maxLen; i >= maxLen / 2; i--) {
+			const ch = html[i];
+			if (ch === '>' || ch === ';') {
+				let safe = true;
+				for (let j = i + 1; j < maxLen; j++) {
+					if (html[j] === '<' || html[j] === '&') { safe = false; break; }
+				}
+				if (safe) return i + 1;
+			}
+		}
+		return maxLen;
+	}
+
 	return {
 		direction: "bidirectional" as const,
 

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -714,7 +714,8 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 
 	/** HTML-safe split: finds > or ; boundary to avoid breaking tags/entities. */
 	function safeHtmlSplit(html: string, maxLen: number): number {
-		for (let i = maxLen; i >= maxLen / 2; i--) {
+		// Scan from maxLen-1 to avoid returning > maxLen chars
+		for (let i = maxLen - 1; i >= maxLen / 2; i--) {
 			const ch = html[i];
 			if (ch === '>' || ch === ';') {
 				let safe = true;

--- a/extensions/pi-channels/src/adapters/telegram.ts
+++ b/extensions/pi-channels/src/adapters/telegram.ts
@@ -812,8 +812,11 @@ export async function createTelegramAdapter(config: AdapterConfig, context: Adap
 				const hasUnclosedTags = hasUnclosedHtmlTags(chunk);
 
 				if (hasUnclosedTags) {
-					// Chunk has unbalanced tags — escape as plain text to avoid broken HTML
-					chunk = chunk.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+					// Chunk has unbalanced tags — re-escape to plain text to avoid broken HTML.
+					// The chunk is already HTML-escaped from formatForPlatform(), so we need to
+					// unescape first, then re-escape to avoid double-escaping.
+					const unescaped = chunk.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"');
+					chunk = unescaped.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 				}
 
 				await sendTelegram(message.recipient, chunk);

--- a/extensions/pi-channels/src/bridge/bridge.ts
+++ b/extensions/pi-channels/src/bridge/bridge.ts
@@ -21,6 +21,7 @@ import { RpcSessionManager } from "./rpc-runner.ts";
 import { isCommand, handleCommand, routeSlashCommand, type CommandContext, type SlashCommandInfo } from "./commands.ts";
 
 import { startTyping } from "./typing.ts";
+import { formatForPlatform } from "../format.ts";
 
 interface BridgeDeps {
 	/** Available slash commands from pi's registry. Updated on session start. */
@@ -457,7 +458,8 @@ export class ChatBridge {
 	// ── Reply ─────────────────────────────────────────────────
 
 	private sendReply(adapter: string, recipient: string, text: string): void {
-		this.registry.send({ adapter, recipient, text });
+		const formatted = formatForPlatform(text, adapter);
+		this.registry.send({ adapter, recipient, text: formatted.text });
 	}
 }
 

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -44,7 +44,7 @@ export function formatForPlatform(text: string, adapter: string): FormattedMessa
 
 /** Escape HTML special chars for Telegram HTML parse_mode. */
 function escapeTelegram(text: string): string {
-	return escapeTelegram(text);
+	return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 function toTelegramHtml(text: string): string {

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -93,7 +93,9 @@ function toSlackMrkdwn(text: string): string {
 	//   - Links: <url|text> instead of [text](url)
 	//   - Lists use • or 1. 2. 3. (no - auto-formatting)
 	//   - No heading support → bold + newline
-	//   - Bold/italic/code are the same (*, _, `)
+	//   - Bold is the same (*)
+	//   - Italic: *text* → _text_
+	//   - Strikethrough: ~~text~~ → ~text~
 
 	let result = text;
 
@@ -103,8 +105,11 @@ function toSlackMrkdwn(text: string): string {
 	// 2. Headings (# ## ###) → bold text
 	result = result.replace(/^#{1,3}\s+(.+)$/gm, "*$1*");
 
-	// Everything else (bold, italic, code, strikethrough, lists) is already standard
-	// Slack-compatible Markdown and doesn't need transformation.
+	// 3. Italic: *text* → _text_ (Slack uses _ for italic, * for bold)
+	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, "$1_$2_$3");
+
+	// 4. Strikethrough: ~~text~~ → ~text~ (Slack uses single tilde)
+	result = result.replace(/~~([^~]+)~~/g, "~$1~");
 
 	return result;
 }

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -48,40 +48,52 @@ function escapeTelegram(text: string): string {
 }
 
 function toTelegramHtml(text: string): string {
-	// Strategy: escape once up-front, then convert Markdown markers to Telegram HTML tags.
-	// Order matters: fenced code before inline code, links before bold/italic.
+	// Strategy: protect code blocks and links first, then process emphasis.
+	// We use placeholders to preserve protected spans, then restore them.
+	const protectedSpans: string[] = [];
+
+	// 1. Protect fenced code blocks: ```...```
+	text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+		const idx = protectedSpans.length;
+		protectedSpans.push(`<pre>${code.trim()}</pre>`);
+		return `__PROTECTED_${idx}__`;
+	});
+
+	// 2. Protect inline code: `...`
+	text = text.replace(/`([^`]+)`/g, (_, code) => {
+		const idx = protectedSpans.length;
+		protectedSpans.push(`<code>${code}</code>`);
+		return `__PROTECTED_${idx}__`;
+	});
+
+	// 3. Protect links: [text](url)
+	text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
+		const idx = protectedSpans.length;
+		protectedSpans.push(`<a href="${url}">${linkText}</a>`);
+		return `__PROTECTED_${idx}__`;
+	});
+
+	// Now escape HTML and process emphasis on unprotected text only
 	let result = escapeTelegram(text);
 
-	// 1. Fenced code blocks: ```...``` — content is already escaped, wrap in <pre>
-	result = result.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, _lang, code) => {
-		return `<pre>${code.trim()}</pre>`;
+	// 4. Bold: **...**
+	result = result.replace(/\*\*([^*]+)\*\*/g, (_, txt) => `<b>${txt}</b>`);
+
+	// 5. Italic: *text*
+	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, (_, before, txt, after) => {
+		return `${before}<i>${txt}</i>${after}`;
 	});
 
-	// 2. Inline code: `...` — content already escaped, wrap in <code>
-	result = result.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
+	// 6. Strikethrough: ~~...~~
+	result = result.replace(/~~([^~]+)~~/g, (_, txt) => `<s>${txt}</s>`);
 
-	// 3. Links: [text](url) — href is raw URL, text already escaped
-	result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
-		return `<a href="${url}">${text}</a>`;
-	});
+	// 7. Headings (# ## ###) → bold
+	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, txt) => `<b>${txt}</b>`);
 
-	// 4. Bold: **...** — content already escaped
-	result = result.replace(/\*\*([^*]+)\*\*/g, (_, text) => `<b>${text}</b>`);
-
-	// 5. Italic: *text* (not preceded by *, not followed by *) — content already escaped
-	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, (_, before, text, after) => {
-		return `${before}<i>${text}</i>${after}`;
-	});
-
-	// 6. Strikethrough: ~~...~~ — content already escaped
-	result = result.replace(/~~([^~]+)~~/g, (_, text) => `<s>${text}</s>`);
-
-	// 7. Headings (# ## ###) → bold, content already escaped
-	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, text) => `<b>${text}</b>`);
-
-	// Note: all text was escaped before replacements, so bare <, >, & are already encoded.
-	// The Markdown markers (```, *, ~~, #, etc.) were also escaped but are un-escaped
-	// by the replacements above, producing valid HTML.
+	// Restore protected spans
+	for (let i = 0; i < protectedSpans.length; i++) {
+		result = result.replace(`__PROTECTED_${i}__`, protectedSpans[i]);
+	}
 
 	return result;
 }
@@ -89,28 +101,45 @@ function toTelegramHtml(text: string): string {
 // ── Slack mrkdwn formatter ──────────────────────────────────────
 
 function toSlackMrkdwn(text: string): string {
-	// Slack mrkdwn is very similar to basic Markdown.
-	// Key differences:
-	//   - Links: <url|text> instead of [text](url)
-	//   - Lists use • or 1. 2. 3. (no - auto-formatting)
-	//   - No heading support → bold + newline
-	//   - Bold is the same (*)
-	//   - Italic: *text* → _text_
-	//   - Strikethrough: ~~text~~ → ~text~
+	// Protect code blocks and links first to avoid corrupting their contents
+	const protectedSpans: string[] = [];
+
+	// 1. Protect fenced code blocks
+	text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+		const idx = protectedSpans.length;
+		protectedSpans.push(`\`\`${lang}\n${code}\`\``);
+		return `__PROTECTED_${idx}__`;
+	});
+
+	// 2. Protect inline code
+	text = text.replace(/`([^`]+)`/g, (_, code) => {
+		const idx = protectedSpans.length;
+		protectedSpans.push(`\`${code}\``);
+		return `__PROTECTED_${idx}__`;
+	});
+
+	// 3. Protect links
+	text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
+		const idx = protectedSpans.length;
+		protectedSpans.push(`<${url}|${linkText}>`);
+		return `__PROTECTED_${idx}__`;
+	});
 
 	let result = text;
 
-	// 1. Links: [text](url) → <url|text>
-	result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
-
-	// 2. Headings (# ## ###) → bold text
+	// 4. Headings → bold
 	result = result.replace(/^#{1,3}\s+(.+)$/gm, "*$1*");
 
-	// 3. Italic: *text* → _text_ (Slack uses _ for italic, * for bold)
+	// 5. Italic: *text* → _text_
 	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, "$1_$2_$3");
 
-	// 4. Strikethrough: ~~text~~ → ~text~ (Slack uses single tilde)
+	// 6. Strikethrough: ~~text~~ → ~text~
 	result = result.replace(/~~([^~]+)~~/g, "~$1~");
+
+	// Restore protected spans
+	for (let i = 0; i < protectedSpans.length; i++) {
+		result = result.replace(`__PROTECTED_${i}__`, protectedSpans[i]);
+	}
 
 	return result;
 }

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -1,0 +1,108 @@
+/**
+ * pi-channels — Platform-specific message formatting.
+ *
+ * Converts Markdown-like text to each platform's native format:
+ *   - Telegram: HTML (parse_mode: HTML)
+ *   - Slack: mrkdwn (with mrkdwn: true in postMessage)
+ *   - Webhook/other: pass through as-is
+ *
+ * Supported Markdown constructs:
+ *   **bold**  → <b>bold</b> (Telegram) / *bold* (Slack)
+ *   *italic*  → <i>italic</i> (Telegram) / _italic_ (Slack)
+ *   `code`    → <code>code</code> (Telegram) / `code` (Slack)
+ *   ```block``` → <pre>block</pre> (Telegram) / ```block``` (Slack)
+ *   [text](url) → <a href="url">text</a> (Telegram) / <url|text> (Slack)
+ *   ~~strike~~ → <s>strike</s> (Telegram) / ~strike~ (Slack)
+ *
+ * Headings (#, ##, ###) → Slack: *bold text* | Telegram: <b>text</b>
+ * Unordered lists (- item) → kept as-is (both platforms support them natively)
+ */
+
+export interface FormattedMessage {
+	/** Formatted text for the target platform. */
+	text: string;
+	/** Parser mode for Telegram (set parse_mode to this value). */
+	telegramParseMode?: string;
+}
+
+/**
+ * Format a message for a specific adapter platform.
+ * Returns the formatted text and any platform-specific hints.
+ */
+export function formatForPlatform(text: string, adapter: string): FormattedMessage {
+	switch (adapter) {
+		case "telegram":
+			return { text: toTelegramHtml(text), telegramParseMode: "HTML" };
+		case "slack":
+			return { text: toSlackMrkdwn(text) };
+		default:
+			return { text };
+	}
+}
+
+// ── Telegram HTML formatter ─────────────────────────────────────
+
+const TELEGRAM_ESCAPE = /[<>&]/g;
+const telegramEscapeMap: Record<string, string> = { "<": "&lt;", ">": "&gt;", "&": "&amp;" };
+
+function escapeTelegram(text: string): string {
+	return text.replace(TELEGRAM_ESCAPE, (ch) => telegramEscapeMap[ch]);
+}
+
+function toTelegramHtml(text: string): string {
+	// Order matters: fenced code before inline code, links before bold/italic
+	let result = text;
+
+	// 1. Fenced code blocks: ```...```
+	result = result.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, _lang, code) => {
+		return `<pre>${escapeTelegram(code.trim())}</pre>`;
+	});
+
+	// 2. Inline code: `...`
+	result = result.replace(/`([^`]+)`/g, (_, code) => `<code>${escapeTelegram(code)}</code>`);
+
+	// 3. Links: [text](url)
+	result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
+		return `<a href="${escapeTelegram(url)}">${escapeTelegram(text)}</a>`;
+	});
+
+	// 4. Bold: **...**
+	result = result.replace(/\*\*([^*]+)\*\*/g, (_, text) => `<b>${escapeTelegram(text)}</b>`);
+
+	// 5. Italic: *text* (not preceded by *, to avoid matching **)
+	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, (_, before, text, after) => {
+		return `${before}<i>${escapeTelegram(text)}</i>${after}`;
+	});
+
+	// 6. Strikethrough: ~~...~~
+	result = result.replace(/~~([^~]+)~~/g, (_, text) => `<s>${escapeTelegram(text)}</s>`);
+
+	// 7. Headings (# ## ###) → bold
+	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, text) => `<b>${text}</b>`);
+
+	return result;
+}
+
+// ── Slack mrkdwn formatter ──────────────────────────────────────
+
+function toSlackMrkdwn(text: string): string {
+	// Slack mrkdwn is very similar to basic Markdown.
+	// Key differences:
+	//   - Links: <url|text> instead of [text](url)
+	//   - Lists use • or 1. 2. 3. (no - auto-formatting)
+	//   - No heading support → bold + newline
+	//   - Bold/italic/code are the same (*, _, `)
+
+	let result = text;
+
+	// 1. Links: [text](url) → <url|text>
+	result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
+
+	// 2. Headings (# ## ###) → bold text
+	result = result.replace(/^#{1,3}\s+(.+)$/gm, "*$1*");
+
+	// Everything else (bold, italic, code, strikethrough, lists) is already standard
+	// Slack-compatible Markdown and doesn't need transformation.
+
+	return result;
+}

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -131,10 +131,13 @@ function toSlackMrkdwn(text: string): string {
 
 	let result = text;
 
-	// 4. Italic: *text* → _text_ (do this BEFORE headings to avoid converting *Heading*)
+	// 4. Bold: **text** → *text* (do this BEFORE italic to avoid conflicts)
+	result = result.replace(/\*\*([^*]+)\*\*/g, "*$1*");
+
+	// 5. Italic: *text* → _text_ (do this BEFORE headings to avoid converting *Heading*)
 	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, "$1_$2_$3");
 
-	// 5. Headings → *bold* (won't match italic anymore since * are now _)
+	// 6. Headings → *bold* (won't match italic anymore since * are now _)
 	result = result.replace(/^#{1,3}\s+(.+)$/gm, "*$1*");
 
 	// 6. Strikethrough: ~~text~~ → ~text~

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -52,29 +52,32 @@ function toTelegramHtml(text: string): string {
 	// We use placeholders to preserve protected spans, then restore them.
 	const protectedSpans: string[] = [];
 
-	// 1. Protect fenced code blocks: ```...```
+	// 1. Protect fenced code blocks: ```...``` — escape content first
 	text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
 		const idx = protectedSpans.length;
-		protectedSpans.push(`<pre>${code.trim()}</pre>`);
+		const escapedCode = code.trim().replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		protectedSpans.push(`<pre>${escapedCode}</pre>`);
 		return `__PROTECTED_${idx}__`;
 	});
 
-	// 2. Protect inline code: `...`
+	// 2. Protect inline code: `...` — escape content first
 	text = text.replace(/`([^`]+)`/g, (_, code) => {
 		const idx = protectedSpans.length;
-		protectedSpans.push(`<code>${code}</code>`);
+		const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		protectedSpans.push(`<code>${escapedCode}</code>`);
 		return `__PROTECTED_${idx}__`;
 	});
 
-	// 3. Protect links: [text](url)
+	// 3. Protect links: [text](url) — escape link text, leave URL raw
 	text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
 		const idx = protectedSpans.length;
-		protectedSpans.push(`<a href="${url}">${linkText}</a>`);
+		const escapedText = linkText.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		protectedSpans.push(`<a href="${url}">${escapedText}</a>`);
 		return `__PROTECTED_${idx}__`;
 	});
 
-	// Now escape HTML and process emphasis on unprotected text only
-	let result = escapeTelegram(text);
+	// Now escape remaining text and process emphasis
+	let result = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
 	// 4. Bold: **...**
 	result = result.replace(/\*\*([^*]+)\*\*/g, (_, txt) => `<b>${txt}</b>`);
@@ -104,10 +107,11 @@ function toSlackMrkdwn(text: string): string {
 	// Protect code blocks and links first to avoid corrupting their contents
 	const protectedSpans: string[] = [];
 
-	// 1. Protect fenced code blocks
+	// 1. Protect fenced code blocks — use triple backticks for Slack
 	text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
 		const idx = protectedSpans.length;
-		protectedSpans.push(`\`\`${lang}\n${code}\`\``);
+		const langPart = lang ? lang : "";
+		protectedSpans.push(`\`\`\`${langPart}\n${code}\`\`\``);
 		return `__PROTECTED_${idx}__`;
 	});
 
@@ -127,11 +131,11 @@ function toSlackMrkdwn(text: string): string {
 
 	let result = text;
 
-	// 4. Headings → bold
-	result = result.replace(/^#{1,3}\s+(.+)$/gm, "*$1*");
-
-	// 5. Italic: *text* → _text_
+	// 4. Italic: *text* → _text_ (do this BEFORE headings to avoid converting *Heading*)
 	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, "$1_$2_$3");
+
+	// 5. Headings → *bold* (won't match italic anymore since * are now _)
+	result = result.replace(/^#{1,3}\s+(.+)$/gm, "*$1*");
 
 	// 6. Strikethrough: ~~text~~ → ~text~
 	result = result.replace(/~~([^~]+)~~/g, "~$1~");

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -68,11 +68,12 @@ function toTelegramHtml(text: string): string {
 		return `__PROTECTED_${idx}__`;
 	});
 
-	// 3. Protect links: [text](url) — escape link text, leave URL raw
+	// 3. Protect links: [text](url) — escape both link text and URL for HTML safety
 	text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
 		const idx = protectedSpans.length;
 		const escapedText = escapeTelegram(linkText);
-		protectedSpans.push(`<a href="${url}">${escapedText}</a>`);
+		const escapedUrl = url.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+		protectedSpans.push(`<a href="${escapedUrl}">${escapedText}</a>`);
 		return `__PROTECTED_${idx}__`;
 	});
 

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -42,43 +42,45 @@ export function formatForPlatform(text: string, adapter: string): FormattedMessa
 
 // ── Telegram HTML formatter ─────────────────────────────────────
 
-const TELEGRAM_ESCAPE = /[<>&]/g;
-const telegramEscapeMap: Record<string, string> = { "<": "&lt;", ">": "&gt;", "&": "&amp;" };
-
+/** Escape HTML special chars for Telegram HTML parse_mode. */
 function escapeTelegram(text: string): string {
-	return text.replace(TELEGRAM_ESCAPE, (ch) => telegramEscapeMap[ch]);
+	return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 function toTelegramHtml(text: string): string {
-	// Order matters: fenced code before inline code, links before bold/italic
+	// Strategy: replace Markdown constructs with HTML tags, escaping text portions.
+	// Order matters: fenced code before inline code, links before bold/italic.
 	let result = text;
 
-	// 1. Fenced code blocks: ```...```
+	// 1. Fenced code blocks: ```...``` — escape content, wrap in <pre>
 	result = result.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, _lang, code) => {
 		return `<pre>${escapeTelegram(code.trim())}</pre>`;
 	});
 
-	// 2. Inline code: `...`
+	// 2. Inline code: `...` — escape content, wrap in <code>
 	result = result.replace(/`([^`]+)`/g, (_, code) => `<code>${escapeTelegram(code)}</code>`);
 
-	// 3. Links: [text](url)
+	// 3. Links: [text](url) — escape both text and url
 	result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
 		return `<a href="${escapeTelegram(url)}">${escapeTelegram(text)}</a>`;
 	});
 
-	// 4. Bold: **...**
+	// 4. Bold: **...** — escape inner text
 	result = result.replace(/\*\*([^*]+)\*\*/g, (_, text) => `<b>${escapeTelegram(text)}</b>`);
 
-	// 5. Italic: *text* (not preceded by *, to avoid matching **)
+	// 5. Italic: *text* (not preceded by *, not followed by *) — escape inner text
 	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, (_, before, text, after) => {
 		return `${before}<i>${escapeTelegram(text)}</i>${after}`;
 	});
 
-	// 6. Strikethrough: ~~...~~
+	// 6. Strikethrough: ~~...~~ — escape inner text
 	result = result.replace(/~~([^~]+)~~/g, (_, text) => `<s>${escapeTelegram(text)}</s>`);
 
-	// 7. Headings (# ## ###) → bold
-	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, text) => `<b>${text}</b>`);
+	// 7. Headings (# ## ###) → bold, escaping the heading text
+	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, text) => `<b>${escapeTelegram(text)}</b>`);
+
+	// 8. Escape any remaining bare HTML special chars not already inside tags
+	result = result.replace(/(>)([^<]+)(<)/g, (_, gt, text_part, lt) => `${gt}${escapeTelegram(text_part)}${lt}`);
 
 	return result;
 }

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -48,39 +48,40 @@ function escapeTelegram(text: string): string {
 }
 
 function toTelegramHtml(text: string): string {
-	// Strategy: replace Markdown constructs with HTML tags, escaping text portions.
+	// Strategy: escape once up-front, then convert Markdown markers to Telegram HTML tags.
 	// Order matters: fenced code before inline code, links before bold/italic.
-	let result = text;
+	let result = escapeTelegram(text);
 
-	// 1. Fenced code blocks: ```...``` — escape content, wrap in <pre>
+	// 1. Fenced code blocks: ```...``` — content is already escaped, wrap in <pre>
 	result = result.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, _lang, code) => {
-		return `<pre>${escapeTelegram(code.trim())}</pre>`;
+		return `<pre>${code.trim()}</pre>`;
 	});
 
-	// 2. Inline code: `...` — escape content, wrap in <code>
-	result = result.replace(/`([^`]+)`/g, (_, code) => `<code>${escapeTelegram(code)}</code>`);
+	// 2. Inline code: `...` — content already escaped, wrap in <code>
+	result = result.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
 
-	// 3. Links: [text](url) — escape both text and url
+	// 3. Links: [text](url) — href is raw URL, text already escaped
 	result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
-		return `<a href="${escapeTelegram(url)}">${escapeTelegram(text)}</a>`;
+		return `<a href="${url}">${text}</a>`;
 	});
 
-	// 4. Bold: **...** — escape inner text
-	result = result.replace(/\*\*([^*]+)\*\*/g, (_, text) => `<b>${escapeTelegram(text)}</b>`);
+	// 4. Bold: **...** — content already escaped
+	result = result.replace(/\*\*([^*]+)\*\*/g, (_, text) => `<b>${text}</b>`);
 
-	// 5. Italic: *text* (not preceded by *, not followed by *) — escape inner text
+	// 5. Italic: *text* (not preceded by *, not followed by *) — content already escaped
 	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, (_, before, text, after) => {
-		return `${before}<i>${escapeTelegram(text)}</i>${after}`;
+		return `${before}<i>${text}</i>${after}`;
 	});
 
-	// 6. Strikethrough: ~~...~~ — escape inner text
-	result = result.replace(/~~([^~]+)~~/g, (_, text) => `<s>${escapeTelegram(text)}</s>`);
+	// 6. Strikethrough: ~~...~~ — content already escaped
+	result = result.replace(/~~([^~]+)~~/g, (_, text) => `<s>${text}</s>`);
 
-	// 7. Headings (# ## ###) → bold, escaping the heading text
-	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, text) => `<b>${escapeTelegram(text)}</b>`);
+	// 7. Headings (# ## ###) → bold, content already escaped
+	result = result.replace(/^#{1,3}\s+(.+)$/gm, (_, text) => `<b>${text}</b>`);
 
-	// 8. Escape any remaining bare HTML special chars not already inside tags
-	result = result.replace(/(>)([^<]+)(<)/g, (_, gt, text_part, lt) => `${gt}${escapeTelegram(text_part)}${lt}`);
+	// Note: all text was escaped before replacements, so bare <, >, & are already encoded.
+	// The Markdown markers (```, *, ~~, #, etc.) were also escaped but are un-escaped
+	// by the replacements above, producing valid HTML.
 
 	return result;
 }

--- a/extensions/pi-channels/src/format.ts
+++ b/extensions/pi-channels/src/format.ts
@@ -44,7 +44,7 @@ export function formatForPlatform(text: string, adapter: string): FormattedMessa
 
 /** Escape HTML special chars for Telegram HTML parse_mode. */
 function escapeTelegram(text: string): string {
-	return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+	return escapeTelegram(text);
 }
 
 function toTelegramHtml(text: string): string {
@@ -55,7 +55,7 @@ function toTelegramHtml(text: string): string {
 	// 1. Protect fenced code blocks: ```...``` — escape content first
 	text = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
 		const idx = protectedSpans.length;
-		const escapedCode = code.trim().replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		const escapedCode = escapeTelegram(code.trim());
 		protectedSpans.push(`<pre>${escapedCode}</pre>`);
 		return `__PROTECTED_${idx}__`;
 	});
@@ -63,7 +63,7 @@ function toTelegramHtml(text: string): string {
 	// 2. Protect inline code: `...` — escape content first
 	text = text.replace(/`([^`]+)`/g, (_, code) => {
 		const idx = protectedSpans.length;
-		const escapedCode = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		const escapedCode = escapeTelegram(code);
 		protectedSpans.push(`<code>${escapedCode}</code>`);
 		return `__PROTECTED_${idx}__`;
 	});
@@ -71,7 +71,7 @@ function toTelegramHtml(text: string): string {
 	// 3. Protect links: [text](url) — escape link text, leave URL raw
 	text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
 		const idx = protectedSpans.length;
-		const escapedText = linkText.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+		const escapedText = escapeTelegram(linkText);
 		protectedSpans.push(`<a href="${url}">${escapedText}</a>`);
 		return `__PROTECTED_${idx}__`;
 	});
@@ -95,7 +95,7 @@ function toTelegramHtml(text: string): string {
 
 	// Restore protected spans
 	for (let i = 0; i < protectedSpans.length; i++) {
-		result = result.replace(`__PROTECTED_${i}__`, protectedSpans[i]);
+		result = result.replace(new RegExp(`__PROTECTED_${i}__`, 'g'), () => protectedSpans[i]);
 	}
 
 	return result;
@@ -131,8 +131,8 @@ function toSlackMrkdwn(text: string): string {
 
 	let result = text;
 
-	// 4. Bold: **text** → *text* (do this BEFORE italic to avoid conflicts)
-	result = result.replace(/\*\*([^*]+)\*\*/g, "*$1*");
+	// 4. Bold: **text** → *_text_* (use underscore to avoid italic pattern)
+	result = result.replace(/\*\*([^*]+)\*\*/g, "_*$1*_");
 
 	// 5. Italic: *text* → _text_ (do this BEFORE headings to avoid converting *Heading*)
 	result = result.replace(/(^|[^*])\*([^*]+)\*([^*]|$)/g, "$1_$2_$3");


### PR DESCRIPTION
- **feat(a2a): add push notification support for real-time telemetry**
- **fix(pi-a2a): address CodeRabbit review feedback for PR #166**
- **docs(skills): fix pr-fix.md markdownlint + align conflicting guidance**
- **fix(pi-a2a): resolve merge conflicts properly - push types + orchestrator/SSE**
- **fix(pi-a2a): skip push when hubAgentId unknown; remove duplicate types**
- **chore: remove unrelated files from PR (agents, channels, web-dashboard, memory)**
- **Add canonical extensions list with descriptions, install commands, and npm publish dates**
- **Simplify extensions doc — they all ship with pi, no install column needed. Published date is what matters.**
- **Add npm install column to extensions doc**
- **feat(pi-channels): platform-specific message formatting for Slack and Telegram**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can register agent IDs and use hub push notifications (register endpoints, send task state, progress, errors, and heartbeats); background pushes start after registration with an initial heartbeat.

* **Improvements**
  * Outgoing messages are formatted per platform (Slack mrkdwn enabled; Telegram uses HTML). Bridge now formats replies per adapter.
  * Telegram message splitting and HTML handling improved to prevent malformed output; safer chunking and tag balancing.

* **Bug Fixes**
  * Pushes are dispatched asynchronously with retries so delivery failures no longer block task persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->