### PR TITLE
feat(pi-a2a): dynamic port discovery with configurable range

### DIFF
--- a/extensions/pi-a2a/src/config.ts
+++ b/extensions/pi-a2a/src/config.ts
@@ -64,6 +64,15 @@ export function loadConfig(cwd: string): ConfigResult {
 			merged.port = port;
 		}
 	}
+	if (merged.portRange !== undefined) {
+		const range = merged.portRange as [number, number];
+		if (!Array.isArray(range) || range.length !== 2 ||
+				!Number.isInteger(range[0]) || !Number.isInteger(range[1]) ||
+				range[0] <= 0 || range[1] > 65535 || range[0] > range[1]) {
+			warnings.push(`Invalid portRange, ignoring`);
+			delete merged.portRange;
+		}
+	}
 	if (merged.bind !== undefined && typeof merged.bind !== "string") {
 		warnings.push(`Invalid bind address "${merged.bind}", falling back to default ("127.0.0.1")`);
 		delete merged.bind;

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -10,7 +10,7 @@
  * that need to call this agent.
  */
 
-import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot, PushEventPayload, PushEventType, AgentSelectionResult, AgentStrategy, ProjectSettings, PipelineStreamEvent, SSEConnection } from "./types.ts";
+import type { HubConfig, RemoteAgentSummary, RemoteAgentDetail, TelemetrySnapshot, PushEventPayload, PushEventType, AgentSelectionResult, AgentStrategy, ProjectSettings, PipelineStreamEvent, } from "./types.ts";
 
 export type PipelineState = "queued" | "planning" | "building" | "reviewing" | "pr_ready" | "blocked" | "approved" | "cancelled";
 export type TaskPriority = "low" | "normal" | "high" | "critical";

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -162,6 +162,28 @@ export async function registerWithHub(
 	return null;
 }
 
+/** Deregister an agent instance from the hub (e.g., on session shutdown). */
+export async function deregisterFromHub(
+	agentId: string,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<boolean> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpc(
+		rpcUrl,
+		"agents.deregister",
+		{ agentId },
+		hubConfig.apiKey,
+		log,
+		"hub_deregister",
+	);
+	if (result) {
+		log("hub_deregister_success", { agentId });
+		return true;
+	}
+	return false;
+}
+
 /**
  * Find an agent on the hub by its URL.
  *

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -138,6 +138,8 @@ export default function (pi: ExtensionAPI) {
 	let pushNotificationStore: SQLitePushNotificationStore | null = null;
 	/** Agent's canonical public URL (set on session_start, used for loop metadata). */
 	let agentPublicUrl: string = "http://localhost:3100";
+	/** Resolved port (fixed or from dynamic discovery). */
+	let agentPort: number = DEFAULT_PORT;
 	/** Configured max hops (set on session_start, used for seeding outbound metadata). */
 	let configuredMaxHops: number = DEFAULT_MAX_HOPS;
 	/** Rate limiter for outbound response injection — 10 triggers per 60s window. */
@@ -546,6 +548,7 @@ export default function (pi: ExtensionAPI) {
 			clearInterval(longRunningTaskPollerInterval);
 			longRunningTaskPollerInterval = null;
 		}
+		const oldHubAgentId = hubAgentId;
 		hubAgentId = null;
 		staticRegistry = null;
 		// Clear active A2A task context BEFORE aborting executor to prevent
@@ -570,22 +573,27 @@ export default function (pi: ExtensionAPI) {
 
 		const { config, warnings } = loadConfig(cwd);
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
-		let port = config.port ?? DEFAULT_PORT;
+		agentPort = config.port ?? DEFAULT_PORT;
 		// If portRange is set, find a free port in the range
 		if (config.portRange) {
 			const [start, end] = config.portRange;
 			const free = await findFreePort(start, end);
 			if (free !== null) {
-				port = free;
-				log("dynamic_port_assigned", { port, range: config.portRange });
+				agentPort = free;
+				log("dynamic_port_assigned", { port: free, range: config.portRange });
 			} else {
-				log("dynamic_port_range_exhausted", { range: config.portRange, fallback: port }, "WARN");
+				log("dynamic_port_range_exhausted", { range: config.portRange, fallback: agentPort }, "WARN");
 			}
 		}
-		const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
+		const publicUrl = config.publicUrl ?? `http://localhost:${agentPort}`;
 		agentPublicUrl = publicUrl;
 		configuredMaxHops = config.maxHops ?? DEFAULT_MAX_HOPS;
 		const agentCard = buildAgentCard(config, publicUrl);
+
+		// Deregister previous instance from hub (before re-registering)
+		if (oldHubAgentId && config.hub?.apiKey) {
+			deregisterFromHub(oldHubAgentId, config.hub, log).catch(() => {});
+		}
 
 		// Initialize persistent task store (must be created before executor)
 		const dbPath = join(getAgentDir(), "db", "a2a.db");
@@ -769,8 +777,25 @@ export default function (pi: ExtensionAPI) {
 		return;
 		}
 		try {
-			await startServer({ port, bind, apiKey: config.apiKey, agentCard, rpcHandler, log });
-			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${port}`, "info");
+			// Try to start server, retrying next port on EADDRINUSE
+			while (true) {
+				try {
+					await startServer({ port: agentPort, bind, apiKey: config.apiKey, agentCard, rpcHandler, log });
+					break;
+				} catch (e: unknown) {
+					const code = (e as NodeJS.ErrnoException).code;
+					if (code === "EADDRINUSE" && config.portRange) {
+						const [start, end] = config.portRange;
+						if (agentPort < end) {
+							agentPort++;
+							log("server_port_retry", { port: agentPort, reason: "EADDRINUSE" }, "WARN");
+							continue;
+						}
+					}
+					throw e;
+				}
+			}
+			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${agentPort}`, "info");
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
 			// Clean up resources allocated before server start
@@ -2070,8 +2095,8 @@ export default function (pi: ExtensionAPI) {
 		handler: async (args, ctx) => {
 			const action = args.trim();
 			const { config } = loadConfig(cwd);
-			const port = config.port ?? DEFAULT_PORT;
-			const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
+			const port = agentPort;
+			const publicUrl = config.publicUrl ?? `http://localhost:${agentPort}`;
 
 			if (action === "status") {
 				if (isRunning()) {
@@ -2082,7 +2107,7 @@ export default function (pi: ExtensionAPI) {
 						? ` | Processing: 1 task${queued > 0 ? ` + ${queued} queued` : ""}`
 						: "";
 					let statusMsg =
-						`A2A server running on port ${port}\n` +
+						`A2A server running on port ${agentPort}\n` +
 						`Agent Card: ${publicUrl}/.well-known/agent-card.json\n` +
 						`Protocol: A2A v0.3.0 | Mode: inline (main process)${busy}\n` +
 						`Skills: ${skillCount} | Streaming: ✓ | Push Notifications: ✓\n` +

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -55,6 +55,7 @@ import { sendA2AMessage, getRemoteTask, type SenderIdentity } from "./client.ts"
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
 import { seedLoopMetadata, DEFAULT_MAX_HOPS } from "./supervisor.ts";
+import { findFreePort } from "./port-finder.ts";
 import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot, PushEventType, PipelineStreamEvent, LongRunningTasksConfig } from "./types.ts";
 import { LongRunningTaskStore, type LongRunningTask, type ResumeRequest } from "./long-running-task-store.ts";
 
@@ -569,7 +570,18 @@ export default function (pi: ExtensionAPI) {
 
 		const { config, warnings } = loadConfig(cwd);
 		for (const w of warnings) log("config_warning", { message: w }, "WARN");
-		const port = config.port ?? DEFAULT_PORT;
+		let port = config.port ?? DEFAULT_PORT;
+		// If portRange is set, find a free port in the range
+		if (config.portRange) {
+			const [start, end] = config.portRange;
+			const free = await findFreePort(start, end);
+			if (free !== null) {
+				port = free;
+				log("dynamic_port_assigned", { port, range: config.portRange });
+			} else {
+				log("dynamic_port_range_exhausted", { range: config.portRange, fallback: port }, "WARN");
+			}
+		}
 		const publicUrl = config.publicUrl ?? `http://localhost:${port}`;
 		agentPublicUrl = publicUrl;
 		configuredMaxHops = config.maxHops ?? DEFAULT_MAX_HOPS;

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -796,6 +796,10 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${agentPort}`, "info");
+			// Rebuild publicUrl/agentCard with final port (may have changed via EADDRINUSE retry)
+			const publicUrl = config.publicUrl ?? `http://localhost:${agentPort}`;
+			agentPublicUrl = publicUrl;
+			updateAgentCard(buildAgentCard(config, publicUrl));
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
 			// Clean up resources allocated before server start

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -50,7 +50,7 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, registerPushEndpoint, sendPushEvent, sendTaskStateChanged, sendTaskProgress, sendTaskError, sendHeartbeat, selectAgent, listStrategies, getProject, listProjects, createProject, updateProject, connectToPipelineStream, listenToSSEStream, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
+import { registerWithHub, deregisterFromHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, registerPushEndpoint, sendPushEvent, sendTaskStateChanged, sendTaskProgress, sendTaskError, sendHeartbeat, selectAgent, listStrategies, getProject, listProjects, createProject, updateProject, connectToPipelineStream, listenToSSEStream, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
 import { sendA2AMessage, getRemoteTask, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger } from "./logger.ts";
@@ -908,6 +908,13 @@ export default function (pi: ExtensionAPI) {
 					config.hub,
 					log,
 				).catch(() => {});
+			}
+		}
+		// Deregister this instance from the hub
+		if (hubAgentId) {
+			const { config } = loadConfig(cwd);
+			if (config.hub?.apiKey) {
+				deregisterFromHub(hubAgentId, config.hub, log).catch(() => {});
 			}
 		}
 		hubAgentId = null;

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -833,7 +833,7 @@ export default function (pi: ExtensionAPI) {
 
 		// Optional: register with A2A Hub
 		if (config.hub && config.hub.apiKey && (config.hub.autoRegister !== false)) {
-			const result = await registerWithHub(publicUrl, config.hub, log);
+			const result = await registerWithHub(agentPublicUrl, config.hub, log);
 			if (result) {
 				hubAgentId = result.agentId;
 				executor?.setHubAgentId(result.agentId);
@@ -2162,7 +2162,7 @@ export default function (pi: ExtensionAPI) {
 					return;
 				}
 
-				const result = await registerWithHub(publicUrl, config.hub, log);
+				const result = await registerWithHub(agentPublicUrl, config.hub, log);
 				if (result) {
 					ctx.ui.notify(`Registered with hub: agentId=${result.agentId}, status=${result.status}`, "info");
 					if (config.apiKey) {
@@ -2187,7 +2187,7 @@ export default function (pi: ExtensionAPI) {
 
 				// We need the agentId. Use registerWithHub which handles conflict
 				// (returns existing agentId if already registered).
-				const reg = await registerWithHub(publicUrl, config.hub, log);
+				const reg = await registerWithHub(agentPublicUrl, config.hub, log);
 				if (!reg) {
 					ctx.ui.notify("Could not determine agentId — registration failed", "warning");
 					return;

--- a/extensions/pi-a2a/src/port-finder.ts
+++ b/extensions/pi-a2a/src/port-finder.ts
@@ -1,0 +1,30 @@
+import { createServer } from "node:net";
+
+/**
+ * Find a free port in the given range (inclusive).
+ * Returns the first available port, or null if none found.
+ */
+export function findFreePort(rangeStart: number, rangeEnd: number): Promise<number | null> {
+	return new Promise((resolve) => {
+		if (rangeStart > rangeEnd) {
+			resolve(null);
+			return;
+		}
+		tryNext(rangeStart);
+		
+		function tryNext(port: number): void {
+			if (port > rangeEnd) {
+				resolve(null);
+				return;
+			}
+			const server = createServer();
+			server.once("error", () => {
+				tryNext(port + 1);
+			});
+			server.once("listening", () => {
+				server.close(() => resolve(port));
+			});
+			server.listen(port, "127.0.0.1");
+		}
+	});
+}

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -9,6 +9,10 @@
 export interface A2AConfig {
 	/** HTTP port for the A2A server. Defaults to 3100. */
 	port?: number;
+	/** Port range for dynamic port discovery (inclusive). When set, pi-a2a
+	 *  finds the first free port in this range instead of using a fixed port.
+	 *  E.g. [3100, 3199]. Takes precedence over `port`. */
+	portRange?: [number, number];
 	/** Bind address for the HTTP server. Defaults to "127.0.0.1" (localhost only).
 	 *  Set to "0.0.0.0" for external access (requires apiKey). */
 	bind?: string;


### PR DESCRIPTION
## Summary

Adds dynamic port discovery to pi-a2a so multiple agent instances can run without port conflicts.

## Usage

```json
{
  "pi-a2a": {
    "portRange": [3100, 3199]
  }
}
```

When `portRange` is set, pi-a2a finds the first free port in the range. Falls back to `port` (default 3100) if the range is exhausted.

## Changes

- **New:** `port-finder.ts` — `findFreePort()` scans a port range for the first available port
- **Updated:** `types.ts` — added `portRange?: [number, number]` to `A2AConfig`
- **Updated:** `config.ts` — validates port range bounds
- **Updated:** `index.ts` — uses dynamic port discovery in `session_start`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic port selection for the pi-a2a extension: discovers an available port within a configured range and uses it at runtime.
  * New optional portRange configuration to enable dynamic discovery.

* **Bug Fixes / Reliability**
  * Validates and ignores invalid portRange values with a warning.
  * Retries on port-in-use and reports if the range is exhausted.
  * Ensures clean deregistration from the hub on shutdown and before re-registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->