### PR TITLE
td a0878c/package scope update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Key extensions:
 
 ### Structure
 - Default export: `export default function (pi: ExtensionAPI) { ... }`
-- Import types from `@mariozechner/pi-coding-agent` (`ExtensionAPI`, `getAgentDir`, `SettingsManager`)
+- Import types from `@earendil-works/pi-coding-agent` (`ExtensionAPI`, `getAgentDir`, `SettingsManager`)
 - TypeScript with `strict: true`, target ES2022, module ESNext, `allowImportingTsExtensions`
 - Use `.ts` extensions in imports (e.g. `import { foo } from "./bar.ts"`)
 - Tool parameter schemas use `@sinclair/typebox` (`Type.Object`, `Type.String`, etc.)

--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -3,9 +3,14 @@
 ## [0.4.0] - 2026-05-08
 
 ### Added
-- `bindInterface` config option to specify which network interface's IP to use for publicUrl auto-detection
+- `bindInterface` config option to bind to and advertise a specific network interface
 - Auto-detect publicUrl IP when `bind: "0.0.0.0"` instead of defaulting to localhost
+- `buildServerConfig()` helper that returns both bind address and publicUrl
 
 ### Changed
+- `bindInterface` now binds to the specified interface's IP (not just advertising it)
 - Migrated from @mariozechner/* to @earendil-works/* package scope
+
+### Fixed
+- Documentation clarified that `bindInterface` binds to the interface, not just advertises it
 

--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+

--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -9,8 +9,9 @@
 - `owner` config field for agent owner name/email (displayed in hub UIs)
 
 ### Changed
+
 - `bindInterface` now binds to the specified interface's IP (not just advertising it)
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 ### Fixed
 - Documentation clarified that `bindInterface` binds to the interface, not just advertises it

--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [0.2.0] - 2026-05-08
+## [0.4.0] - 2026-05-08
+
+### Added
+- `bindInterface` config option to specify which network interface's IP to use for publicUrl auto-detection
+- Auto-detect publicUrl IP when `bind: "0.0.0.0"` instead of defaulting to localhost
 
 ### Changed
 - Migrated from @mariozechner/* to @earendil-works/* package scope

--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `bindInterface` config option to bind to and advertise a specific network interface
 - Auto-detect publicUrl IP when `bind: "0.0.0.0"` instead of defaulting to localhost
 - `buildServerConfig()` helper that returns both bind address and publicUrl
+- `owner` config field for agent owner name/email (displayed in hub UIs)
 
 ### Changed
 - `bindInterface` now binds to the specified interface's IP (not just advertising it)

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -74,6 +74,7 @@ Add to `~/.pi/agent/settings.json`:
     "description": "Personal AI coding agent",
     "version": "1.0.0",
     "organization": "e9n",
+    "owner": "Espen Nilsen <hi@e9n.dev>",
     "skills": [
       {
         "id": "coding",
@@ -148,6 +149,7 @@ Server binds to localhost, but advertises external URL for reverse proxy setups.
 | `version` | string | `"1.0.0"` | Agent version |
 | `organization` | string | `"Pi"` | Provider organization |
 | `providerUrl` | string | — | Provider website URL |
+| `owner` | string | — | Agent owner name or email (displayed in hub UIs and agent discovery) |
 | `skills` | array | default set | Skills to advertise |
 | `hub` | object | — | Hub registration config (see below) |
 

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -70,7 +70,6 @@ Add to `~/.pi/agent/settings.json`:
 {
   "pi-a2a": {
     "port": 3100,
-    "publicUrl": "http://localhost:3100",
     "name": "Pi Agent",
     "description": "Personal AI coding agent",
     "version": "1.0.0",
@@ -94,14 +93,56 @@ Add to `~/.pi/agent/settings.json`:
 }
 ```
 
+### Examples
+
+**Localhost only (default):**
+```json
+{}
+```
+Server binds to `127.0.0.1:3100`, publicUrl auto-generates as `http://localhost:3100`.
+
+**LAN access (auto-detects IP):**
+```json
+{
+  "pi-a2a": {
+    "bind": "0.0.0.0",
+    "apiKey": "lan-secret"
+  }
+}
+```
+Server binds to all interfaces, publicUrl auto-detects primary IP (e.g., `http://192.168.1.100:3100`).
+
+**LAN access (specific interface):**
+```json
+{
+  "pi-a2a": {
+    "bindInterface": "en1"
+  }
+}
+```
+Server binds to localhost, but advertises en1's IP (e.g., `http://192.168.50.25:3100`). Useful for multi-homed machines.
+
+**Reverse proxy:**
+```json
+{
+  "pi-a2a": {
+    "bind": "127.0.0.1",
+    "publicUrl": "https://agent.mydomain.com"
+  }
+}
+```
+Server binds to localhost, but advertises external URL for reverse proxy setups.
+
 ### Config Reference
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `port` | number | `3100` | HTTP server port |
 | `bind` | string | `"127.0.0.1"` | Bind address (`"0.0.0.0"` for external access) |
+| `bindInterface` | string | — | Network interface name or IP for publicUrl auto-detection (e.g., `"en0"`, `"eth0"`, `"192.168.1.100"`). When set, publicUrl uses this interface's IP instead of the primary IP. |
 | `apiKey` | string | — | API key for Bearer auth (required for external access) |
-| `publicUrl` | string | `http://localhost:{port}` | Public-facing URL for the Agent Card |
+| `publicUrl` | string | auto-detected | Public-facing URL for the Agent Card. Auto-detects primary IP when `bind: "0.0.0.0"` or `bindInterface` is set. |
+| `name` | string | `"Pi Agent"` | Agent display name |
 | `name` | string | `"Pi Agent"` | Agent display name |
 | `description` | string | — | Agent description |
 | `version` | string | `"1.0.0"` | Agent version |

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -120,7 +120,7 @@ Server binds to all interfaces, publicUrl auto-detects primary IP (e.g., `http:/
   }
 }
 ```
-Server binds to localhost, but advertises en1's IP (e.g., `http://192.168.50.25:3100`). Useful for multi-homed machines.
+Server binds to en1's IP and advertises it (e.g., binds to `192.168.50.25:3100`, advertises `http://192.168.50.25:3100`). Useful for multi-homed machines to control which interface is used.
 
 **Reverse proxy:**
 ```json
@@ -139,7 +139,7 @@ Server binds to localhost, but advertises external URL for reverse proxy setups.
 |-----|------|---------|-------------|
 | `port` | number | `3100` | HTTP server port |
 | `bind` | string | `"127.0.0.1"` | Bind address (`"0.0.0.0"` for external access) |
-| `bindInterface` | string | — | Network interface name or IP for publicUrl auto-detection (e.g., `"en0"`, `"eth0"`, `"192.168.1.100"`). When set, publicUrl uses this interface's IP instead of the primary IP. |
+| `bindInterface` | string | — | Network interface name or IP to bind to and advertise (e.g., `"en0"`, `"eth0"`, `"192.168.1.100"`). When set, the server binds to this interface's IP and uses it for the publicUrl. Overrides `bind`. |
 | `apiKey` | string | — | API key for Bearer auth (required for external access) |
 | `publicUrl` | string | auto-detected | Public-facing URL for the Agent Card. Auto-detects primary IP when `bind: "0.0.0.0"` or `bindInterface` is set. |
 | `name` | string | `"Pi Agent"` | Agent display name |

--- a/extensions/pi-a2a/package.json
+++ b/extensions/pi-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-a2a",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A2A protocol extension for pi — serves an Agent Card, handles JSON-RPC requests, and optionally registers with an A2A Hub",
   "type": "module",
   "keywords": [
@@ -17,7 +17,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-a2a/package.json
+++ b/extensions/pi-a2a/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-a2a/package.json
+++ b/extensions/pi-a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-a2a",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "A2A protocol extension for pi — serves an Agent Card, handles JSON-RPC requests, and optionally registers with an A2A Hub",
   "type": "module",
   "keywords": [

--- a/extensions/pi-a2a/src/agent-card.ts
+++ b/extensions/pi-a2a/src/agent-card.ts
@@ -92,6 +92,10 @@ export function buildAgentCard(config: A2AConfig, baseUrl: string): AgentCard {
 		],
 	};
 
+	if (config.owner) {
+		(card as any).owner = config.owner;
+	}
+
 	if (config.iconUrl) {
 		card.iconUrl = config.iconUrl;
 	}

--- a/extensions/pi-a2a/src/config.ts
+++ b/extensions/pi-a2a/src/config.ts
@@ -27,7 +27,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import type { A2AConfig } from "./types.ts";
 
 const SETTINGS_KEY = "pi-a2a";

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -35,6 +35,7 @@ import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
+import { networkInterfaces } from "node:os";
 import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { join } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
@@ -60,6 +61,49 @@ import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot, Pu
 import { LongRunningTaskStore, type LongRunningTask, type ResumeRequest } from "./long-running-task-store.ts";
 
 const DEFAULT_PORT = 3100;
+
+/** Get primary non-loopback IPv4 address, or specific interface if provided. */
+function getPrimaryIP(interfaceName?: string): string {
+	const nets = networkInterfaces();
+	
+	// If interface specified, use it
+	if (interfaceName) {
+		const netsForInterface = nets[interfaceName];
+		if (netsForInterface) {
+			for (const net of netsForInterface) {
+				if (net.family === "IPv4" && !net.internal) {
+					return net.address;
+				}
+			}
+			// Interface exists but no IPv4, check if it's an IP address directly
+			if (interfaceName.includes(".")) {
+				return interfaceName; // assume it's an IP
+			}
+		}
+	}
+	
+	// Default: find first non-loopback IPv4
+	for (const name of Object.keys(nets)) {
+		for (const net of nets[name]!) {
+			if (net.family === "IPv4" && !net.internal) {
+				return net.address;
+			}
+		}
+	}
+	return "localhost"; // fallback
+}
+
+/** Build publicUrl from config, bind address, and port. Auto-detects IP for external binds. */
+function buildPublicUrl(config: any, bind: string | undefined, port: number): string {
+	if (config.publicUrl) {
+		return config.publicUrl; // explicit override
+	}
+	// Auto-detect for external binds or when bindInterface is specified
+	const isExternal = bind === "0.0.0.0" || bind === "::";
+	const hasInterface = config.bindInterface !== undefined;
+	const host = (isExternal || hasInterface) ? getPrimaryIP(config.bindInterface) : "localhost";
+	return `http://${host}:${port}`;
+}
 
 /** Sliding-window rate limiter for outbound response injection. */
 class RateLimiter {
@@ -585,7 +629,7 @@ export default function (pi: ExtensionAPI) {
 				log("dynamic_port_range_exhausted", { range: config.portRange, fallback: agentPort }, "WARN");
 			}
 		}
-		const publicUrl = config.publicUrl ?? `http://localhost:${agentPort}`;
+		const publicUrl = buildPublicUrl(config, config.bind, agentPort);
 		agentPublicUrl = publicUrl;
 		configuredMaxHops = config.maxHops ?? DEFAULT_MAX_HOPS;
 		const agentCard = buildAgentCard(config, publicUrl);
@@ -797,7 +841,7 @@ export default function (pi: ExtensionAPI) {
 			}
 			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${agentPort}`, "info");
 			// Rebuild publicUrl/agentCard with final port (may have changed via EADDRINUSE retry)
-			const publicUrl = config.publicUrl ?? `http://localhost:${agentPort}`;
+			const publicUrl = buildPublicUrl(config, bind, agentPort);
 			agentPublicUrl = publicUrl;
 			updateAgentCard(buildAgentCard(config, publicUrl));
 		} catch (err: unknown) {
@@ -2100,7 +2144,7 @@ export default function (pi: ExtensionAPI) {
 			const action = args.trim();
 			const { config } = loadConfig(cwd);
 			const port = agentPort;
-			const publicUrl = config.publicUrl ?? `http://localhost:${agentPort}`;
+			const publicUrl = buildPublicUrl(config, config.bind, agentPort);
 
 			if (action === "status") {
 				if (isRunning()) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -62,8 +62,8 @@ import { LongRunningTaskStore, type LongRunningTask, type ResumeRequest } from "
 
 const DEFAULT_PORT = 3100;
 
-/** Get primary non-loopback IPv4 address, or specific interface if provided. */
-function getPrimaryIP(interfaceName?: string): string {
+/** Get interface IP by name, or primary non-loopback IPv4 if not specified. */
+function getInterfaceIP(interfaceName?: string): string | null {
 	const nets = networkInterfaces();
 	
 	// If interface specified, use it
@@ -75,11 +75,12 @@ function getPrimaryIP(interfaceName?: string): string {
 					return net.address;
 				}
 			}
-			// Interface exists but no IPv4, check if it's an IP address directly
-			if (interfaceName.includes(".")) {
-				return interfaceName; // assume it's an IP
-			}
 		}
+		// Check if it's already an IP address
+		if (interfaceName.includes(".")) {
+			return interfaceName;
+		}
+		return null; // interface not found
 	}
 	
 	// Default: find first non-loopback IPv4
@@ -90,19 +91,47 @@ function getPrimaryIP(interfaceName?: string): string {
 			}
 		}
 	}
-	return "localhost"; // fallback
+	return null;
 }
 
-/** Build publicUrl from config, bind address, and port. Auto-detects IP for external binds. */
-function buildPublicUrl(config: any, bind: string | undefined, port: number): string {
+/** Build publicUrl and bind address from config and port. Returns {publicUrl, bind}. */
+function buildServerConfig(config: any, port: number): { publicUrl: string; bind: string } {
+	// Explicit publicUrl override
 	if (config.publicUrl) {
-		return config.publicUrl; // explicit override
+		return {
+			publicUrl: config.publicUrl,
+			bind: config.bind ?? "127.0.0.1",
+		};
 	}
-	// Auto-detect for external binds or when bindInterface is specified
+	
+	// bindInterface specified: bind to that interface's IP, advertise it
+	if (config.bindInterface) {
+		const interfaceIP = getInterfaceIP(config.bindInterface);
+		if (interfaceIP) {
+			return {
+				publicUrl: `http://${interfaceIP}:${port}`,
+				bind: interfaceIP,
+			};
+		}
+		// Interface not found, fall back to primary
+	}
+	
+	// bind: "0.0.0.0" or "::": auto-detect primary IP for advertising
+	const bind = config.bind ?? "127.0.0.1";
 	const isExternal = bind === "0.0.0.0" || bind === "::";
-	const hasInterface = config.bindInterface !== undefined;
-	const host = (isExternal || hasInterface) ? getPrimaryIP(config.bindInterface) : "localhost";
-	return `http://${host}:${port}`;
+	if (isExternal) {
+		const primaryIP = getInterfaceIP();
+		return {
+			publicUrl: primaryIP ? `http://${primaryIP}:${port}` : `http://localhost:${port}`,
+			bind,
+		};
+	}
+	
+	// Default: localhost
+	return {
+		publicUrl: `http://localhost:${port}`,
+		bind,
+	};
 }
 
 /** Sliding-window rate limiter for outbound response injection. */
@@ -629,7 +658,9 @@ export default function (pi: ExtensionAPI) {
 				log("dynamic_port_range_exhausted", { range: config.portRange, fallback: agentPort }, "WARN");
 			}
 		}
-		const publicUrl = buildPublicUrl(config, config.bind, agentPort);
+		const serverConfig = buildServerConfig(config, agentPort);
+		const publicUrl = serverConfig.publicUrl;
+		const bind = serverConfig.bind;
 		agentPublicUrl = publicUrl;
 		configuredMaxHops = config.maxHops ?? DEFAULT_MAX_HOPS;
 		const agentCard = buildAgentCard(config, publicUrl);
@@ -804,7 +835,7 @@ export default function (pi: ExtensionAPI) {
 		const rpcHandler = new JsonRpcTransportHandler(requestHandler);
 
 		// Start the A2A server
-		const bind = config.bind;
+		let bind = serverConfig.bind;
 		const isLocalhost = !bind || bind === "127.0.0.1" || bind === "::1";
 		if (!isLocalhost && !config.apiKey) {
 		// Security: refuse to start when binding to external interfaces without authentication
@@ -833,15 +864,19 @@ export default function (pi: ExtensionAPI) {
 						if (agentPort < end) {
 							agentPort++;
 							log("server_port_retry", { port: agentPort, reason: "EADDRINUSE" }, "WARN");
+							// Rebuild server config with new port
+							const newConfig = buildServerConfig(config, agentPort);
+							bind = newConfig.bind;
 							continue;
 						}
 					}
 					throw e;
 				}
 			}
-			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind ?? "127.0.0.1"}:${agentPort}`, "info");
+			ctx.ui.notify(`pi-a2a: A2A server listening on ${bind}:${agentPort}`, "info");
 			// Rebuild publicUrl/agentCard with final port (may have changed via EADDRINUSE retry)
-			const publicUrl = buildPublicUrl(config, bind, agentPort);
+			const serverConfigFinal = buildServerConfig(config, agentPort);
+			const publicUrl = serverConfigFinal.publicUrl;
 			agentPublicUrl = publicUrl;
 			updateAgentCard(buildAgentCard(config, publicUrl));
 		} catch (err: unknown) {
@@ -2144,7 +2179,8 @@ export default function (pi: ExtensionAPI) {
 			const action = args.trim();
 			const { config } = loadConfig(cwd);
 			const port = agentPort;
-			const publicUrl = buildPublicUrl(config, config.bind, agentPort);
+			const serverConfigCmd = buildServerConfig(config, agentPort);
+			const publicUrl = serverConfigCmd.publicUrl;
 
 			if (action === "status") {
 				if (isRunning()) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -35,9 +35,9 @@ import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
-import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { join } from "node:path";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { Type } from "typebox";
 import {
 	A2AError,

--- a/extensions/pi-a2a/src/logger.ts
+++ b/extensions/pi-a2a/src/logger.ts
@@ -2,7 +2,7 @@
  * pi-a2a — Structured logger via pi-logger event bus.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -34,6 +34,8 @@ export interface A2AConfig {
 	organization?: string;
 	/** Provider URL. */
 	providerUrl?: string;
+	/** Agent owner name or email (displayed in agent discovery and hub UIs). */
+	owner?: string;
 	/** Skills to advertise in the Agent Card. */
 	skills?: Array<{ id: string; name: string; description: string; tags?: string[] }>;
 	/** A2A Hub settings for optional registration. */

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -16,6 +16,10 @@ export interface A2AConfig {
 	/** Bind address for the HTTP server. Defaults to "127.0.0.1" (localhost only).
 	 *  Set to "0.0.0.0" for external access (requires apiKey). */
 	bind?: string;
+	/** Network interface name or IP to use for publicUrl auto-detection.
+	 *  When set, publicUrl uses this interface's IP instead of the primary IP.
+	 *  Examples: "en0", "eth0", "192.168.1.100". Requires `bind` to be set if not localhost. */
+	bindInterface?: string;
 	/** API key for authenticating RPC requests. Required when bind is not localhost. */
 	apiKey?: string;
 	/** Public-facing base URL. Defaults to http://localhost:{port}. */

--- a/extensions/pi-brave-search/CHANGELOG.md
+++ b/extensions/pi-brave-search/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-brave-search/CHANGELOG.md
+++ b/extensions/pi-brave-search/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-brave-search/package.json
+++ b/extensions/pi-brave-search/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-brave-search/package.json
+++ b/extensions/pi-brave-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-brave-search",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit"
@@ -9,7 +9,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "license": "MIT",

--- a/extensions/pi-brave-search/src/index.ts
+++ b/extensions/pi-brave-search/src/index.ts
@@ -16,7 +16,7 @@
  * Get an API key at: https://brave.com/search/api/
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { getSettings, type BraveSearchSettings } from "./settings.ts";
 import { registerSearchTool } from "./tool.ts";

--- a/extensions/pi-brave-search/src/logger.ts
+++ b/extensions/pi-brave-search/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "brave-search";
 

--- a/extensions/pi-brave-search/src/settings.ts
+++ b/extensions/pi-brave-search/src/settings.ts
@@ -1,4 +1,4 @@
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface BraveSearchSettings {
 	/** Brave Search API subscription token (required) */

--- a/extensions/pi-brave-search/src/tool.ts
+++ b/extensions/pi-brave-search/src/tool.ts
@@ -5,7 +5,7 @@
  * for current information, news, documentation, etc.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { search, type SearchOptions } from "./search.ts";
 

--- a/extensions/pi-calendar/CHANGELOG.md
+++ b/extensions/pi-calendar/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-calendar/CHANGELOG.md
+++ b/extensions/pi-calendar/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-calendar/package.json
+++ b/extensions/pi-calendar/package.json
@@ -1,42 +1,42 @@
 {
-	"name": "@e9n/pi-calendar",
-	"version": "0.1.0",
-	"description": "Calendar extension for pi — events, reminders, recurrence, and web dashboard",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-calendar"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"dependencies": {
-		"better-sqlite3": "^11.10.0"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24"
-	},
-	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.12",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	]
+  "name": "@e9n/pi-calendar",
+  "version": "0.2.0",
+  "description": "Calendar extension for pi — events, reminders, recurrence, and web dashboard",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-calendar"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "dependencies": {
+    "better-sqlite3": "^11.10.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-calendar/package.json
+++ b/extensions/pi-calendar/package.json
@@ -17,7 +17,8 @@
     "directory": "extensions/pi-calendar"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-calendar/src/db-kysely.ts
+++ b/extensions/pi-calendar/src/db-kysely.ts
@@ -15,7 +15,7 @@
  */
 
 import { readdirSync, readFileSync } from "node:fs";
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import type { CalendarEvent, CreateEventInput, RecurrenceRule, UpdateEventInput } from "./types.ts";
 
 const ACTOR = "pi-calendar";

--- a/extensions/pi-calendar/src/index.ts
+++ b/extensions/pi-calendar/src/index.ts
@@ -18,8 +18,8 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { setStore, isStoreReady, createSqliteStore, createKyselyStore } from "./store.ts";
 import { registerCalendarTool } from "./tool.ts";

--- a/extensions/pi-calendar/src/logger.ts
+++ b/extensions/pi-calendar/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "calendar";
 

--- a/extensions/pi-calendar/src/reminders.ts
+++ b/extensions/pi-calendar/src/reminders.ts
@@ -6,7 +6,7 @@
  * Tracks sent reminders to avoid duplicates.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { CalendarEvent } from "./types.ts";
 import { getStore } from "./store.ts";
 import { expandOccurrences } from "./recurrence.ts";

--- a/extensions/pi-calendar/src/tool.ts
+++ b/extensions/pi-calendar/src/tool.ts
@@ -4,9 +4,9 @@
  * Actions: list, create, update, delete, today, upcoming
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { getStore } from "./store.ts";
 import type { CalendarEvent, RecurrenceRule } from "./types.ts";
 import { expandOccurrences } from "./recurrence.ts";

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -1,32 +1,14 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
-
-## [0.3.0] - 2026-04-26
-
-### Added
-
-- **File upload support (GitHub #153):** Incoming files of any type (video, audio, binary, etc.) can be saved to temp and passed to the LLM as attachments with `fileUpload.enabled: true` in adapter config
-- **Bidirectional file transfer:** New `send_file` action on the `notify` tool lets the LLM send local files back to Telegram chats
-- **`ChannelMessage.filePath/fileName/caption`:** Outgoing messages can now include a file attachment instead of text
-- **`ChannelAdapter.sendFile()`:** Adapters can implement file sending (Telegram supports sendDocument/sendPhoto/sendAudio/sendVideo)
-- **`channel:send_file` event:** Event bus API for file sends from other extensions
-- **`FileUploadConfig` type:** Configurable `maxSize` (default 50MB) for file uploads per adapter
-- **Video support:** Telegram adapter handles video messages when `fileUpload` is enabled
-- **Smart fallback:** Audio/voice transcription falls back to file upload when transcription fails and `fileUpload` is enabled
-- **`IncomingAttachment.type: "file"`:** New attachment type for generic file uploads
-
-### Changed
-
-- Photos use `fileUpload.maxSize` when `fileUpload` is enabled (previously hard-coded 1MB limit)
-- Documents use `fileUpload.maxSize` when `fileUpload` is enabled (previously hard-coded 1MB limit)
-- Unsupported file types now suggest enabling `fileUpload` instead of just rejecting
-- Audio/voice messages without transcription configured now suggest enabling `fileUpload` as alternative
-- `notify` tool description updated to include `send_file` action
-- Event bus command handlers now forward the `source` field, allowing web/mobile clients to route `command_result` events to the originating UI
 
 ## [0.2.0] - 2026-03-06
 

--- a/extensions/pi-channels/CHANGELOG.md
+++ b/extensions/pi-channels/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-channels/package.json
+++ b/extensions/pi-channels/package.json
@@ -12,6 +12,10 @@
       "./src/index.ts"
     ]
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"

--- a/extensions/pi-channels/package.json
+++ b/extensions/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-channels",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Two-way channel extension for pi — route messages between agents and Telegram, webhooks, and custom adapters",
   "keywords": [
     "pi-package"
@@ -17,8 +17,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-channels/src/adapters/transcription.ts
+++ b/extensions/pi-channels/src/adapters/transcription.ts
@@ -14,7 +14,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFile } from "node:child_process";
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { TranscriptionConfig } from "../types.ts";
 
 // ── Public interface ────────────────────────────────────────────

--- a/extensions/pi-channels/src/bridge/bridge.ts
+++ b/extensions/pi-channels/src/bridge/bridge.ts
@@ -15,7 +15,7 @@ import type {
 	BridgeConfig,
 } from "../types.ts";
 import type { ChannelRegistry } from "../registry.ts";
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import { runPrompt } from "./runner.ts";
 import { RpcSessionManager } from "./rpc-runner.ts";
 import { isCommand, handleCommand, routeSlashCommand, type CommandContext, type SlashCommandInfo } from "./commands.ts";

--- a/extensions/pi-channels/src/config.ts
+++ b/extensions/pi-channels/src/config.ts
@@ -32,7 +32,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import type { ChannelConfig } from "./types.ts";
 
 const SETTINGS_KEY = "pi-channels";

--- a/extensions/pi-channels/src/events.ts
+++ b/extensions/pi-channels/src/events.ts
@@ -14,7 +14,7 @@
  *   bridge:*          — chat bridge lifecycle events
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { ChannelRegistry } from "./registry.ts";
 import type { ChannelAdapter, ChannelMessage, IncomingMessage } from "./types.ts";
 import type { ChatBridge } from "./bridge/bridge.ts";

--- a/extensions/pi-channels/src/history.ts
+++ b/extensions/pi-channels/src/history.ts
@@ -9,7 +9,7 @@
  * Config: messageRetentionDays in pi-channels settings (default: 30)
  */
 
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import type { ChannelMessage, IncomingMessage } from "./types.ts";
 
 export const TABLE_NAME = "pi-channels__messages";

--- a/extensions/pi-channels/src/index.ts
+++ b/extensions/pi-channels/src/index.ts
@@ -18,7 +18,7 @@
  * event bus; skill/prompt commands are expanded into the agent prompt.
  */
 
-import type { ExtensionAPI, SlashCommandInfo } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "./config.ts";
 import { ChannelRegistry } from "./registry.ts";
 import { registerChannelEvents, setBridge, setHistory } from "./events.ts";
@@ -70,7 +70,7 @@ async function waitForKysely(pi: ExtensionAPI): Promise<void> {
 
 /** Show message history in a TUI overlay popup. */
 async function showHistoryPopup(ctx: any, rows: MessageRow[]): Promise<void> {
-	const { matchesKey, Key, truncateToWidth } = await import("@mariozechner/pi-tui");
+	const { matchesKey, Key, truncateToWidth } = await import("@earendil-works/pi-tui");
 
 	const arrow = (d: string) => (d === "in" ? "←" : "→");
 	const source = (row: MessageRow) =>

--- a/extensions/pi-channels/src/logger.ts
+++ b/extensions/pi-channels/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "channels";
 

--- a/extensions/pi-channels/src/registry.ts
+++ b/extensions/pi-channels/src/registry.ts
@@ -2,7 +2,7 @@
  * pi-channels — Adapter registry + route resolution.
  */
 
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { ChannelAdapter, ChannelMessage, AdapterConfig, ChannelConfig, AdapterDirection, OnIncomingMessage, IncomingMessage } from "./types.ts";
 import type { MessageHistory } from "./history.ts";
 import { createTelegramAdapter } from "./adapters/telegram.ts";

--- a/extensions/pi-channels/src/tool.ts
+++ b/extensions/pi-channels/src/tool.ts
@@ -8,9 +8,9 @@
  *   test      — Send a test ping
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ChannelRegistry } from "./registry.ts";

--- a/extensions/pi-cmux/CHANGELOG.md
+++ b/extensions/pi-cmux/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-cmux/CHANGELOG.md
+++ b/extensions/pi-cmux/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-cmux/package.json
+++ b/extensions/pi-cmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-cmux",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "cmux terminal app integration for pi — notifications, pane management, screen reading, and browser automation",
   "type": "module",
   "keywords": [
@@ -17,7 +17,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-cmux/package.json
+++ b/extensions/pi-cmux/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-cmux/src/index.ts
+++ b/extensions/pi-cmux/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { basename } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { CmuxClient } from "./client.ts";
 import { registerTools } from "./tools.ts";

--- a/extensions/pi-cmux/src/logger.ts
+++ b/extensions/pi-cmux/src/logger.ts
@@ -2,7 +2,7 @@
  * pi-cmux — Structured logger via pi-logger event bus.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 

--- a/extensions/pi-cmux/src/tools.ts
+++ b/extensions/pi-cmux/src/tools.ts
@@ -12,7 +12,7 @@
  */
 
 import { Type } from "typebox";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { CmuxClient } from "./client.ts";
 import type { LogFn } from "./logger.ts";
 

--- a/extensions/pi-context/CHANGELOG.md
+++ b/extensions/pi-context/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-context/CHANGELOG.md
+++ b/extensions/pi-context/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-context/package.json
+++ b/extensions/pi-context/package.json
@@ -1,13 +1,17 @@
 {
   "name": "@e9n/pi-context",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Context window usage command for pi — visual breakdown of token usage by category",
-  "keywords": ["pi-package"],
+  "keywords": [
+    "pi-package"
+  ],
   "license": "MIT",
   "author": "Espen Nilsen <hi@e9n.dev>",
   "type": "module",
   "pi": {
-    "extensions": ["./src/index.ts"]
+    "extensions": [
+      "./src/index.ts"
+    ]
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
@@ -17,7 +21,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "files": [
     "CHANGELOG.md",

--- a/extensions/pi-context/package.json
+++ b/extensions/pi-context/package.json
@@ -14,7 +14,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/extensions/pi-context/src/index.ts
+++ b/extensions/pi-context/src/index.ts
@@ -10,8 +10,8 @@
  *   - Per-item token counts for tools, agents, and skills
  */
 
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, estimateTokens, SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, estimateTokens, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { join } from "node:path";
 import { readdirSync, readFileSync } from "node:fs";
 

--- a/extensions/pi-cron/CHANGELOG.md
+++ b/extensions/pi-cron/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-cron/CHANGELOG.md
+++ b/extensions/pi-cron/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-cron/package.json
+++ b/extensions/pi-cron/package.json
@@ -12,6 +12,10 @@
       "./src/index.ts"
     ]
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"

--- a/extensions/pi-cron/package.json
+++ b/extensions/pi-cron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-cron",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Cron scheduler extension for pi — schedule recurring prompts as isolated subprocesses",
   "keywords": [
     "pi-package"
@@ -17,8 +17,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
     "typebox": "^1.1.24"
   },
   "files": [

--- a/extensions/pi-cron/src/api.ts
+++ b/extensions/pi-cron/src/api.ts
@@ -20,7 +20,7 @@
  *   pi.events.on("cron:reload", (jobs) => ...)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { CronScheduler } from "./scheduler.ts";
 import { loadJobs, getJob, addJob, removeJob, updateJob, type CronJob } from "./crontab.ts";
 import { validateCron } from "./scheduler.ts";

--- a/extensions/pi-cron/src/index.ts
+++ b/extensions/pi-cron/src/index.ts
@@ -18,9 +18,9 @@
  * jobs actually execute on their schedule.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { ensureTabFile, loadJobs, addJob, removeJob, updateJob, initTabPath, type CronJob } from "./crontab.ts";
 import { CronScheduler, validateCron } from "./scheduler.ts";
 import { acquireLock, releaseLock, lockHolder, initLockPath } from "./lock.ts";

--- a/extensions/pi-cron/src/logger.ts
+++ b/extensions/pi-cron/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "cron";
 

--- a/extensions/pi-cron/src/settings.ts
+++ b/extensions/pi-cron/src/settings.ts
@@ -2,7 +2,7 @@
  * pi-cron — Settings loader.
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface CronSettings {
 	autostart: boolean;

--- a/extensions/pi-dotenv/CHANGELOG.md
+++ b/extensions/pi-dotenv/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-dotenv/CHANGELOG.md
+++ b/extensions/pi-dotenv/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-dotenv/package.json
+++ b/extensions/pi-dotenv/package.json
@@ -1,38 +1,38 @@
 {
-	"name": "@e9n/pi-dotenv",
-	"version": "0.1.0",
-	"description": "Deprecated dotenv extension for pi — no-op kept for backwards compatibility",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"license": "MIT",
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"devDependencies": {
-		"@types/node": "^22.0.0",
-		"typescript": "^5.0.0"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-dotenv"
-	},
-	"private": true
+  "name": "@e9n/pi-dotenv",
+  "version": "0.2.0",
+  "description": "Deprecated dotenv extension for pi — no-op kept for backwards compatibility",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "license": "MIT",
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-dotenv"
+  },
+  "private": true
 }

--- a/extensions/pi-dotenv/package.json
+++ b/extensions/pi-dotenv/package.json
@@ -14,7 +14,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/extensions/pi-dotenv/src/index.ts
+++ b/extensions/pi-dotenv/src/index.ts
@@ -8,7 +8,7 @@
  * (safe to remove from your extensions directory).
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (_pi: ExtensionAPI) {
 	// No-op — all config is now in settings.json

--- a/extensions/pi-github/CHANGELOG.md
+++ b/extensions/pi-github/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-github/CHANGELOG.md
+++ b/extensions/pi-github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-github/package.json
+++ b/extensions/pi-github/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/extensions/pi-github/package.json
+++ b/extensions/pi-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-github",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "GitHub integration for pi — PR management, issue tracking, and review feedback commands",
   "type": "module",
   "keywords": [
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-github/src/commands.ts
+++ b/extensions/pi-github/src/commands.ts
@@ -8,7 +8,7 @@
  */
 
 import { execFile } from "node:child_process";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { gh, ghJson, getCurrentBranch } from "./gh.ts";
 import { extractRepoRef, resolveRepo, repoFlag } from "./repo-ref.ts";
 

--- a/extensions/pi-github/src/index.ts
+++ b/extensions/pi-github/src/index.ts
@@ -16,8 +16,8 @@
  * Requires gh CLI installed and authenticated.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { SettingsManager, getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { registerCommands, setSessionCwd } from "./commands.ts";
 import { registerPrFixCommand } from "./pr-fix.ts";
 import { registerPrFixTools } from "./pr-fix-tools.ts";

--- a/extensions/pi-github/src/logger.ts
+++ b/extensions/pi-github/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 type LogFn = (event: string, data: unknown, level?: string) => void;
 

--- a/extensions/pi-github/src/pr-fix-tools.ts
+++ b/extensions/pi-github/src/pr-fix-tools.ts
@@ -10,7 +10,7 @@
  *   - github_post_pr_comment    — post a top-level PR comment
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { ghGraphql, ghJson, gh } from "./gh.ts";
 

--- a/extensions/pi-github/src/pr-fix.ts
+++ b/extensions/pi-github/src/pr-fix.ts
@@ -13,7 +13,7 @@
  * No args: auto-detect from branch, or list PRs with feedback
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { ghJson, ghGraphql, gitExec, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
 import { registerDualCommand } from "./commands.ts";
 import { extractRepoRef, resolveRepo, resolveLocalClone, repoFlag } from "./repo-ref.ts";

--- a/extensions/pi-github/src/pr-merge.ts
+++ b/extensions/pi-github/src/pr-merge.ts
@@ -12,7 +12,7 @@
 
 import { rmdir } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { gh, ghJson, gitExec, gitExecRetry, getCurrentBranch, findWorktreeForBranch } from "./gh.ts";
 import { registerDualCommand } from "./commands.ts";
 import { extractRepoRef, resolveRepo, repoFlag } from "./repo-ref.ts";

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-gmail/package.json
+++ b/extensions/pi-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-gmail",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Gmail extension for pi — read, search, compose, and send emails via Gmail API",
   "type": "module",
   "keywords": [
@@ -21,8 +21,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "files": [

--- a/extensions/pi-gmail/package.json
+++ b/extensions/pi-gmail/package.json
@@ -14,7 +14,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/extensions/pi-gmail/src/index.ts
+++ b/extensions/pi-gmail/src/index.ts
@@ -23,8 +23,8 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { registerGmailTool } from "./tool.ts";
 import { mountGmailRoutes, unmountGmailRoutes } from "./web.ts";

--- a/extensions/pi-gmail/src/logger.ts
+++ b/extensions/pi-gmail/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "gmail";
 

--- a/extensions/pi-gmail/src/tool.ts
+++ b/extensions/pi-gmail/src/tool.ts
@@ -7,10 +7,10 @@
  *          download_attachment
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import * as client from "./client.ts";
 import {
 	parseMessage,

--- a/extensions/pi-heartbeat/CHANGELOG.md
+++ b/extensions/pi-heartbeat/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-heartbeat/CHANGELOG.md
+++ b/extensions/pi-heartbeat/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-heartbeat/package.json
+++ b/extensions/pi-heartbeat/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-heartbeat/package.json
+++ b/extensions/pi-heartbeat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-heartbeat",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Periodic health check extension for pi — runs a heartbeat prompt as an isolated subprocess",
   "type": "module",
   "keywords": [
@@ -20,7 +20,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-heartbeat/src/db-kysely.ts
+++ b/extensions/pi-heartbeat/src/db-kysely.ts
@@ -11,7 +11,7 @@
  * Requires pi-kysely extension to be loaded.
  */
 
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 
 const ACTOR = "pi-heartbeat";
 const EVENT_TIMEOUT_MS = 15_000;

--- a/extensions/pi-heartbeat/src/index.ts
+++ b/extensions/pi-heartbeat/src/index.ts
@@ -14,7 +14,7 @@
  * If HEARTBEAT.md is missing or empty, does a generic check.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings } from "./settings.ts";
 import { HeartbeatRunner } from "./heartbeat.ts";
 import { mountHeartbeatRoutes, unmountHeartbeatRoutes } from "./web.ts";

--- a/extensions/pi-heartbeat/src/logger.ts
+++ b/extensions/pi-heartbeat/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "heartbeat";
 

--- a/extensions/pi-heartbeat/src/settings.ts
+++ b/extensions/pi-heartbeat/src/settings.ts
@@ -4,7 +4,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface HeartbeatSettings {
 	autostart: boolean;

--- a/extensions/pi-jobs/CHANGELOG.md
+++ b/extensions/pi-jobs/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-jobs/CHANGELOG.md
+++ b/extensions/pi-jobs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-jobs/package.json
+++ b/extensions/pi-jobs/package.json
@@ -1,42 +1,42 @@
 {
-	"name": "@e9n/pi-jobs",
-	"version": "0.1.1",
-	"description": "Agent run tracking extension for pi — job history, cost analysis, and session telemetry",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24"
-	},
-	"dependencies": {
-		"better-sqlite3": "^12.6.2"
-	},
-	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.12",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-jobs"
-	}
+  "name": "@e9n/pi-jobs",
+  "version": "0.2.0",
+  "description": "Agent run tracking extension for pi — job history, cost analysis, and session telemetry",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-jobs"
+  }
 }

--- a/extensions/pi-jobs/package.json
+++ b/extensions/pi-jobs/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-jobs/src/db-kysely.ts
+++ b/extensions/pi-jobs/src/db-kysely.ts
@@ -17,7 +17,7 @@
 
 import { readdirSync, readFileSync } from "node:fs";
 import * as crypto from "node:crypto";
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import type {
 	JobRecord,
 	ToolCallRecord,

--- a/extensions/pi-jobs/src/index.ts
+++ b/extensions/pi-jobs/src/index.ts
@@ -25,8 +25,8 @@
  */
 
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { resolveSettings } from "./settings.ts";
 import { closeDb } from "./db.ts";

--- a/extensions/pi-jobs/src/logger.ts
+++ b/extensions/pi-jobs/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "jobs";
 

--- a/extensions/pi-jobs/src/settings.ts
+++ b/extensions/pi-jobs/src/settings.ts
@@ -2,7 +2,7 @@
  * pi-jobs — Settings loader.
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface JobsSettings {
 	dbPath: string;

--- a/extensions/pi-jobs/src/tool.ts
+++ b/extensions/pi-jobs/src/tool.ts
@@ -2,9 +2,9 @@
  * pi-jobs — LLM tool for querying job stats.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { getJobsStore } from "./store.ts";
 
 interface JobsToolParams {

--- a/extensions/pi-jobs/src/tracker.ts
+++ b/extensions/pi-jobs/src/tracker.ts
@@ -6,7 +6,7 @@
  * and cron:job_complete events from other extensions.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getJobsStore, isStoreReady } from "./store.ts";
 
 interface TrackerState {

--- a/extensions/pi-kysely/CHANGELOG.md
+++ b/extensions/pi-kysely/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-kysely/CHANGELOG.md
+++ b/extensions/pi-kysely/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-kysely/package.json
+++ b/extensions/pi-kysely/package.json
@@ -1,48 +1,48 @@
 {
-	"name": "@e9n/pi-kysely",
-	"version": "0.1.1",
-	"description": "Shared Kysely database registry for pi — multi-dialect SQL with table-level RBAC",
-	"type": "module",
-	"keywords": [
-		"pi-package",
-		"kysely",
-		"pi-extension"
-	],
-	"exports": {
-		".": "./src/index.ts"
-	},
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-kysely"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"dependencies": {
-		"better-sqlite3": "*",
-		"kysely": "^0.28.8",
-		"mysql2": "*",
-		"pg": "*"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"devDependencies": {
-		"@types/node": "^24.3.0",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	]
+  "name": "@e9n/pi-kysely",
+  "version": "0.2.0",
+  "description": "Shared Kysely database registry for pi — multi-dialect SQL with table-level RBAC",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "kysely",
+    "pi-extension"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-kysely"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "dependencies": {
+    "better-sqlite3": "*",
+    "kysely": "^0.28.8",
+    "mysql2": "*",
+    "pg": "*"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-kysely/package.json
+++ b/extensions/pi-kysely/package.json
@@ -22,7 +22,8 @@
     "directory": "extensions/pi-kysely"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-kysely/src/events.ts
+++ b/extensions/pi-kysely/src/events.ts
@@ -11,7 +11,7 @@
  * Plus RBAC grant/revoke events.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	executeQuery,
 	grantTableAccess,

--- a/extensions/pi-kysely/src/index.ts
+++ b/extensions/pi-kysely/src/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { wireKyselyEvents } from "./events.ts";
 import {

--- a/extensions/pi-kysely/src/logger.ts
+++ b/extensions/pi-kysely/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "kysely";
 

--- a/extensions/pi-kysely/src/settings.ts
+++ b/extensions/pi-kysely/src/settings.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { DatabaseDriver } from "./registry.ts";
 
 export interface KyselyRuntimeSettings {

--- a/extensions/pi-logger/CHANGELOG.md
+++ b/extensions/pi-logger/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-logger/CHANGELOG.md
+++ b/extensions/pi-logger/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-logger/package.json
+++ b/extensions/pi-logger/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-logger/package.json
+++ b/extensions/pi-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-logger",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Event bus logger for pi — writes structured JSONL logs from bus events",
   "type": "module",
   "keywords": [
@@ -17,7 +17,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-logger/src/index.ts
+++ b/extensions/pi-logger/src/index.ts
@@ -32,7 +32,7 @@
  *   pi.events.emit("log:warn", { event: "cache-miss", level: "ERROR", data: { ... } })
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings, type LogLevel, type LoggerSettings } from "./settings.ts";
 import { writeLogEntry } from "./writer.ts";
 

--- a/extensions/pi-logger/src/settings.ts
+++ b/extensions/pi-logger/src/settings.ts
@@ -5,7 +5,7 @@
  * (project overrides global).
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 

--- a/extensions/pi-logger/src/writer.ts
+++ b/extensions/pi-logger/src/writer.ts
@@ -12,7 +12,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import type { LogScope } from "./settings.ts";
 
 export interface LogEntry {

--- a/extensions/pi-mealie/CHANGELOG.md
+++ b/extensions/pi-mealie/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 ## 0.2.0 — 2026-04-15
 

--- a/extensions/pi-mealie/CHANGELOG.md
+++ b/extensions/pi-mealie/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 ## 0.2.0 — 2026-04-15
 
 - `mealie_mealplans`: auto-update recipe `lastMade` when adding a recipe to today or a past date

--- a/extensions/pi-mealie/package.json
+++ b/extensions/pi-mealie/package.json
@@ -1,42 +1,42 @@
 {
-	"name": "@e9n/pi-mealie",
-	"version": "0.2.0",
-	"description": "Mealie recipe manager API integration for pi — recipes, meal plans, and shopping lists",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"exports": {
-		".": "./src/index.ts"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24"
-	},
-	"devDependencies": {
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24",
-		"typescript": "^5.9.3"
-	},
-	"license": "MIT",
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-mealie"
-	}
+  "name": "@e9n/pi-mealie",
+  "version": "0.3.0",
+  "description": "Mealie recipe manager API integration for pi — recipes, meal plans, and shopping lists",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24",
+    "typescript": "^5.9.3"
+  },
+  "license": "MIT",
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-mealie"
+  }
 }

--- a/extensions/pi-mealie/package.json
+++ b/extensions/pi-mealie/package.json
@@ -15,7 +15,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/extensions/pi-mealie/src/index.ts
+++ b/extensions/pi-mealie/src/index.ts
@@ -14,7 +14,7 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings } from "./settings.ts";
 import { initClient, resetClient, isClientReady, mealie, apiList } from "./client.ts";
 import { registerRecipesTool } from "./tools/recipes.ts";

--- a/extensions/pi-mealie/src/settings.ts
+++ b/extensions/pi-mealie/src/settings.ts
@@ -10,7 +10,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface MealieSettings {
 	/** Mealie API base URL (e.g. https://mealie.e9n.dev/api). */

--- a/extensions/pi-mealie/src/tools/mealplans.ts
+++ b/extensions/pi-mealie/src/tools/mealplans.ts
@@ -2,7 +2,7 @@
  * mealie_mealplans tool -- Meal planning: view today/week, add meals, remove meals.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { isClientReady, mealie, apiList } from "../client.ts";
 

--- a/extensions/pi-mealie/src/tools/organizer.ts
+++ b/extensions/pi-mealie/src/tools/organizer.ts
@@ -2,7 +2,7 @@
  * mealie_organizer tool — Tags, categories, tools, foods, and units.
  */
 
-import type { ExtensionAPI, AgentToolResult } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, AgentToolResult } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { isClientReady, mealie, apiList } from "../client.ts";
 

--- a/extensions/pi-mealie/src/tools/recipes.ts
+++ b/extensions/pi-mealie/src/tools/recipes.ts
@@ -2,7 +2,7 @@
  * mealie_recipes tool — Browse, search, get, create, update, and delete recipes.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { isClientReady, mealie, apiList } from "../client.ts";
 

--- a/extensions/pi-mealie/src/tools/shopping.ts
+++ b/extensions/pi-mealie/src/tools/shopping.ts
@@ -2,7 +2,7 @@
  * mealie_shopping tool — Shopping lists: view lists, add/check items.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { isClientReady, mealie, apiList } from "../client.ts";
 

--- a/extensions/pi-memory/CHANGELOG.md
+++ b/extensions/pi-memory/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-memory/CHANGELOG.md
+++ b/extensions/pi-memory/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-memory/package.json
+++ b/extensions/pi-memory/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-memory/package.json
+++ b/extensions/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Persistent memory system for pi — long-term facts, daily logs, and search",
   "type": "module",
   "keywords": [
@@ -20,8 +20,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-memory/src/context.ts
+++ b/extensions/pi-memory/src/context.ts
@@ -9,7 +9,7 @@
  * Also injects behavioral instructions for when to write/search memory.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import * as files from "./files.ts";
 
 const MEMORY_INSTRUCTIONS = `

--- a/extensions/pi-memory/src/index.ts
+++ b/extensions/pi-memory/src/index.ts
@@ -17,7 +17,7 @@
  * Defaults to cwd if no path is configured.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { setBasePath } from "./files.ts";
 import { registerMemoryTools } from "./tools.ts";
 import { registerMemoryContext } from "./context.ts";

--- a/extensions/pi-memory/src/logger.ts
+++ b/extensions/pi-memory/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "memory";
 

--- a/extensions/pi-memory/src/tools.ts
+++ b/extensions/pi-memory/src/tools.ts
@@ -7,9 +7,9 @@
  *   memory_search — Full-text search across all memory files
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import * as files from "./files.ts";
 
 function text(s: string) {

--- a/extensions/pi-mobile/CHANGELOG.md
+++ b/extensions/pi-mobile/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-mobile/CHANGELOG.md
+++ b/extensions/pi-mobile/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.4.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-mobile/package.json
+++ b/extensions/pi-mobile/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-mobile/package.json
+++ b/extensions/pi-mobile/package.json
@@ -1,32 +1,32 @@
 {
-	"name": "@e9n/pi-mobile",
-	"version": "0.3.0",
-	"description": "PWA mobile app for Pi agents — mounts on pi-webserver at /mobile",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"devDependencies": {
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"public",
-		"src"
-	]
+  "name": "@e9n/pi-mobile",
+  "version": "0.4.0",
+  "description": "PWA mobile app for Pi agents — mounts on pi-webserver at /mobile",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "public",
+    "src"
+  ]
 }

--- a/extensions/pi-mobile/src/index.ts
+++ b/extensions/pi-mobile/src/index.ts
@@ -25,7 +25,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { ExtensionAPI, SlashCommandInfo } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 
 // ── Static files ─────────────────────────────────────────────
 

--- a/extensions/pi-model-router/CHANGELOG.md
+++ b/extensions/pi-model-router/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-model-router/CHANGELOG.md
+++ b/extensions/pi-model-router/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-model-router/package.json
+++ b/extensions/pi-model-router/package.json
@@ -12,6 +12,10 @@
       "./src/index.ts"
     ]
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"

--- a/extensions/pi-model-router/package.json
+++ b/extensions/pi-model-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-model-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "LLM-classified model routing for pi — automatically selects the right model based on task complexity",
   "keywords": [
     "pi-package"
@@ -17,8 +17,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-ai": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*"
   },
   "files": [
     "CHANGELOG.md",

--- a/extensions/pi-model-router/src/classifier.ts
+++ b/extensions/pi-model-router/src/classifier.ts
@@ -8,8 +8,8 @@
  * Supports OpenAI-compatible and Anthropic API formats.
  */
 
-import type { Api, Model } from "@mariozechner/pi-ai";
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { ClassifierSettings, Tier } from "./settings.ts";
 import { findModel } from "./match.ts";
 

--- a/extensions/pi-model-router/src/index.ts
+++ b/extensions/pi-model-router/src/index.ts
@@ -16,7 +16,7 @@
  *   - TUI (ctx.hasUI):    configurable — off / suggest / auto
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings, type InteractiveMode, type RouterSettings, type Tier } from "./settings.ts";
 import { matchOverride } from "./rules.ts";
 import { ClassificationCache } from "./cache.ts";

--- a/extensions/pi-model-router/src/match.ts
+++ b/extensions/pi-model-router/src/match.ts
@@ -12,8 +12,8 @@
  * 4. Partial match on model name — prefer shorter names
  */
 
-import type { Api, Model } from "@mariozechner/pi-ai";
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 export function findModel(
 	pattern: string,

--- a/extensions/pi-model-router/src/resolver.ts
+++ b/extensions/pi-model-router/src/resolver.ts
@@ -5,8 +5,8 @@
  * from pi's model registry. Delegates to shared fuzzy matching.
  */
 
-import type { Api, Model } from "@mariozechner/pi-ai";
-import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { TierTarget } from "./settings.ts";
 import { findModel } from "./match.ts";
 

--- a/extensions/pi-model-router/src/settings.ts
+++ b/extensions/pi-model-router/src/settings.ts
@@ -2,7 +2,7 @@
  * pi-model-router — Settings loader.
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 // ── Types ───────────────────────────────────────────────────────
 

--- a/extensions/pi-myfinance/CHANGELOG.md
+++ b/extensions/pi-myfinance/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-myfinance/CHANGELOG.md
+++ b/extensions/pi-myfinance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-myfinance/package.json
+++ b/extensions/pi-myfinance/package.json
@@ -1,49 +1,49 @@
 {
-	"name": "@e9n/pi-myfinance",
-	"version": "0.1.0",
-	"description": "Personal finance extension for pi — accounts, transactions, budgets, and reports",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"exports": {
-		".": "./src/index.ts"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit",
-		"test": "tsx src/test-db.ts"
-	},
-	"dependencies": {
-		"better-sqlite3": "^11.8.1",
-		"read-excel-file": "^6.0.3"
-	},
-	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.13",
-		"tsx": "^4.19.3",
-		"typescript": "^5.7.3"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"typebox": "^1.1.24",
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"license": "MIT",
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"finance.html",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-myfinance"
-	}
+  "name": "@e9n/pi-myfinance",
+  "version": "0.2.0",
+  "description": "Personal finance extension for pi — accounts, transactions, budgets, and reports",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsx src/test-db.ts"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.8.1",
+    "read-excel-file": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "tsx": "^4.19.3",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "typebox": "^1.1.24",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "license": "MIT",
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "finance.html",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-myfinance"
+  }
 }

--- a/extensions/pi-myfinance/src/index.ts
+++ b/extensions/pi-myfinance/src/index.ts
@@ -12,8 +12,8 @@
  *   "pi-myfinance": { "useKysely": true }           // pi-kysely shared DB
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { closeDb } from "./db.ts";
 import { getFinanceStore, setFinanceStore, isStoreReady, createSqliteStore, createKyselyStore } from "./store.ts";
 import { registerFinanceTool, setToolLogger } from "./tool.ts";

--- a/extensions/pi-myfinance/src/logger.ts
+++ b/extensions/pi-myfinance/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "finance";
 

--- a/extensions/pi-myfinance/src/tool.ts
+++ b/extensions/pi-myfinance/src/tool.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { getFinanceStore } from "./store.ts";
 import { generateInsights, analyzeTrends, autoCategorize } from "./insights.ts";
 import { importBankFile, importBankDirectory } from "./import-bank.ts";

--- a/extensions/pi-npm/CHANGELOG.md
+++ b/extensions/pi-npm/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-npm/CHANGELOG.md
+++ b/extensions/pi-npm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-npm/package.json
+++ b/extensions/pi-npm/package.json
@@ -12,6 +12,10 @@
       "./src/index.ts"
     ]
   },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0"

--- a/extensions/pi-npm/package.json
+++ b/extensions/pi-npm/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@e9n/pi-npm",
-	"version": "0.1.0",
-	"description": "npm workflow extension for pi — run common npm commands including publish and version",
-	"keywords": [
-		"pi-package"
-	],
-	"license": "MIT",
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"devDependencies": {
-		"@types/node": "^22.0.0",
-		"typescript": "^5.0.0"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*",
-		"@mariozechner/pi-ai": "*",
-		"typebox": "^1.1.24"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-npm"
-	}
+  "name": "@e9n/pi-npm",
+  "version": "0.2.0",
+  "description": "npm workflow extension for pi — run common npm commands including publish and version",
+  "keywords": [
+    "pi-package"
+  ],
+  "license": "MIT",
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "typebox": "^1.1.24"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-npm"
+  }
 }

--- a/extensions/pi-npm/src/index.ts
+++ b/extensions/pi-npm/src/index.ts
@@ -11,9 +11,9 @@
  * An optional `path` parameter lets you target a different directory.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { createLogger } from "./logger.ts";

--- a/extensions/pi-npm/src/logger.ts
+++ b/extensions/pi-npm/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "npm";
 

--- a/extensions/pi-openrouter/CHANGELOG.md
+++ b/extensions/pi-openrouter/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-openrouter/CHANGELOG.md
+++ b/extensions/pi-openrouter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-openrouter/package.json
+++ b/extensions/pi-openrouter/package.json
@@ -24,7 +24,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/extensions/pi-openrouter/package.json
+++ b/extensions/pi-openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-openrouter",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "OpenRouter provider with OAuth PKCE and dynamic model filtering",
   "type": "module",
   "license": "MIT",
@@ -27,8 +27,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-openrouter/src/index.ts
+++ b/extensions/pi-openrouter/src/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { login, refreshToken, getApiKey } from "./oauth.ts";
 import { loadCache, saveCache, fetchModels, filterModels, toProviderModel } from "./models.ts";
 import { resolveSettings, type OpenRouterSettings } from "./settings.ts";

--- a/extensions/pi-openrouter/src/models.ts
+++ b/extensions/pi-openrouter/src/models.ts
@@ -1,4 +1,4 @@
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import * as fs from "node:fs";
 import * as path from "node:path";
 

--- a/extensions/pi-openrouter/src/oauth.ts
+++ b/extensions/pi-openrouter/src/oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 
 const OPENROUTER_AUTH_URL = "https://openrouter.ai/auth";
 const OPENROUTER_KEYS_URL = "https://openrouter.ai/api/v1/auth/keys";

--- a/extensions/pi-openrouter/src/settings.ts
+++ b/extensions/pi-openrouter/src/settings.ts
@@ -1,4 +1,4 @@
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface OpenRouterSettings {
 	/** Glob patterns for model IDs to include. Default: ["*"] (all models). */

--- a/extensions/pi-penpot/CHANGELOG.md
+++ b/extensions/pi-penpot/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+

--- a/extensions/pi-penpot/CHANGELOG.md
+++ b/extensions/pi-penpot/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 

--- a/extensions/pi-penpot/package.json
+++ b/extensions/pi-penpot/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/extensions/pi-penpot/package.json
+++ b/extensions/pi-penpot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-penpot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Penpot design tool integration for pi — projects, files, pages, shapes, comments, and more",
   "type": "module",
   "keywords": [
@@ -15,8 +15,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-penpot/src/index.ts
+++ b/extensions/pi-penpot/src/index.ts
@@ -13,7 +13,7 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings } from "./settings.ts";
 import { initClient, resetClient, isClientReady } from "./client.ts";
 import { registerPenpotTool } from "./tools/penpot.ts";

--- a/extensions/pi-penpot/src/settings.ts
+++ b/extensions/pi-penpot/src/settings.ts
@@ -10,7 +10,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface PenpotSettings {
 	/** Penpot instance URL (e.g. https://penpot.e9n.dev). */

--- a/extensions/pi-penpot/src/tools/penpot-comment.ts
+++ b/extensions/pi-penpot/src/tools/penpot-comment.ts
@@ -4,11 +4,11 @@
  * Handles comment threads, replies, and thread management.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { apiPost, isClientReady } from "../client.ts";
-import { truncateHead, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@mariozechner/pi-coding-agent";
+import { truncateHead, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import type { CommentThread, Comment } from "../types.ts";
 
 const ACTIONS = [

--- a/extensions/pi-penpot/src/tools/penpot-page.ts
+++ b/extensions/pi-penpot/src/tools/penpot-page.ts
@@ -5,11 +5,11 @@
  * and write operations via Penpot's change-based update-file API.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { apiPost, apiPostTransit, isClientReady } from "../client.ts";
-import { truncateHead, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@mariozechner/pi-coding-agent";
+import { truncateHead, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import type {
 	File,
 	PageData,

--- a/extensions/pi-penpot/src/tools/penpot.ts
+++ b/extensions/pi-penpot/src/tools/penpot.ts
@@ -4,11 +4,11 @@
  * Covers the organizational layer of the Penpot API.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { apiGet, apiPost, apiDownload, isClientReady, getEndpoint } from "../client.ts";
-import { truncateHead, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@mariozechner/pi-coding-agent";
+import { truncateHead, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import type {
 	Profile,
 	Team,

--- a/extensions/pi-personal-crm/CHANGELOG.md
+++ b/extensions/pi-personal-crm/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-personal-crm/CHANGELOG.md
+++ b/extensions/pi-personal-crm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-personal-crm/package.json
+++ b/extensions/pi-personal-crm/package.json
@@ -1,45 +1,45 @@
 {
-	"name": "@e9n/pi-personal-crm",
-	"version": "0.2.1",
-	"description": "Personal CRM extension for pi — contacts, companies, interactions, and reminders",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit",
-		"test": "node --import tsx/esm test-db.ts"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24"
-	},
-	"dependencies": {
-		"better-sqlite3": "^12.6.2"
-	},
-	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.12",
-		"tsx": "^4.21.0",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"crm.html",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-personal-crm"
-	}
+  "name": "@e9n/pi-personal-crm",
+  "version": "0.3.0",
+  "description": "Personal CRM extension for pi — contacts, companies, interactions, and reminders",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx/esm test-db.ts"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "crm.html",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-personal-crm"
+  }
 }

--- a/extensions/pi-personal-crm/src/db-kysely.ts
+++ b/extensions/pi-personal-crm/src/db-kysely.ts
@@ -16,7 +16,7 @@
  */
 
 import { readdirSync, readFileSync } from "node:fs";
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import type {
 	Contact,
 	CreateContactData,

--- a/extensions/pi-personal-crm/src/index.ts
+++ b/extensions/pi-personal-crm/src/index.ts
@@ -18,8 +18,8 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/extensions/pi-personal-crm/src/logger.ts
+++ b/extensions/pi-personal-crm/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "crm";
 

--- a/extensions/pi-personal-crm/src/tool.ts
+++ b/extensions/pi-personal-crm/src/tool.ts
@@ -5,7 +5,7 @@
  */
 
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { getCrmStore } from "./store.ts";
 
 /** Sanitize a URL: only allow http(s). Returns cleaned URL or undefined. */
@@ -18,7 +18,7 @@ function sanitizeUrl(value: unknown): string | undefined {
 	throw new Error("Invalid URL protocol — only http and https are allowed");
 }
 
-// Note: ExtensionAPI is from @mariozechner/pi-coding-agent
+// Note: ExtensionAPI is from @earendil-works/pi-coding-agent
 // We define minimal interface here to avoid hard dependency
 interface ExtensionAPI {
 	registerTool(tool: any): void;

--- a/extensions/pi-prism/CHANGELOG.md
+++ b/extensions/pi-prism/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-prism/CHANGELOG.md
+++ b/extensions/pi-prism/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-prism/package.json
+++ b/extensions/pi-prism/package.json
@@ -1,46 +1,46 @@
 {
-	"name": "@e9n/pi-prism",
-	"version": "0.1.0",
-	"description": "Configurable widget sidebar overlay for pi — operational dashboard in the TUI",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-prism"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": ">=0.65.2",
-		"@mariozechner/pi-tui": ">=0.65.2",
-		"typebox": "^1.1.24"
-	},
-	"dependencies": {
-		"luxon": "^3.7.2"
-	},
-	"devDependencies": {
-		"@mariozechner/pi-coding-agent": ">=0.65.2",
-		"@mariozechner/pi-tui": ">=0.65.2",
-		"typebox": "^1.1.24",
-		"@types/luxon": "^3.7.1",
-		"luxon": "^3.6.1",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	]
+  "name": "@e9n/pi-prism",
+  "version": "0.2.0",
+  "description": "Configurable widget sidebar overlay for pi — operational dashboard in the TUI",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-prism"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.65.2",
+    "@earendil-works/pi-tui": ">=0.65.2",
+    "typebox": "^1.1.24"
+  },
+  "dependencies": {
+    "luxon": "^3.7.2"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.65.2",
+    "@earendil-works/pi-tui": ">=0.65.2",
+    "typebox": "^1.1.24",
+    "@types/luxon": "^3.7.1",
+    "luxon": "^3.6.1",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-prism/package.json
+++ b/extensions/pi-prism/package.json
@@ -17,7 +17,8 @@
     "directory": "extensions/pi-prism"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-prism/src/helpers.ts
+++ b/extensions/pi-prism/src/helpers.ts
@@ -2,8 +2,8 @@
  * Shared helpers for pi-prism widgets.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { DateTime } from "luxon";
 
 // ── Types ────────────────────────────────────────────────────

--- a/extensions/pi-prism/src/index.ts
+++ b/extensions/pi-prism/src/index.ts
@@ -12,9 +12,9 @@
  *   recent-ops, system-health, reminders, recent-contacts, session-stats, clock
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import type { OverlayHandle, TUI } from "@mariozechner/pi-tui";
-import { Key } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { OverlayHandle, TUI } from "@earendil-works/pi-tui";
+import { Key } from "@earendil-works/pi-tui";
 import { resolveSettings, type PrismSettings } from "./settings.ts";
 import { WidgetSidebar } from "./sidebar.ts";
 import { WIDGET_FACTORIES, DEFAULT_WIDGETS, type Widget } from "./widgets/index.ts";

--- a/extensions/pi-prism/src/settings.ts
+++ b/extensions/pi-prism/src/settings.ts
@@ -2,7 +2,7 @@
  * Settings loader for pi-prism.
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface PrismSettings {
 	/** Widget IDs to show (order matters). */

--- a/extensions/pi-prism/src/sidebar.ts
+++ b/extensions/pi-prism/src/sidebar.ts
@@ -5,9 +5,9 @@
  * refresh, and keyboard input.
  */
 
-import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
-import type { TUI } from "@mariozechner/pi-tui";
-import { matchesKey, truncateToWidth, visibleWidth, Key } from "@mariozechner/pi-tui";
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import type { TUI } from "@earendil-works/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth, Key } from "@earendil-works/pi-tui";
 import { createQuery, fmtAgo, type Q } from "./helpers.ts";
 import { resolveSettings } from "./settings.ts";
 import type { Widget, WidgetContext } from "./widgets/index.ts";

--- a/extensions/pi-prism/src/widgets/active-task.ts
+++ b/extensions/pi-prism/src/widgets/active-task.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { hubRpc, type HubTask } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/clock.ts
+++ b/extensions/pi-prism/src/widgets/clock.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { Widget, WidgetContext } from "./index.ts";
 
 export class ClockWidget implements Widget {

--- a/extensions/pi-prism/src/widgets/git-status.ts
+++ b/extensions/pi-prism/src/widgets/git-status.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { execCmd } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/index.ts
+++ b/extensions/pi-prism/src/widgets/index.ts
@@ -2,7 +2,7 @@
  * Widget registry — all available widgets and their factories.
  */
 
-import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { Q } from "../helpers.ts";
 
 // ── Widget interface ─────────────────────────────────────────

--- a/extensions/pi-prism/src/widgets/recent-contacts.ts
+++ b/extensions/pi-prism/src/widgets/recent-contacts.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { fmtDate } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/recent-ops.ts
+++ b/extensions/pi-prism/src/widgets/recent-ops.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { fmtTime } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/reminders.ts
+++ b/extensions/pi-prism/src/widgets/reminders.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { fmtDate, todayIso, daysAheadIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/session-stats.ts
+++ b/extensions/pi-prism/src/widgets/session-stats.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { todayIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/system-health.ts
+++ b/extensions/pi-prism/src/widgets/system-health.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { execCmd, hubRpc, pad } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/task-queue.ts
+++ b/extensions/pi-prism/src/widgets/task-queue.ts
@@ -1,5 +1,5 @@
-import type { Theme, ThemeColor } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { hubRpc, type HubTask } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/today-calendar.ts
+++ b/extensions/pi-prism/src/widgets/today-calendar.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { fmtTime, todayIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-prism/src/widgets/week-calendar.ts
+++ b/extensions/pi-prism/src/widgets/week-calendar.ts
@@ -1,5 +1,5 @@
-import type { Theme } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { fmtDate, fmtTime, todayIso, daysAheadIso } from "../helpers.ts";
 import type { Widget, WidgetContext } from "./index.ts";
 

--- a/extensions/pi-projects/CHANGELOG.md
+++ b/extensions/pi-projects/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-projects/CHANGELOG.md
+++ b/extensions/pi-projects/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-projects/package.json
+++ b/extensions/pi-projects/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-projects/package.json
+++ b/extensions/pi-projects/package.json
@@ -1,46 +1,46 @@
 {
-	"name": "@e9n/pi-projects",
-	"version": "0.1.1",
-	"description": "Project tracking extension for pi — auto-discovers git repos with health status dashboard",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		],
-		"skills": [
-			"./skills"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24"
-	},
-	"dependencies": {
-		"better-sqlite3": "^12.6.2"
-	},
-	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.12",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"skills",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-projects"
-	}
+  "name": "@e9n/pi-projects",
+  "version": "0.2.0",
+  "description": "Project tracking extension for pi — auto-discovers git repos with health status dashboard",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "skills",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-projects"
+  }
 }

--- a/extensions/pi-projects/src/db-kysely.ts
+++ b/extensions/pi-projects/src/db-kysely.ts
@@ -13,7 +13,7 @@
  */
 
 import { readdirSync, readFileSync } from "node:fs";
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import type { ProjectSourceRecord, ProjectHiddenRecord } from "./db.ts";
 
 const ACTOR = "pi-projects";

--- a/extensions/pi-projects/src/index.ts
+++ b/extensions/pi-projects/src/index.ts
@@ -25,8 +25,8 @@
  */
 
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { resolveSettings } from "./settings.ts";
 import { closeProjectsDb } from "./db.ts";

--- a/extensions/pi-projects/src/logger.ts
+++ b/extensions/pi-projects/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "projects";
 

--- a/extensions/pi-projects/src/settings.ts
+++ b/extensions/pi-projects/src/settings.ts
@@ -4,7 +4,7 @@
 
 import * as os from "node:os";
 import * as path from "node:path";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface ProjectsSettings {
 	devDir: string;

--- a/extensions/pi-projects/src/tool.ts
+++ b/extensions/pi-projects/src/tool.ts
@@ -2,9 +2,9 @@
  * pi-projects — LLM tool for managing projects.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { scanProjects, type ProjectInfo } from "./scanner.ts";
 import { getProjectsStore } from "./store.ts";
 

--- a/extensions/pi-subagent/CHANGELOG.md
+++ b/extensions/pi-subagent/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-subagent/CHANGELOG.md
+++ b/extensions/pi-subagent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-subagent/package.json
+++ b/extensions/pi-subagent/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-subagent/package.json
+++ b/extensions/pi-subagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-subagent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Parallel task delegation for pi — spawn isolated subagents for single, parallel, and chain execution",
   "type": "module",
   "keywords": [
@@ -20,11 +20,11 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24",
-    "@mariozechner/pi-agent-core": "*",
-    "@mariozechner/pi-tui": "*"
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-subagent/shim/index.ts
+++ b/extensions/pi-subagent/shim/index.ts
@@ -10,7 +10,7 @@
  *   PI_POOL_AGENT_ID — This agent's ID in the pool
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import * as http from "node:http";
 

--- a/extensions/pi-subagent/src/agents.ts
+++ b/extensions/pi-subagent/src/agents.ts
@@ -18,7 +18,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { parseFrontmatter } from "@mariozechner/pi-coding-agent";
+import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig, AgentScope } from "./types.ts";
 
 export interface AgentDiscoveryResult {

--- a/extensions/pi-subagent/src/index.ts
+++ b/extensions/pi-subagent/src/index.ts
@@ -25,7 +25,7 @@
  *   - subagent:complete { agent, trackingId, status, tokens, cost, durationMs }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerSubagentTool, disposePool } from "./tool.ts";
 import { resolveSettings } from "./settings.ts";
 import { discoverAgents } from "./agents.ts";

--- a/extensions/pi-subagent/src/logger.ts
+++ b/extensions/pi-subagent/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "subagent";
 

--- a/extensions/pi-subagent/src/tool.ts
+++ b/extensions/pi-subagent/src/tool.ts
@@ -12,12 +12,12 @@
  *   - renderCall / renderResult for TUI display
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getMarkdownTheme } from "@mariozechner/pi-coding-agent";
-import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getMarkdownTheme } from "@earendil-works/pi-coding-agent";
+import { Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
-import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { runIsolatedAgent } from "./runner.ts";
 import { discoverAgents } from "./agents.ts";
 import { oneShotTracker } from "./tracker.ts";

--- a/extensions/pi-supabase/CHANGELOG.md
+++ b/extensions/pi-supabase/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-supabase/CHANGELOG.md
+++ b/extensions/pi-supabase/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-supabase/package.json
+++ b/extensions/pi-supabase/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/extensions/pi-supabase/package.json
+++ b/extensions/pi-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-supabase",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Supabase integration for pi — read-only queries, table subscriptions, and pi-channels notifications",
   "type": "module",
   "keywords": [
@@ -15,8 +15,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-supabase/src/index.ts
+++ b/extensions/pi-supabase/src/index.ts
@@ -19,7 +19,7 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings } from "./settings.ts";
 import { initClient, resetClient, isClientReady, getClient } from "./client.ts";
 import { registerSupabaseTool, setRpcAllowList } from "./tool.ts";

--- a/extensions/pi-supabase/src/logger.ts
+++ b/extensions/pi-supabase/src/logger.ts
@@ -2,7 +2,7 @@
  * pi-supabase — Logger via pi-logger event bus.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 type LogFn = (event: string, data: unknown, level?: string) => void;
 

--- a/extensions/pi-supabase/src/settings.ts
+++ b/extensions/pi-supabase/src/settings.ts
@@ -18,7 +18,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface NotificationSettings {
 	/** Enable pi-channels notifications for table changes (default: false). */

--- a/extensions/pi-supabase/src/tool.ts
+++ b/extensions/pi-supabase/src/tool.ts
@@ -10,9 +10,9 @@
  *   - status:    Show connection status and subscription info
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { getClient, isClientReady } from "./client.ts";
 import { isStoreReady, getStore } from "./store.ts";
 

--- a/extensions/pi-td-hub/CHANGELOG.md
+++ b/extensions/pi-td-hub/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+

--- a/extensions/pi-td-hub/CHANGELOG.md
+++ b/extensions/pi-td-hub/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 

--- a/extensions/pi-td-hub/package.json
+++ b/extensions/pi-td-hub/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-td-hub/package.json
+++ b/extensions/pi-td-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-td-hub",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cross-project task aggregator — reads td databases across ~/Dev for PM coordination",
   "type": "module",
   "keywords": [
@@ -17,7 +17,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "dependencies": {
     "typebox": "^1.1.24",

--- a/extensions/pi-td-hub/src/index.ts
+++ b/extensions/pi-td-hub/src/index.ts
@@ -21,8 +21,8 @@ import { join, basename, resolve } from "node:path";
 import { homedir } from "node:os";
 import Database from "better-sqlite3";
 import { Type } from "typebox";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 // ── Types ────────────────────────────────────────────────────
 

--- a/extensions/pi-td/CHANGELOG.md
+++ b/extensions/pi-td/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-td/CHANGELOG.md
+++ b/extensions/pi-td/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-td/package.json
+++ b/extensions/pi-td/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/extensions/pi-td/package.json
+++ b/extensions/pi-td/package.json
@@ -1,42 +1,42 @@
 {
-	"name": "@e9n/pi-td",
-	"version": "0.2.1",
-	"description": "Task management extension for pi — issues, sessions, handoffs, and web dashboard",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*",
-		"@mariozechner/pi-ai": "*",
-		"typebox": "^1.1.24"
-	},
-	"dependencies": {
-		"better-sqlite3": "^11.10.0"
-	},
-	"devDependencies": {
-		"@types/better-sqlite3": "^7.6.12",
-		"typescript": "^5.9.3"
-	},
-	"license": "MIT",
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-td"
-	}
+  "name": "@e9n/pi-td",
+  "version": "0.3.0",
+  "description": "Task management extension for pi — issues, sessions, handoffs, and web dashboard",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "typebox": "^1.1.24"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.10.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "typescript": "^5.9.3"
+  },
+  "license": "MIT",
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-td"
+  }
 }

--- a/extensions/pi-td/src/index.ts
+++ b/extensions/pi-td/src/index.ts
@@ -8,7 +8,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { badRequest, html, json, notFound, readBody, serverError } from "./http-helpers.ts";
 import { getAllProjectIssues, getCrossProjectStats, getProjectTree } from "./cross-project.ts";
 import { getCrossProjectConfig, loadTdSettings } from "./td-settings.ts";

--- a/extensions/pi-td/src/td-settings.ts
+++ b/extensions/pi-td/src/td-settings.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import { SettingsManager, getAgentDir } from "@mariozechner/pi-coding-agent";
+import { SettingsManager, getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export interface CrossProjectConfig {
 	rootDir: string;

--- a/extensions/pi-td/src/tool.ts
+++ b/extensions/pi-td/src/tool.ts
@@ -8,8 +8,8 @@
  */
 
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const text = (s: string) => ({ content: [{ type: "text" as const, text: s }], details: {} });
 

--- a/extensions/pi-telemetry/CHANGELOG.md
+++ b/extensions/pi-telemetry/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [1.1.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-telemetry/CHANGELOG.md
+++ b/extensions/pi-telemetry/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-telemetry/package.json
+++ b/extensions/pi-telemetry/package.json
@@ -1,35 +1,35 @@
 {
-	"name": "@e9n/pi-telemetry",
-	"license": "MIT",
-	"version": "1.0.1",
-	"type": "module",
-	"scripts": {
-		"clean": "echo 'nothing to clean'",
-		"build": "echo 'nothing to build'",
-		"check": "echo 'nothing to check'"
-	},
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"keywords": [
-		"pi-package"
-	],
-	"description": "Local telemetry extension for pi — captures session events and writes to disk",
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-telemetry"
-	}
+  "name": "@e9n/pi-telemetry",
+  "license": "MIT",
+  "version": "1.1.0",
+  "type": "module",
+  "scripts": {
+    "clean": "echo 'nothing to clean'",
+    "build": "echo 'nothing to build'",
+    "check": "echo 'nothing to check'"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "keywords": [
+    "pi-package"
+  ],
+  "description": "Local telemetry extension for pi — captures session events and writes to disk",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-telemetry"
+  }
 }

--- a/extensions/pi-telemetry/package.json
+++ b/extensions/pi-telemetry/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "clean": "echo 'nothing to clean'",
     "build": "echo 'nothing to build'",
-    "check": "echo 'nothing to check'"
+    "check": "echo 'nothing to check'",
+    "test": "node --test"
   },
   "pi": {
     "extensions": [

--- a/extensions/pi-telemetry/src/index.ts
+++ b/extensions/pi-telemetry/src/index.ts
@@ -13,8 +13,8 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, VERSION } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, VERSION } from "@earendil-works/pi-coding-agent";
 import { type TelemetryConfig, defaultTelemetryConfig, shouldLog } from "./config.js";
 import type { TelemetryEvent, TelemetryLevel } from "./types.js";
 import { writeTelemetryEvent } from "./writer.js";

--- a/extensions/pi-telemetry/src/writer.ts
+++ b/extensions/pi-telemetry/src/writer.ts
@@ -1,4 +1,4 @@
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { TelemetryEvent } from "./types.js";

--- a/extensions/pi-todoist/CHANGELOG.md
+++ b/extensions/pi-todoist/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+

--- a/extensions/pi-todoist/CHANGELOG.md
+++ b/extensions/pi-todoist/CHANGELOG.md
@@ -3,5 +3,6 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 

--- a/extensions/pi-todoist/package.json
+++ b/extensions/pi-todoist/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/extensions/pi-todoist/package.json
+++ b/extensions/pi-todoist/package.json
@@ -1,18 +1,22 @@
 {
   "name": "@e9n/pi-todoist",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Todoist task management integration for pi — tasks, projects, sections, labels, and comments",
   "type": "module",
-  "keywords": ["pi-package"],
+  "keywords": [
+    "pi-package"
+  ],
   "pi": {
-    "extensions": ["./src/index.ts"]
+    "extensions": [
+      "./src/index.ts"
+    ]
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "dependencies": {
@@ -23,7 +27,11 @@
   },
   "license": "MIT",
   "author": "Espen Nilsen <hi@e9n.dev>",
-  "files": ["README.md", "package.json", "src"],
+  "files": [
+    "README.md",
+    "package.json",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/espennilsen/pi.git",

--- a/extensions/pi-todoist/src/index.ts
+++ b/extensions/pi-todoist/src/index.ts
@@ -14,7 +14,7 @@
  *   }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveSettings } from "./settings.ts";
 import { initClient, resetClient } from "./client.ts";
 import { registerTasksTool } from "./tools/todoist-tasks.ts";

--- a/extensions/pi-todoist/src/settings.ts
+++ b/extensions/pi-todoist/src/settings.ts
@@ -9,7 +9,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface TodoistSettings {
 	/** Todoist API token. */

--- a/extensions/pi-todoist/src/tools/todoist-comments.ts
+++ b/extensions/pi-todoist/src/tools/todoist-comments.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { getClient, isClientReady } from "../client.ts";
 import type { Comment } from "@doist/todoist-api-typescript";

--- a/extensions/pi-todoist/src/tools/todoist-labels.ts
+++ b/extensions/pi-todoist/src/tools/todoist-labels.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { getClient, isClientReady } from "../client.ts";
 import type { Label } from "@doist/todoist-api-typescript";

--- a/extensions/pi-todoist/src/tools/todoist-projects.ts
+++ b/extensions/pi-todoist/src/tools/todoist-projects.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { getClient, isClientReady } from "../client.ts";
 import type { PersonalProject, WorkspaceProject } from "@doist/todoist-api-typescript";

--- a/extensions/pi-todoist/src/tools/todoist-sections.ts
+++ b/extensions/pi-todoist/src/tools/todoist-sections.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { getClient, isClientReady } from "../client.ts";
 import type { Section } from "@doist/todoist-api-typescript";

--- a/extensions/pi-todoist/src/tools/todoist-tasks.ts
+++ b/extensions/pi-todoist/src/tools/todoist-tasks.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { getClient, isClientReady } from "../client.ts";
 import type { Task } from "@doist/todoist-api-typescript";

--- a/extensions/pi-tts/CHANGELOG.md
+++ b/extensions/pi-tts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

--- a/extensions/pi-tts/CHANGELOG.md
+++ b/extensions/pi-tts/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-tts/package.json
+++ b/extensions/pi-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-tts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit"
@@ -9,8 +9,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
     "typebox": "^1.1.24"
   },
   "license": "MIT",

--- a/extensions/pi-tts/package.json
+++ b/extensions/pi-tts/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.0",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-tts/src/index.ts
+++ b/extensions/pi-tts/src/index.ts
@@ -21,7 +21,7 @@
  *   }
  */
 
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { registerTtsTool } from "./tool.ts";
 import { resolveSettings } from "./settings.ts";

--- a/extensions/pi-tts/src/logger.ts
+++ b/extensions/pi-tts/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "tts";
 

--- a/extensions/pi-tts/src/settings.ts
+++ b/extensions/pi-tts/src/settings.ts
@@ -10,7 +10,7 @@
  * }
  */
 
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 export interface TtsSettings {
 	/** TTS server base URL (default: "http://192.168.0.27:8001"). */

--- a/extensions/pi-tts/src/tool.ts
+++ b/extensions/pi-tts/src/tool.ts
@@ -5,9 +5,9 @@
  * Returns a file path to the generated WAV audio.
  */
 
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { Text } from "@mariozechner/pi-tui";
+import { Text } from "@earendil-works/pi-tui";
 import { generateAudio, type TtsResult } from "./tts-client.ts";
 import { resolveVoicePath, getAvailableVoices } from "./voices.ts";
 

--- a/extensions/pi-untappd/CHANGELOG.md
+++ b/extensions/pi-untappd/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to pi-untappd will be documented in this file.
 

--- a/extensions/pi-untappd/CHANGELOG.md
+++ b/extensions/pi-untappd/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to pi-untappd will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/extensions/pi-untappd/package.json
+++ b/extensions/pi-untappd/package.json
@@ -24,7 +24,8 @@
     "directory": "extensions/pi-untappd"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-untappd/package.json
+++ b/extensions/pi-untappd/package.json
@@ -1,47 +1,47 @@
 {
-	"name": "@e9n/pi-untappd",
-	"version": "0.1.0",
-	"description": "Untappd venue, user, and brewery monitoring with RSS polling and menu tracking",
-	"type": "module",
-	"keywords": [
-		"pi-package",
-		"pi-extension",
-		"untappd",
-		"beer",
-		"rss"
-	],
-	"exports": {
-		".": "./src/index.ts"
-	},
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-untappd"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"dependencies": {
-		"rss-parser": "^3.13.0"
-	},
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"devDependencies": {
-		"@types/node": "^24.3.0",
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	]
+  "name": "@e9n/pi-untappd",
+  "version": "0.2.0",
+  "description": "Untappd venue, user, and brewery monitoring with RSS polling and menu tracking",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "untappd",
+    "beer",
+    "rss"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-untappd"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "dependencies": {
+    "rss-parser": "^3.13.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-untappd/src/db/init.ts
+++ b/extensions/pi-untappd/src/db/init.ts
@@ -11,7 +11,7 @@
  * Requires pi-kysely extension to be loaded.
  */
 
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import { SCHEMA } from "./schema.ts";
 
 const ACTOR = "pi-untappd";

--- a/extensions/pi-untappd/src/index.ts
+++ b/extensions/pi-untappd/src/index.ts
@@ -14,7 +14,7 @@
  *   - pi-cron: scheduled RSS polling (configured via crontab, see README)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { initDb } from "./db/init.ts";
 import { mountWebRoutes, unmountWebRoutes } from "./web/index.ts";

--- a/extensions/pi-untappd/src/logger.ts
+++ b/extensions/pi-untappd/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export type LogFn = (event: string, data: unknown, level?: string) => void;
 

--- a/extensions/pi-untappd/src/web/index.ts
+++ b/extensions/pi-untappd/src/web/index.ts
@@ -2,7 +2,7 @@
  * Web interface and API for pi-untappd.
  */
 
-import type { EventBus } from "@mariozechner/pi-coding-agent";
+import type { EventBus } from "@earendil-works/pi-coding-agent";
 import type { LogFn } from "../logger.ts";
 import * as http from "node:http";
 

--- a/extensions/pi-vault/CHANGELOG.md
+++ b/extensions/pi-vault/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-vault/CHANGELOG.md
+++ b/extensions/pi-vault/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-vault/package.json
+++ b/extensions/pi-vault/package.json
@@ -1,38 +1,38 @@
 {
-	"name": "@e9n/pi-vault",
-	"version": "0.1.0",
-	"description": "Obsidian vault extension for pi — read, write, search notes and health dashboard",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-vault"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-ai": "*",
-		"@mariozechner/pi-coding-agent": "*",
-		"typebox": "^1.1.24"
-	},
-	"devDependencies": {
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"package.json",
-		"src"
-	]
+  "name": "@e9n/pi-vault",
+  "version": "0.2.0",
+  "description": "Obsidian vault extension for pi — read, write, search notes and health dashboard",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-vault"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "^1.1.24"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-vault/package.json
+++ b/extensions/pi-vault/package.json
@@ -17,7 +17,8 @@
     "directory": "extensions/pi-vault"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-vault/src/index.ts
+++ b/extensions/pi-vault/src/index.ts
@@ -19,7 +19,7 @@
  * Requires pi-webserver for the web dashboard. Tool works standalone.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { resolveConfig } from "./api-client.ts";
 import { registerObsidianTool } from "./tool.ts";
 import { mountVaultRoutes, unmountVaultRoutes } from "./web.ts";

--- a/extensions/pi-vault/src/logger.ts
+++ b/extensions/pi-vault/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "vault";
 

--- a/extensions/pi-vault/src/tool.ts
+++ b/extensions/pi-vault/src/tool.ts
@@ -25,9 +25,9 @@
  * Config via settings.json under "pi-vault" (vaultPath, apiUrl, apiKey)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { VaultConfig } from "./api-client.ts";

--- a/extensions/pi-vault/src/web.ts
+++ b/extensions/pi-vault/src/web.ts
@@ -8,7 +8,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { VaultConfig } from "./api-client.ts";
 import { getVaultHealthData } from "./health.ts";
 

--- a/extensions/pi-web-dashboard/CHANGELOG.md
+++ b/extensions/pi-web-dashboard/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-web-dashboard/CHANGELOG.md
+++ b/extensions/pi-web-dashboard/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.4.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-web-dashboard/package.json
+++ b/extensions/pi-web-dashboard/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-web-dashboard/package.json
+++ b/extensions/pi-web-dashboard/package.json
@@ -1,37 +1,37 @@
 {
-	"name": "@e9n/pi-web-dashboard",
-	"version": "0.3.0",
-	"description": "Live agent dashboard for pi — SSE streaming, session view, and prompt submission",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"devDependencies": {
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"dashboard.html",
-		"package.json",
-		"src"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-web-dashboard"
-	}
+  "name": "@e9n/pi-web-dashboard",
+  "version": "0.4.0",
+  "description": "Live agent dashboard for pi — SSE streaming, session view, and prompt submission",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dashboard.html",
+    "package.json",
+    "src"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-web-dashboard"
+  }
 }

--- a/extensions/pi-web-dashboard/src/index.ts
+++ b/extensions/pi-web-dashboard/src/index.ts
@@ -21,7 +21,7 @@
  *   tool_end      — { type, toolName, toolCallId, isError, content }
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { mountDashboard, unmountDashboard, broadcast, setAbortFn } from "./web.ts";
 import { createLogger } from "./logger.ts";
 

--- a/extensions/pi-web-dashboard/src/logger.ts
+++ b/extensions/pi-web-dashboard/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "dashboard";
 

--- a/extensions/pi-web-dashboard/src/web.ts
+++ b/extensions/pi-web-dashboard/src/web.ts
@@ -12,7 +12,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { ExtensionAPI, SlashCommandInfo } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, SlashCommandInfo } from "@earendil-works/pi-coding-agent";
 
 // ── SSE state ───────────────────────────────────────────────────
 

--- a/extensions/pi-webnav/CHANGELOG.md
+++ b/extensions/pi-webnav/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-webnav/CHANGELOG.md
+++ b/extensions/pi-webnav/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-webnav/package.json
+++ b/extensions/pi-webnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-webnav",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Unified navigation shell for pi-webserver — wraps all mounts in a shared nav layout with iframe routing",
   "type": "module",
   "keywords": [
@@ -17,7 +17,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-webnav/package.json
+++ b/extensions/pi-webnav/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-webnav/src/index.ts
+++ b/extensions/pi-webnav/src/index.ts
@@ -18,7 +18,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 
 const NAV_HTML = fs.readFileSync(

--- a/extensions/pi-webnav/src/logger.ts
+++ b/extensions/pi-webnav/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "webnav";
 

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.3.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-webserver/package.json
+++ b/extensions/pi-webserver/package.json
@@ -17,7 +17,8 @@
     "directory": "extensions/pi-webserver"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-webserver/package.json
+++ b/extensions/pi-webserver/package.json
@@ -1,37 +1,37 @@
 {
-	"name": "@e9n/pi-webserver",
-	"version": "0.2.0",
-	"description": "Shared HTTP server for pi — authenticated web host with extension mount points",
-	"type": "module",
-	"keywords": [
-		"pi-package"
-	],
-	"pi": {
-		"extensions": [
-			"./src/index.ts"
-		]
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/espennilsen/pi.git",
-		"directory": "extensions/pi-webserver"
-	},
-	"scripts": {
-		"typecheck": "tsc --noEmit"
-	},
-	"author": "Espen Nilsen <hi@e9n.dev>",
-	"license": "MIT",
-	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "*"
-	},
-	"devDependencies": {
-		"typescript": "^5.9.3"
-	},
-	"files": [
-		"CHANGELOG.md",
-		"README.md",
-		"dashboard.html",
-		"package.json",
-		"src"
-	]
+  "name": "@e9n/pi-webserver",
+  "version": "0.3.0",
+  "description": "Shared HTTP server for pi — authenticated web host with extension mount points",
+  "type": "module",
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/espennilsen/pi.git",
+    "directory": "extensions/pi-webserver"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "Espen Nilsen <hi@e9n.dev>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "README.md",
+    "dashboard.html",
+    "package.json",
+    "src"
+  ]
 }

--- a/extensions/pi-webserver/src/index.ts
+++ b/extensions/pi-webserver/src/index.ts
@@ -9,8 +9,8 @@
  *   2. Event bus:      pi.events.emit("web:mount", config)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { getAgentDir, SettingsManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { start, stop, mount, unmount, mountApi, unmountApi, isRunning, getUrl, getPort, getMounts, getApiMounts, setAuth, getAuth, setApiToken, setApiReadToken, getApiTokenStatus, setLogger } from "./server.ts";
 import { createLogger } from "./logger.ts";
 import type { MountConfig } from "./server.ts";

--- a/extensions/pi-webserver/src/logger.ts
+++ b/extensions/pi-webserver/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "webserver";
 

--- a/extensions/pi-workon/CHANGELOG.md
+++ b/extensions/pi-workon/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.2.0] - 2026-05-08
 
 ### Changed
-- Migrated from @mariozechner/* to @earendil-works/* package scope
+
+- Migrated from `@mariozechner/*` to `@earendil-works/*` package scope
 
 All notable changes to this project will be documented in this file.
 

--- a/extensions/pi-workon/CHANGELOG.md
+++ b/extensions/pi-workon/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-05-08
+
+### Changed
+- Migrated from @mariozechner/* to @earendil-works/* package scope
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/),

--- a/extensions/pi-workon/package.json
+++ b/extensions/pi-workon/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test"
   },
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",

--- a/extensions/pi-workon/package.json
+++ b/extensions/pi-workon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-workon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Project context switching and initialization for pi — switch projects, detect stacks, scaffold AGENTS.md",
   "type": "module",
   "keywords": [
@@ -20,8 +20,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-workon/src/index.ts
+++ b/extensions/pi-workon/src/index.ts
@@ -22,7 +22,7 @@
  * Defaults to ~/Dev if nothing is configured.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerWorkonTool, registerProjectInitTool } from "./tool.ts";
 import { resolveSettings } from "./settings.ts";
 import { resolveProject, listProjectDirs } from "./resolver.ts";

--- a/extensions/pi-workon/src/logger.ts
+++ b/extensions/pi-workon/src/logger.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 const CHANNEL = "workon";
 

--- a/extensions/pi-workon/src/tool.ts
+++ b/extensions/pi-workon/src/tool.ts
@@ -11,9 +11,9 @@ import * as path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import * as os from "node:os";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { resolveProject, listProjectDirs } from "./resolver.ts";
 import { detectStack, type ProjectProfile } from "./detector.ts";
 import {

--- a/extensions/web-fetch.ts
+++ b/extensions/web-fetch.ts
@@ -5,16 +5,16 @@
  * Output is truncated to avoid overwhelming the context window.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	DEFAULT_MAX_BYTES,
 	DEFAULT_MAX_LINES,
 	formatSize,
 	truncateHead,
-} from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";


### PR DESCRIPTION
- **refactor(extensions): migrate from @mariozechner to @earendil-works package scope**
- **feat(pi-a2a): auto-detect publicUrl IP and add bindInterface config**
- **feat(pi-a2a): bindInterface binds to interface IP (not just advertises)**
- **feat(pi-a2a): add owner field to agent card**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose a network interface to bind/advertise and auto-detect the public URL when binding to all interfaces.
  * Add an owner field to surface agent owner info in discovery/hub UIs.

* **Changed**
  * Public URL detection and status output now reflect the actual advertised address.
  * Package scope migrated to a new namespace across extensions.

* **Fixed**
  * bindInterface now correctly binds to the selected interface IP; docs updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->