### PR TITLE
fix: pin @earendil-works peer dependencies to ^0.74.0

### DIFF
--- a/extensions/pi-a2a/package.json
+++ b/extensions/pi-a2a/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-brave-search/package.json
+++ b/extensions/pi-brave-search/package.json
@@ -10,7 +10,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "license": "MIT",

--- a/extensions/pi-calendar/package.json
+++ b/extensions/pi-calendar/package.json
@@ -26,8 +26,8 @@
     "better-sqlite3": "^11.10.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-channels/package.json
+++ b/extensions/pi-channels/package.json
@@ -21,8 +21,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-cmux/package.json
+++ b/extensions/pi-cmux/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-context/package.json
+++ b/extensions/pi-context/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "files": [
     "CHANGELOG.md",

--- a/extensions/pi-cron/package.json
+++ b/extensions/pi-cron/package.json
@@ -21,8 +21,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "files": [

--- a/extensions/pi-dotenv/package.json
+++ b/extensions/pi-dotenv/package.json
@@ -18,7 +18,7 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/extensions/pi-github/package.json
+++ b/extensions/pi-github/package.json
@@ -19,7 +19,7 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-gmail/package.json
+++ b/extensions/pi-gmail/package.json
@@ -22,8 +22,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "files": [

--- a/extensions/pi-heartbeat/package.json
+++ b/extensions/pi-heartbeat/package.json
@@ -21,7 +21,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-jobs/package.json
+++ b/extensions/pi-jobs/package.json
@@ -18,8 +18,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-kysely/package.json
+++ b/extensions/pi-kysely/package.json
@@ -34,7 +34,7 @@
     "pg": "*"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/extensions/pi-logger/package.json
+++ b/extensions/pi-logger/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-mealie/package.json
+++ b/extensions/pi-mealie/package.json
@@ -19,7 +19,7 @@
     "test": "npm run typecheck"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-memory/package.json
+++ b/extensions/pi-memory/package.json
@@ -21,8 +21,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-mobile/package.json
+++ b/extensions/pi-mobile/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-model-router/package.json
+++ b/extensions/pi-model-router/package.json
@@ -21,8 +21,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-ai": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0"
   },
   "files": [
     "CHANGELOG.md",

--- a/extensions/pi-myfinance/package.json
+++ b/extensions/pi-myfinance/package.json
@@ -28,9 +28,9 @@
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
     "typebox": "^1.1.24",
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "license": "MIT",
   "author": "Espen Nilsen <hi@e9n.dev>",

--- a/extensions/pi-npm/package.json
+++ b/extensions/pi-npm/package.json
@@ -21,8 +21,8 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "files": [

--- a/extensions/pi-openrouter/package.json
+++ b/extensions/pi-openrouter/package.json
@@ -28,8 +28,8 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-penpot/package.json
+++ b/extensions/pi-penpot/package.json
@@ -16,8 +16,8 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-personal-crm/package.json
+++ b/extensions/pi-personal-crm/package.json
@@ -18,8 +18,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-projects/package.json
+++ b/extensions/pi-projects/package.json
@@ -21,8 +21,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-subagent/package.json
+++ b/extensions/pi-subagent/package.json
@@ -21,11 +21,11 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24",
-    "@earendil-works/pi-agent-core": "*",
-    "@earendil-works/pi-tui": "*"
+    "@earendil-works/pi-agent-core": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-supabase/package.json
+++ b/extensions/pi-supabase/package.json
@@ -16,8 +16,8 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-td-hub/package.json
+++ b/extensions/pi-td-hub/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "dependencies": {
     "typebox": "^1.1.24",

--- a/extensions/pi-td/package.json
+++ b/extensions/pi-td/package.json
@@ -16,8 +16,8 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-ai": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-telemetry/package.json
+++ b/extensions/pi-telemetry/package.json
@@ -20,7 +20,7 @@
   ],
   "description": "Local telemetry extension for pi — captures session events and writes to disk",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "files": [
     "CHANGELOG.md",

--- a/extensions/pi-todoist/package.json
+++ b/extensions/pi-todoist/package.json
@@ -16,8 +16,8 @@
     "test": "node --test"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "dependencies": {

--- a/extensions/pi-tts/package.json
+++ b/extensions/pi-tts/package.json
@@ -10,8 +10,8 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-tui": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "license": "MIT",

--- a/extensions/pi-untappd/package.json
+++ b/extensions/pi-untappd/package.json
@@ -33,7 +33,7 @@
     "rss-parser": "^3.13.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/extensions/pi-vault/package.json
+++ b/extensions/pi-vault/package.json
@@ -23,8 +23,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {

--- a/extensions/pi-web-dashboard/package.json
+++ b/extensions/pi-web-dashboard/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-webnav/package.json
+++ b/extensions/pi-webnav/package.json
@@ -18,7 +18,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-webserver/package.json
+++ b/extensions/pi-webserver/package.json
@@ -23,7 +23,7 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/extensions/pi-workon/package.json
+++ b/extensions/pi-workon/package.json
@@ -21,8 +21,8 @@
   "author": "Espen Nilsen <hi@e9n.dev>",
   "license": "MIT",
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "typebox": "^1.1.24"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace wildcard (*) peer dependencies with ^0.74.0 for all @earendil-works packages to prevent accidental breaking upgrades.

All @earendil-works packages (pi-coding-agent, pi-ai, pi-tui, pi-agent-core) are currently at v0.74.0 on npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized peer dependency version requirements across all extension packages by pinning core dependencies to version 0.74.0 instead of allowing unrestricted versions. This change ensures consistent compatibility and stability throughout the entire extension ecosystem, effectively reduces potential version conflicts between components, and significantly improves overall platform reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->