### PR TITLE
fix(pi-a2a): auto-generate local apiKey for hub-backed binds

### DIFF
--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `/a2a apikey` command to show the current effective local API key
+
+### Changed
+- Auto-generate `local.apiKey` for external binds when `hub.url` is configured, even if `local.requireApiKey` is unset
+
+### Fixed
+- Warn when `local.requireApiKey` auto-generates a local API key without hub config, so users know to recover it via `/a2a apikey`
+
 ## [0.4.0] - 2026-05-08
 
 ### Added

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -117,6 +117,9 @@ Server binds to `127.0.0.1:3100`, publicUrl auto-generates as `http://localhost:
 
 Server binds to all interfaces, publicUrl auto-detects primary IP (e.g., `http://192.168.1.100:3100`).
 
+If you configure an external bind together with `hub.url` and omit `local.apiKey`, pi-a2a auto-generates a local API key automatically.
+If you configure an external bind without a hub, set `local.requireApiKey: true` to auto-generate one and use `/a2a apikey` to view it later.
+
 **LAN access (specific interface):**
 
 ```json
@@ -179,6 +182,7 @@ Server binds to localhost, but advertises external URL for reverse proxy setups.
 | `/a2a card` | Print the full Agent Card JSON |
 | `/a2a refresh` | Re-discover tools and update the Agent Card |
 | `/a2a register` | Manually register with the configured A2A Hub |
+| `/a2a apikey` | Show the current effective local API key |
 
 ## A2A Protocol Methods
 
@@ -218,6 +222,8 @@ When `apiKey` is configured:
 - Agent Card endpoints (`/.well-known/agent-card.json`) remain unauthenticated for discovery
 
 When binding to non-localhost (`bind: "0.0.0.0"`), an `apiKey` is strongly recommended.
+If `hub.url` is configured, pi-a2a auto-generates a local API key for external binds when one is not explicitly provided.
+If no hub is configured, set `pi-a2a.local.requireApiKey: true` to opt into auto-generation for external binds.
 
 ## License
 

--- a/extensions/pi-a2a/src/config.ts
+++ b/extensions/pi-a2a/src/config.ts
@@ -41,6 +41,14 @@ const SETTINGS_KEY = "pi-a2a";
 // Cache for auto-generated API key to ensure consistency across loadConfig() calls
 let cachedGeneratedApiKey: string | undefined;
 
+function isExternalBind(local: Record<string, unknown>): boolean {
+	if (typeof local.bindInterface === "string" && local.bindInterface.length > 0) {
+		return true;
+	}
+	const bind = typeof local.bind === "string" ? local.bind : undefined;
+	return !!bind && bind !== "127.0.0.1" && bind !== "::1";
+}
+
 export interface ConfigResult {
 	config: A2AConfig;
 	warnings: string[];
@@ -141,12 +149,20 @@ export function loadConfig(cwd: string): ConfigResult {
 		delete local.bind;
 	}
 
-	// ── Auto-generate apiKey when required ──
-	if (local.requireApiKey === true && !local.apiKey) {
+	// ── Auto-generate apiKey when required or implied by hub-backed external exposure ──
+	const hubImpliesApiKey = isExternalBind(local) && typeof (merged.hub as Record<string, unknown> | undefined)?.url === "string";
+	const requireApiKeyImpliesApiKey = local.requireApiKey === true;
+	const shouldAutoGenerateApiKey = !local.apiKey && (requireApiKeyImpliesApiKey || hubImpliesApiKey);
+	if (shouldAutoGenerateApiKey) {
 		// Check for existing generated key before creating a new one
 		if (!cachedGeneratedApiKey) {
 			cachedGeneratedApiKey = "a2a_" + randomBytes(32).toString("hex");
-			// Only warn when newly generating the key
+			if (requireApiKeyImpliesApiKey && !hubImpliesApiKey) {
+				warnings.push(
+					"pi-a2a auto-generated a local API key for external access. " +
+					"Run `/a2a apikey` to view it.",
+				);
+			}
 			if (merged.staticAgents && Array.isArray(merged.staticAgents) && merged.staticAgents.length > 0) {
 				warnings.push(
 					`Warning: an API key was auto-generated but staticAgents are configured. ` +

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2194,7 +2194,7 @@ export default function (pi: ExtensionAPI) {
 	// ── Commands ──────────────────────────────────────────────
 
 	pi.registerCommand("a2a", {
-		description: "Manage the A2A protocol server. Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a discover [query] | /a2a agents [refresh|name]",
+		description: "Manage the A2A protocol server. Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a apikey | /a2a discover [query] | /a2a agents [refresh|name]",
 		handler: async (args, ctx) => {
 			const action = args.trim();
 			const { config } = loadConfig(cwd);
@@ -2306,6 +2306,15 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
+			if (action === "apikey") {
+				if (!config.local?.apiKey) {
+					ctx.ui.notify("No effective pi-a2a local API key is configured", "warning");
+					return;
+				}
+				ctx.ui.notify(`pi-a2a local API key: ${config.local.apiKey}`, "info");
+				return;
+			}
+
 			if (action === "discover" || action.startsWith("discover ")) {
 				if (!config.hub?.apiKey) {
 					ctx.ui.notify("No hub config — set pi-a2a.hub.url and pi-a2a.hub.apiKey", "warning");
@@ -2390,7 +2399,7 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			ctx.ui.notify(
-				"Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a discover [query] | /a2a agents [refresh|name]",
+				"Usage: /a2a status | /a2a card | /a2a refresh | /a2a register | /a2a credential | /a2a apikey | /a2a discover [query] | /a2a agents [refresh|name]",
 				"info",
 			);
 		},

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -22,10 +22,12 @@ export interface LocalConfig {
 	bindInterface?: string;
 	/** Public-facing base URL. Defaults to http://localhost:{port}. */
 	publicUrl?: string;
-	/** Require an API key for inbound requests. When true and apiKey is unset, one is auto-generated. */
+	/** Require an API key for inbound requests. When true and apiKey is unset, one is auto-generated.
+	 *  Useful for external binds that are not using hub configuration. */
 	requireApiKey?: boolean;
 	/** API key for authenticating RPC requests. Required when bind is not localhost.
-	 *  Optional when requireApiKey is true, as loadConfig() will auto-generate one if not provided. */
+	 *  Optional when requireApiKey is true, or when hub.url is configured for an external bind,
+	 *  as loadConfig() will auto-generate one if not provided. */
 	apiKey?: string;
 }
 


### PR DESCRIPTION
## Summary
- auto-generate `pi-a2a.local.apiKey` for external binds when `hub.url` is configured
- warn when `local.requireApiKey` triggers non-hub auto-generation and add `/a2a apikey` to recover the key
- update pi-a2a docs and changelog for the new behavior

## Verification
- cd extensions/pi-a2a && npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/a2a apikey` command to display configured API keys.
  * Auto-generates local API keys for external binds when hub URL is configured.

* **Documentation**
  * Updated configuration guides with API key auto-generation behavior.
  * Added warnings to help users understand auto-generated keys and retrieval instructions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/181)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->