### PR TITLE
fix(pi-authentik): use ESM imports for pi-coding-agent instead of require

### DIFF
--- a/extensions/pi-authentik/index.test.ts
+++ b/extensions/pi-authentik/index.test.ts
@@ -173,7 +173,7 @@ function createHarness(overrides: Partial<DepsOverride> = {}) {
   let currentModels = overrides.models ?? [{ id: "gpt-4.1" }];
 
   const deps = {
-    resolveSettings: () => overrides.settings ?? configuredSettings,
+    resolveSettings: async () => overrides.settings ?? configuredSettings,
     runFirstRunSetup: overrides.runFirstRunSetup ?? (async () => ({ saved: true, settings: null, connectivityTested: false })),
     saveSettings: overrides.saveSettings ?? (async () => undefined),
     loadStoredSession: overrides.loadStoredSession ?? (async () => null),

--- a/extensions/pi-authentik/index.ts
+++ b/extensions/pi-authentik/index.ts
@@ -12,12 +12,12 @@ import { createOpenAICompatibleClient } from "./llm-client.ts";
 import { createLogger } from "./logger.ts";
 import { filterProviderModels, mapOpenAIModelsToProviderModels, type ProviderModelConfig } from "./models.ts";
 import { generateNonce, createPkcePair, generateState } from "./pkce.ts";
-import { resolveSettings } from "./settings.ts";
+import { createEmptySettings, resolveSettings } from "./settings.ts";
 import { saveCurrentGlobalSettings } from "./settings-store.ts";
 import { clearStoredSession, loadStoredSession, saveStoredSession } from "./token-store.ts";
 import type { AuthentikResolvedSettings, AuthentikSessionRecord, AuthentikStoredSettings } from "./types.ts";
 
-export { DEFAULT_MODEL_FILTERS, DEFAULT_SCOPES, canonicalizeLlmBaseUrl, resolveSettings } from "./settings.ts";
+export { DEFAULT_MODEL_FILTERS, DEFAULT_SCOPES, canonicalizeLlmBaseUrl, createEmptySettings, resolveSettings } from "./settings.ts";
 export { normalizeOpenAIBaseUrl, testModelsEndpointConnectivity, validateOpenAIBaseUrl } from "./endpoint-validator.ts";
 export { createOpenAICompatibleClient } from "./llm-client.ts";
 export { filterProviderModels, mapOpenAIModelToProviderModel, mapOpenAIModelsToProviderModels } from "./models.ts";
@@ -105,7 +105,7 @@ const defaultDeps: AuthentikExtensionDeps = {
  * @param deps - Optional dependency overrides for tests and alternate runtime wiring.
  */
 export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<AuthentikExtensionDeps> = {}): void {
-  const api = pi as ExtensionApiLike;
+  const api = pi;
   const runtime = { ...defaultDeps, ...deps };
   const log = createLogger(pi, "pi-authentik");
 
@@ -116,7 +116,7 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
     lastCtx: SessionContextLike | CommandContextLike | null;
     discovery: OidcDiscoveryMetadata | null;
   } = {
-    settings: runtime.resolveSettings(process.cwd()),
+    settings: createEmptySettings(),
     session: null,
     models: [],
     lastCtx: null,
@@ -125,7 +125,7 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
 
   api.on("session_start", async (_event: unknown, ctx: SessionContextLike) => {
     state.lastCtx = ctx;
-    state.settings = runtime.resolveSettings(ctx.cwd);
+    state.settings = await runtime.resolveSettings(ctx.cwd);
     state.discovery = null;
     await initializeSession(ctx).catch((error) => {
       log.error("session_start failed", error);
@@ -236,7 +236,7 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
     });
 
     if (!result.saved) return;
-    state.settings = runtime.resolveSettings(ctx.cwd);
+    state.settings = await runtime.resolveSettings(ctx.cwd);
     state.discovery = null;
     updateStatus(ctx);
   }

--- a/extensions/pi-authentik/settings-store.ts
+++ b/extensions/pi-authentik/settings-store.ts
@@ -2,8 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { getAgentDir } from "@earendil-works/pi-coding-agent";
-
 import type { AuthentikStoredSettings } from "./types.ts";
 
 /** Top-level Pi settings key used by this extension. */
@@ -70,8 +68,9 @@ function readJsonFile(filePath: string): Record<string, unknown> {
  * Returns the path to Pi's global settings file.
  * @returns Absolute path to the active global settings file.
  */
-export function getGlobalSettingsPath(): string {
+export async function getGlobalSettingsPath(): Promise<string> {
   try {
+    const { getAgentDir } = await import("@earendil-works/pi-coding-agent");
     return path.join(getAgentDir(), "settings.json");
   } catch {
     return path.join(os.homedir(), ".pi", "agent", "settings.json");
@@ -83,8 +82,9 @@ export function getGlobalSettingsPath(): string {
  * @param settingsFile - Optional explicit settings file path.
  * @returns Sanitized stored settings.
  */
-export function loadGlobalSettings(settingsFile = getGlobalSettingsPath()): AuthentikStoredSettings {
-  return sanitizeStoredSettings(readJsonFile(settingsFile)[SETTINGS_KEY]);
+export async function loadGlobalSettings(settingsFile?: string): Promise<AuthentikStoredSettings> {
+  const resolvedPath = settingsFile ?? await getGlobalSettingsPath();
+  return sanitizeStoredSettings(readJsonFile(resolvedPath)[SETTINGS_KEY]);
 }
 
 /**
@@ -112,6 +112,6 @@ export function saveGlobalSettings(settingsFile: string, settings: AuthentikStor
  * Saves `pi-authentik` settings into the active Pi global settings file.
  * @param settings - Non-secret extension settings to persist.
  */
-export function saveCurrentGlobalSettings(settings: AuthentikStoredSettings): void {
-  saveGlobalSettings(getGlobalSettingsPath(), settings);
+export async function saveCurrentGlobalSettings(settings: AuthentikStoredSettings): Promise<void> {
+  saveGlobalSettings(await getGlobalSettingsPath(), settings);
 }

--- a/extensions/pi-authentik/settings-store.ts
+++ b/extensions/pi-authentik/settings-store.ts
@@ -72,8 +72,18 @@ export async function getGlobalSettingsPath(): Promise<string> {
   try {
     const { getAgentDir } = await import("@earendil-works/pi-coding-agent");
     return path.join(getAgentDir(), "settings.json");
-  } catch {
-    return path.join(os.homedir(), ".pi", "agent", "settings.json");
+  } catch (error) {
+    // Only fall back to home directory if the module cannot be resolved
+    const isModuleNotFound =
+      (error as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND" ||
+      (error instanceof Error && error.message.includes("@earendil-works/pi-coding-agent"));
+
+    if (isModuleNotFound) {
+      return path.join(os.homedir(), ".pi", "agent", "settings.json");
+    }
+
+    // Re-throw genuine runtime or import errors
+    throw error;
   }
 }
 

--- a/extensions/pi-authentik/settings-store.ts
+++ b/extensions/pi-authentik/settings-store.ts
@@ -1,11 +1,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createRequire } from "node:module";
+
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 import type { AuthentikStoredSettings } from "./types.ts";
-
-const require = createRequire(import.meta.url);
 
 /** Top-level Pi settings key used by this extension. */
 export const SETTINGS_KEY = "pi-authentik";
@@ -73,8 +72,7 @@ function readJsonFile(filePath: string): Record<string, unknown> {
  */
 export function getGlobalSettingsPath(): string {
   try {
-    const piModule = require("@earendil-works/pi-coding-agent") as { getAgentDir: () => string };
-    return path.join(piModule.getAgentDir(), "settings.json");
+    return path.join(getAgentDir(), "settings.json");
   } catch {
     return path.join(os.homedir(), ".pi", "agent", "settings.json");
   }

--- a/extensions/pi-authentik/settings.test.ts
+++ b/extensions/pi-authentik/settings.test.ts
@@ -8,8 +8,8 @@ import { DEFAULT_MODEL_FILTERS, resolveSettings } from "./settings.ts";
 import { loadGlobalSettings, saveGlobalSettings } from "./settings-store.ts";
 import type { AuthentikStoredSettings } from "./types.ts";
 
-test("resolveSettings uses default scopes and omits offline_access by default", () => {
-  const settings = resolveSettings(process.cwd(), {
+test("resolveSettings uses default scopes and omits offline_access by default", async () => {
+  const settings = await resolveSettings(process.cwd(), {
     globalSettings: {},
     projectSettings: {},
   });
@@ -18,8 +18,8 @@ test("resolveSettings uses default scopes and omits offline_access by default", 
   assert.equal(settings.enableOfflineAccess, false);
 });
 
-test("resolveSettings appends offline_access only when enabled", () => {
-  const settings = resolveSettings(process.cwd(), {
+test("resolveSettings appends offline_access only when enabled", async () => {
+  const settings = await resolveSettings(process.cwd(), {
     globalSettings: {
       enableOfflineAccess: true,
       scopes: ["openid", "email", "profile", "offline_access"],
@@ -31,8 +31,8 @@ test("resolveSettings appends offline_access only when enabled", () => {
   assert.deepEqual(settings.scopes, ["openid", "email", "profile", "offline_access"]);
 });
 
-test("resolveSettings merges project settings over global settings", () => {
-  const settings = resolveSettings(process.cwd(), {
+test("resolveSettings merges project settings over global settings", async () => {
+  const settings = await resolveSettings(process.cwd(), {
     globalSettings: {
       authentikHost: "https://global.example",
       providerSlug: "global-provider",
@@ -57,8 +57,8 @@ test("resolveSettings merges project settings over global settings", () => {
   assert.deepEqual(settings.modelFilters, ["o3-*"]);
 });
 
-test("resolveSettings canonicalizes llm base url to an absolute /v1 endpoint", () => {
-  const settings = resolveSettings(process.cwd(), {
+test("resolveSettings canonicalizes llm base url to an absolute /v1 endpoint", async () => {
+  const settings = await resolveSettings(process.cwd(), {
     globalSettings: {
       llmBaseUrl: "https://llm.example/internal/v1/",
     },
@@ -68,8 +68,8 @@ test("resolveSettings canonicalizes llm base url to an absolute /v1 endpoint", (
   assert.equal(settings.llmBaseUrl, "https://llm.example/internal/v1");
 });
 
-test("resolveSettings auto-appends /v1 and rejects invalid urls", () => {
-  const fixed = resolveSettings(process.cwd(), {
+test("resolveSettings auto-appends /v1 and rejects invalid urls", async () => {
+  const fixed = await resolveSettings(process.cwd(), {
     globalSettings: {
       llmBaseUrl: "https://llm.example/internal",
     },
@@ -77,9 +77,9 @@ test("resolveSettings auto-appends /v1 and rejects invalid urls", () => {
   });
   assert.equal(fixed.llmBaseUrl, "https://llm.example/internal/v1");
 
-  assert.throws(
-    () =>
-      resolveSettings(process.cwd(), {
+  await assert.rejects(
+    async () =>
+      await resolveSettings(process.cwd(), {
         globalSettings: {
           llmBaseUrl: "/not/absolute",
         },
@@ -89,8 +89,8 @@ test("resolveSettings auto-appends /v1 and rejects invalid urls", () => {
   );
 });
 
-test("resolveSettings falls back to default model filters", () => {
-  const settings = resolveSettings(process.cwd(), {
+test("resolveSettings falls back to default model filters", async () => {
+  const settings = await resolveSettings(process.cwd(), {
     globalSettings: {
       modelFilters: "",
     },
@@ -131,7 +131,7 @@ test("saveGlobalSettings persists only the extension key atomically", () => {
   assert.equal(fs.existsSync(`${settingsFile}.tmp`), false);
 });
 
-test("loadGlobalSettings returns sanitized persisted values", () => {
+test("loadGlobalSettings returns sanitized persisted values", async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-authentik-settings-"));
   const settingsFile = path.join(tempRoot, "settings.json");
   fs.writeFileSync(
@@ -149,7 +149,7 @@ test("loadGlobalSettings returns sanitized persisted values", () => {
     ),
   );
 
-  assert.deepEqual(loadGlobalSettings(settingsFile), {
+  assert.deepEqual(await loadGlobalSettings(settingsFile), {
     authentikHost: "https://auth.example/",
     llmBaseUrl: "https://llm.example/v1/",
     modelFilters: ["anthropic/*"],

--- a/extensions/pi-authentik/settings.ts
+++ b/extensions/pi-authentik/settings.ts
@@ -1,5 +1,3 @@
-import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
-
 import type { AuthentikResolvedSettings, AuthentikStoredSettings, ResolveSettingsOptions } from "./types.ts";
 import { sanitizeStoredSettings } from "./settings-store.ts";
 
@@ -7,6 +5,25 @@ import { sanitizeStoredSettings } from "./settings-store.ts";
 export const DEFAULT_SCOPES = ["openid", "profile", "email"];
 /** Default model filter that exposes every discovered model. */
 export const DEFAULT_MODEL_FILTERS = ["*"];
+
+/**
+ * Creates an empty resolved settings object with default values.
+ * @returns Default resolved settings with all auth fields set to null.
+ */
+export function createEmptySettings(): AuthentikResolvedSettings {
+  return {
+    authentikHost: null,
+    providerSlug: null,
+    clientId: null,
+    scopes: DEFAULT_SCOPES,
+    enableOfflineAccess: false,
+    discoveryUrl: null,
+    logoutUrl: null,
+    llmBaseUrl: null,
+    authStorageBackend: null,
+    modelFilters: DEFAULT_MODEL_FILTERS,
+  };
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -108,8 +125,9 @@ function mergeStoredSettings(globalSettings: unknown, projectSettings: unknown):
   };
 }
 
-function readSettingsFromManager(cwd: string): { globalSettings: unknown; projectSettings: unknown } {
+async function readSettingsFromManager(cwd: string): Promise<{ globalSettings: unknown; projectSettings: unknown }> {
   try {
+    const { getAgentDir, SettingsManager } = await import("@earendil-works/pi-coding-agent");
     const sm = SettingsManager.create(cwd, getAgentDir());
     const global = asRecord(sm.getGlobalSettings())["pi-authentik"];
     const project = asRecord(sm.getProjectSettings())["pi-authentik"];
@@ -134,9 +152,9 @@ function readSettingsFromManager(cwd: string): { globalSettings: unknown; projec
  * @param options - Optional test overrides for settings sources.
  * @returns The normalized runtime settings for the extension.
  */
-export function resolveSettings(cwd: string, options: ResolveSettingsOptions = {}): AuthentikResolvedSettings {
+export async function resolveSettings(cwd: string, options: ResolveSettingsOptions = {}): Promise<AuthentikResolvedSettings> {
   const sources = options.globalSettings === undefined && options.projectSettings === undefined
-    ? readSettingsFromManager(cwd)
+    ? await readSettingsFromManager(cwd)
     : {
         globalSettings: options.globalSettings,
         projectSettings: options.projectSettings,

--- a/extensions/pi-authentik/settings.ts
+++ b/extensions/pi-authentik/settings.ts
@@ -1,9 +1,7 @@
-import { createRequire } from "node:module";
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 
 import type { AuthentikResolvedSettings, AuthentikStoredSettings, ResolveSettingsOptions } from "./types.ts";
 import { sanitizeStoredSettings } from "./settings-store.ts";
-
-const require = createRequire(import.meta.url);
 
 /** Default scopes requested when no scopes are configured explicitly. */
 export const DEFAULT_SCOPES = ["openid", "profile", "email"];
@@ -112,11 +110,7 @@ function mergeStoredSettings(globalSettings: unknown, projectSettings: unknown):
 
 function readSettingsFromManager(cwd: string): { globalSettings: unknown; projectSettings: unknown } {
   try {
-    const piModule = require("@earendil-works/pi-coding-agent") as {
-      getAgentDir: () => string;
-      SettingsManager: { create: (cwd: string, agentDir: string) => { getGlobalSettings(): unknown; getProjectSettings(): unknown } };
-    };
-    const sm = piModule.SettingsManager.create(cwd, piModule.getAgentDir());
+    const sm = SettingsManager.create(cwd, getAgentDir());
     const global = asRecord(sm.getGlobalSettings())["pi-authentik"];
     const project = asRecord(sm.getProjectSettings())["pi-authentik"];
     return {

--- a/extensions/pi-authentik/tsconfig.json
+++ b/extensions/pi-authentik/tsconfig.json
@@ -7,6 +7,7 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
     "types": ["node"]
   },
   "include": ["*.ts", "*.d.ts"],


### PR DESCRIPTION
createRequire().require("@earendil-works/pi-coding-agent") uses the CommonJS resolver, which selects the "require" export condition. That package exposes only "import" and "types" in exports; resolution fails with ERR_PACKAGE_PATH_NOT_EXPORTED / No exports main defined when the extension loads under jiti.

Co-authored-by: Cursor <cursoragent@cursor.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings I/O converted to async with safer resolution and a robust fallback for missing modules.
  * Startup now uses empty defaults and loads persisted settings asynchronously during session start and first-run flows.

* **New Features**
  * Added a helper to produce default/empty resolved settings.
  * Exposed the empty-settings helper for runtime use.

* **Tests**
  * Tests updated to accommodate async settings APIs.

* **Chores**
  * TypeScript config adjusted to improve interoperability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/183)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->