### PR TITLE
feat(pi-authentik): discovery-first setup, auth-aware /models probe, keep discovery on LLM endpoint update

### DIFF
--- a/extensions/pi-authentik/AUTHENTIK_SETUP.md
+++ b/extensions/pi-authentik/AUTHENTIK_SETUP.md
@@ -6,17 +6,18 @@ This extension uses authentik through OIDC Authorization Code + PKCE with a loop
 
 Configure these values under the `pi-authentik` key in Pi settings:
 
-- `authentikHost` — for example `https://auth.example`
-- `providerSlug` — the provider/application slug Pi uses for discovery
 - `clientId` — the public client ID issued by authentik
+- **Either** `discoveryUrl` — full OpenID Provider Configuration URL (`…/.well-known/openid-configuration`), **or** both:
+  - `authentikHost` — for example `https://auth.example`
+  - `providerSlug` — the OAuth2 provider/application slug Pi uses when deriving discovery
 
-By default Pi derives discovery from:
+When `discoveryUrl` is omitted, Pi derives it as:
 
 ```text
 https://<authentik-host>/application/o/<provider-slug>/.well-known/openid-configuration
 ```
 
-If needed, you can override that with `discoveryUrl`.
+The `/authentik-setup` wizard asks for discovery first (recommended), with host + slug as a fallback when you leave discovery empty.
 
 ## Create or update the provider
 

--- a/extensions/pi-authentik/auth-client.test.ts
+++ b/extensions/pi-authentik/auth-client.test.ts
@@ -90,10 +90,13 @@ test("runBrowserLogin orchestrates callback server wait and browser hook separat
 
   const exchangeCall = calls[2];
   if (!exchangeCall) throw new Error("expected exchangeCode call");
-  assert.ok(exchangeCall.startsWith("exchangeCode:"));
-  const exchangeParts = exchangeCall.split(":");
-  assert.equal(exchangeParts[1], "auth-code-123");
-  assert.equal(exchangeParts[2], "http://127.0.0.1:43123/callback");
+  const prefix = "exchangeCode:";
+  assert.ok(exchangeCall.startsWith(prefix));
+  const remainder = exchangeCall.slice(prefix.length);
+  const sep = remainder.indexOf(":");
+  assert.equal(sep >= 0, true);
+  assert.equal(remainder.slice(0, sep), "auth-code-123");
+  assert.equal(remainder.slice(sep + 1), "http://127.0.0.1:43123/callback");
 
   assert.equal(calls[3], "close");
 });

--- a/extensions/pi-authentik/endpoint-validator.test.ts
+++ b/extensions/pi-authentik/endpoint-validator.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import http from "node:http";
 
 import {
+  MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,
+  MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE,
   normalizeOpenAIBaseUrl,
   testModelsEndpointConnectivity,
   validateOpenAIBaseUrl,
@@ -54,4 +56,69 @@ test("testModelsEndpointConnectivity calls GET /models with auth strategy", asyn
   } finally {
     await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
   }
+});
+
+test("testModelsEndpointConnectivity without auth rejects Authentik-style login redirects", async () => {
+  const fetchImpl: typeof fetch = async (input) => {
+    const reqUrl = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+    assert.match(reqUrl, /\/v1\/models$/);
+    return new Response(null, {
+      status: 302,
+      headers: { location: "https://idp.example/if/flow/default-authentication-flow/?next=/" },
+    });
+  };
+
+  await assert.rejects(
+    async () =>
+      testModelsEndpointConnectivity({
+        baseUrl: "https://proxy.example/services/llm/v1",
+        fetchImpl,
+      }),
+    (error: unknown) => error instanceof Error && error.message === MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,
+  );
+});
+
+test("testModelsEndpointConnectivity without auth rejects HTML bodies", async () => {
+  const fetchImpl: typeof fetch = async () =>
+    new Response("<!DOCTYPE html><html><title>Login</title></html>", {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+
+  await assert.rejects(
+    async () =>
+      testModelsEndpointConnectivity({
+        baseUrl: "https://api.example/v1",
+        fetchImpl,
+      }),
+    (error: unknown) => error instanceof Error && error.message === MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE,
+  );
+});
+
+test("testModelsEndpointConnectivity without auth follows benign redirects then parses JSON", async () => {
+  let call = 0;
+  const fetchImpl: typeof fetch = async (input) => {
+    const reqUrl = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+    call += 1;
+    if (call === 1) {
+      assert.equal(reqUrl, "https://api.example/v1/models");
+      return new Response(null, {
+        status: 307,
+        headers: { location: "https://api.example/alt/v1/models" },
+      });
+    }
+    assert.equal(reqUrl, "https://api.example/alt/v1/models");
+    return new Response(JSON.stringify({ object: "list", data: [{ id: "m1" }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const result = await testModelsEndpointConnectivity({
+    baseUrl: "https://api.example/v1",
+    fetchImpl,
+  });
+
+  assert.equal(result.modelCount, 1);
+  assert.equal(result.normalizedUrl, "https://api.example/v1");
 });

--- a/extensions/pi-authentik/endpoint-validator.ts
+++ b/extensions/pi-authentik/endpoint-validator.ts
@@ -29,6 +29,116 @@ export interface ConnectivityTestResult {
   modelCount: number;
 }
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+const MAX_PROBE_REDIRECTS = 8;
+
+/** User-facing explanation when probing /models reaches an SSO or OAuth login redirect. */
+export const MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE =
+  "GET /models redirected to a login or authorization page. Your LLM base URL appears to be behind authentication. Skip the connectivity test during setup (you can verify after running /authentik-login), or run the probe with credentials if your tooling supports Bearer tokens.";
+
+/** User-facing explanation when probing /models returns HTML instead of JSON. */
+export const MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE =
+  "GET /models returned HTML instead of JSON (often SSO or an error page). Skip the connectivity test until /models succeeds with your Authentik-issued Bearer token.";
+
+function locationSuggestsAuthenticationRedirect(parsed: URL): boolean {
+  const path = parsed.pathname;
+  const lowerPath = path.toLowerCase();
+
+  if (lowerPath.includes("/if/")) {
+    return true;
+  }
+
+  if (lowerPath.includes("default-authentication-flow")) {
+    return true;
+  }
+
+  if (lowerPath.includes("/application/o/authorize")) {
+    return true;
+  }
+
+  if (/\/oauth\/authorize\b/i.test(lowerPath) || /\bauthorize\/$/i.test(lowerPath)) {
+    return true;
+  }
+
+  return false;
+}
+
+function responseLooksLikeHtml(response: Response, bodyText: string): boolean {
+  const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
+  if (contentType.includes("text/html")) {
+    return true;
+  }
+
+  const start = bodyText.trimStart();
+  return start.startsWith("<!DOCTYPE") || start.toLowerCase().startsWith("<html");
+}
+
+async function probeModelsPayload(
+  normalizedBaseUrl: string,
+  fetchImpl: typeof fetch,
+  authStrategy?: LlmAuthStrategy,
+): Promise<{ modelCount: number; finalUrl: string }> {
+  const modelsUrl = `${normalizedBaseUrl.replace(/\/+$/, "")}/models`;
+
+  let currentUrl = modelsUrl;
+
+  for (let hop = 0; hop < MAX_PROBE_REDIRECTS; hop++) {
+    const headers = new Headers();
+    headers.set("accept", "application/json");
+    if (authStrategy) {
+      await authStrategy.apply(headers);
+    }
+
+    const response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual" });
+
+    if (REDIRECT_STATUSES.has(response.status)) {
+      const location = response.headers.get("location");
+      if (!location || !location.trim()) {
+        throw new Error(`GET /models returned ${response.status} without a Location header.`);
+      }
+
+      const next = new URL(location.trim(), response.url || currentUrl);
+      if (locationSuggestsAuthenticationRedirect(next)) {
+        throw new Error(MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+      }
+
+      currentUrl = next.toString();
+      continue;
+    }
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
+    }
+
+    if (responseLooksLikeHtml(response, text)) {
+      throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text) as unknown;
+    } catch {
+      throw new Error(
+        `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
+      );
+    }
+
+    if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
+      throw new Error(
+        `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
+      );
+    }
+
+    const data = (payload as { data: unknown[] }).data;
+    return { modelCount: data.length, finalUrl: response.url || currentUrl };
+  }
+
+  throw new Error(`GET /models followed more than ${MAX_PROBE_REDIRECTS} redirects; aborting probe.`);
+}
+
 /**
  * Validates and canonicalizes an OpenAI-compatible base URL that must end in `/v1`.
  * @param value - Raw base URL entered by the user.
@@ -100,22 +210,35 @@ export function validateOpenAIBaseUrl(value: string): BaseUrlValidationResult {
 }
 
 /**
- * Probes the configured models endpoint to confirm connectivity and endpoint shape.
+ * Probes the configured models endpoint to confirm connectivity and endpoint shape,
+ * detecting SSO redirects and HTML responses that would confuse a naive JSON probe.
  * @param options - Base URL, auth strategy, and optional fetch override.
  * @returns Connectivity details including the normalized base URL and model count.
  */
 export async function testModelsEndpointConnectivity(options: ConnectivityTestOptions): Promise<ConnectivityTestResult> {
   const normalizedUrl = normalizeOpenAIBaseUrl(options.baseUrl);
-  const client = createOpenAICompatibleClient({
-    baseUrl: normalizedUrl,
-    authStrategy: options.authStrategy,
-    fetchImpl: options.fetchImpl,
-  });
-  const models = await client.listModels();
+  const fetchImpl = options.fetchImpl ?? fetch;
 
+  /** When Bearer auth already applies, reuse the structured client path (fewer probes). */
+  if (options.authStrategy) {
+    const client = createOpenAICompatibleClient({
+      baseUrl: normalizedUrl,
+      authStrategy: options.authStrategy,
+      fetchImpl: options.fetchImpl,
+    });
+    const models = await client.listModels();
+
+    return {
+      ok: true,
+      normalizedUrl,
+      modelCount: models.length,
+    };
+  }
+
+  const probe = await probeModelsPayload(normalizedUrl, fetchImpl);
   return {
     ok: true,
     normalizedUrl,
-    modelCount: models.length,
+    modelCount: probe.modelCount,
   };
 }

--- a/extensions/pi-authentik/endpoint-validator.ts
+++ b/extensions/pi-authentik/endpoint-validator.ts
@@ -91,48 +91,68 @@ async function probeModelsPayload(
       await authStrategy.apply(headers);
     }
 
-    const response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual" });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual", signal: controller.signal });
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`GET /models timed out after 30000ms`);
+      }
+      throw error;
+    }
 
     if (REDIRECT_STATUSES.has(response.status)) {
       const location = response.headers.get("location");
       if (!location || !location.trim()) {
+        clearTimeout(timeoutId);
         throw new Error(`GET /models returned ${response.status} without a Location header.`);
       }
 
       const next = new URL(location.trim(), response.url || currentUrl);
       if (locationSuggestsAuthenticationRedirect(next)) {
+        clearTimeout(timeoutId);
         throw new Error(MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
       }
 
+      clearTimeout(timeoutId);
       currentUrl = next.toString();
       continue;
     }
 
     const text = await response.text();
 
-    if (!response.ok) {
-      throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
+    if (responseLooksLikeHtml(response, text)) {
+      clearTimeout(timeoutId);
+      throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
     }
 
-    if (responseLooksLikeHtml(response, text)) {
-      throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
+    if (!response.ok) {
+      clearTimeout(timeoutId);
+      throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
     }
 
     let payload: unknown;
     try {
       payload = JSON.parse(text) as unknown;
     } catch {
+      clearTimeout(timeoutId);
       throw new Error(
         `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
       );
     }
 
     if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
+      clearTimeout(timeoutId);
       throw new Error(
         `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
       );
     }
 
+    clearTimeout(timeoutId);
     const data = (payload as { data: unknown[] }).data;
     return { modelCount: data.length, finalUrl: response.url || currentUrl };
   }

--- a/extensions/pi-authentik/endpoint-validator.ts
+++ b/extensions/pi-authentik/endpoint-validator.ts
@@ -71,7 +71,8 @@ function responseLooksLikeHtml(response: Response, bodyText: string): boolean {
   }
 
   const start = bodyText.trimStart();
-  return start.startsWith("<!DOCTYPE") || start.toLowerCase().startsWith("<html");
+  const lower = start.toLowerCase();
+  return lower.startsWith("<!doctype") || lower.startsWith("<html");
 }
 
 async function probeModelsPayload(

--- a/extensions/pi-authentik/endpoint-validator.ts
+++ b/extensions/pi-authentik/endpoint-validator.ts
@@ -94,67 +94,62 @@ async function probeModelsPayload(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
-    let response: Response;
     try {
-      response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual", signal: controller.signal });
-    } catch (error) {
-      clearTimeout(timeoutId);
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error(`GET /models timed out after 30000ms`);
-      }
-      throw error;
-    }
-
-    if (REDIRECT_STATUSES.has(response.status)) {
-      const location = response.headers.get("location");
-      if (!location || !location.trim()) {
-        clearTimeout(timeoutId);
-        throw new Error(`GET /models returned ${response.status} without a Location header.`);
+      let response: Response;
+      try {
+        response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual", signal: controller.signal });
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          throw new Error(`GET /models timed out after 30000ms`);
+        }
+        throw error;
       }
 
-      const next = new URL(location.trim(), response.url || currentUrl);
-      if (locationSuggestsAuthenticationRedirect(next)) {
-        clearTimeout(timeoutId);
-        throw new Error(MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+      if (REDIRECT_STATUSES.has(response.status)) {
+        const location = response.headers.get("location");
+        if (!location || !location.trim()) {
+          throw new Error(`GET /models returned ${response.status} without a Location header.`);
+        }
+
+        const next = new URL(location.trim(), response.url || currentUrl);
+        if (locationSuggestsAuthenticationRedirect(next)) {
+          throw new Error(MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+        }
+
+        currentUrl = next.toString();
+        continue;
       }
 
+      const text = await response.text();
+
+      if (responseLooksLikeHtml(response, text)) {
+        throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
+      }
+
+      if (!response.ok) {
+        throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
+      }
+
+      let payload: unknown;
+      try {
+        payload = JSON.parse(text) as unknown;
+      } catch {
+        throw new Error(
+          `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
+        );
+      }
+
+      if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
+        throw new Error(
+          `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
+        );
+      }
+
+      const data = (payload as { data: unknown[] }).data;
+      return { modelCount: data.length, finalUrl: response.url || currentUrl };
+    } finally {
       clearTimeout(timeoutId);
-      currentUrl = next.toString();
-      continue;
     }
-
-    const text = await response.text();
-
-    if (responseLooksLikeHtml(response, text)) {
-      clearTimeout(timeoutId);
-      throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
-    }
-
-    if (!response.ok) {
-      clearTimeout(timeoutId);
-      throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
-    }
-
-    let payload: unknown;
-    try {
-      payload = JSON.parse(text) as unknown;
-    } catch {
-      clearTimeout(timeoutId);
-      throw new Error(
-        `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
-      );
-    }
-
-    if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
-      clearTimeout(timeoutId);
-      throw new Error(
-        `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
-      );
-    }
-
-    clearTimeout(timeoutId);
-    const data = (payload as { data: unknown[] }).data;
-    return { modelCount: data.length, finalUrl: response.url || currentUrl };
   }
 
   throw new Error(`GET /models followed more than ${MAX_PROBE_REDIRECTS} redirects; aborting probe.`);

--- a/extensions/pi-authentik/first-run.test.ts
+++ b/extensions/pi-authentik/first-run.test.ts
@@ -1,19 +1,35 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { OidcDiscoveryMetadata } from "./discovery.ts";
 import { runFirstRunSetup, type FirstRunUi } from "./first-run.ts";
 import type { AuthentikStoredSettings } from "./types.ts";
 
-test("runFirstRunSetup prompts in order, tests endpoint, and saves only non-secret config", async () => {
+function exampleMetadata(): OidcDiscoveryMetadata {
+  return {
+    issuer: "https://auth.example/application/o/provider/",
+    authorization_endpoint: "https://auth.example/application/o/authorize/",
+    token_endpoint: "https://auth.example/application/o/token/",
+    jwks_uri: "https://auth.example/application/o/jwks/",
+    response_types_supported: ["code"],
+    subject_types_supported: ["public"],
+    id_token_signing_alg_values_supported: ["RS256"],
+    code_challenge_methods_supported: ["S256"],
+    end_session_endpoint: "https://auth.example/application/o/logout/",
+  };
+}
+
+test("runFirstRunSetup uses pasted discovery URL, confirms redirect URIs, tests endpoint, and saves discoveryUrl", async () => {
   const prompts: string[] = [];
   const notifications: Array<{ message: string; level: string }> = [];
   const saved: AuthentikStoredSettings[] = [];
   const connectivityCalls: string[] = [];
 
+  const discoveryUrl = "https://auth.example/application/o/my-app/.well-known/openid-configuration";
+
   const ui = createUi({
     inputs: [
-      "https://auth.example/",
-      "main-provider",
+      discoveryUrl,
       "pi-client",
       "openid profile email",
       "https://llm.example/v1",
@@ -32,40 +48,73 @@ test("runFirstRunSetup prompts in order, tests endpoint, and saves only non-secr
       connectivityCalls.push(baseUrl);
       return { ok: true, normalizedUrl: baseUrl, modelCount: 3 };
     },
+    fetchDiscoveryMetadata: async (url) => {
+      assert.equal(url, discoveryUrl);
+      return exampleMetadata();
+    },
+  });
+
+  assert.deepEqual(prompts, ["OIDC discovery URL (OpenID configuration)", "Client ID", "Scopes", "LLM base URL"]);
+  assert.equal(connectivityCalls[0], "https://llm.example/v1");
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0]?.discoveryUrl, discoveryUrl);
+  assert.equal(saved[0]?.authentikHost, undefined);
+  assert.equal(saved[0]?.providerSlug, undefined);
+  assert.equal(saved[0]?.clientId, "pi-client");
+  assert.deepEqual(saved[0]?.scopes, ["openid", "profile", "email"]);
+  assert.equal(saved[0]?.enableOfflineAccess, true);
+  assert.deepEqual(result.settings, saved[0]);
+  assert.equal("clientSecret" in saved[0]!, false);
+  assert.match(notifications.map(({ message }) => message).join("\n"), /3 models/i);
+  assert.match(notifications.map(({ message }) => message).join("\n"), /issuer:/i);
+});
+
+test("runFirstRunSetup falls back to Authentik host + slug when discovery URL blank", async () => {
+  const prompts: string[] = [];
+  const ui = createUi({
+    inputs: [
+      "",
+      "https://auth.example/",
+      "main-provider",
+      "pi-client",
+      "openid profile email",
+      "https://llm.example/v1",
+    ],
+    confirms: [true, true, true],
+    prompts,
+  });
+
+  const saved: AuthentikStoredSettings[] = [];
+
+  await runFirstRunSetup({
+    ui,
+    saveSettings(settings) {
+      saved.push(settings);
+    },
+    testConnectivity: async (baseUrl) => ({ ok: true, normalizedUrl: baseUrl, modelCount: 3 }),
+    fetchDiscoveryMetadata: async (url) => {
+      assert.match(url, /\/application\/o\/main-provider\/\.well-known\/openid-configuration$/);
+      return exampleMetadata();
+    },
   });
 
   assert.deepEqual(prompts, [
+    "OIDC discovery URL (OpenID configuration)",
     "Authentik host",
     "Provider slug",
     "Client ID",
     "Scopes",
     "LLM base URL",
   ]);
-  assert.equal(connectivityCalls[0], "https://llm.example/v1");
-  assert.equal(saved.length, 1);
-  assert.deepEqual(saved[0], {
-    authentikHost: "https://auth.example",
-    providerSlug: "main-provider",
-    clientId: "pi-client",
-    scopes: ["openid", "profile", "email"],
-    enableOfflineAccess: true,
-    llmBaseUrl: "https://llm.example/v1",
-  });
-  assert.deepEqual(result.settings, saved[0]);
-  assert.equal("clientSecret" in saved[0], false);
-  assert.match(notifications.map(({ message }) => message).join("\n"), /3 models/i);
+  assert.equal(saved[0]?.authentikHost, "https://auth.example");
+  assert.equal(saved[0]?.providerSlug, "main-provider");
+  assert.equal(saved[0]?.discoveryUrl, undefined);
 });
 
 test("runFirstRunSetup offers to auto-append /v1 after confirmation", async () => {
   const ui = createUi({
-    inputs: [
-      "https://auth.example",
-      "main-provider",
-      "pi-client",
-      "",
-      "https://llm.example/openai",
-    ],
-    confirms: [false, true, true],
+    inputs: ["", "https://auth.example", "main-provider", "pi-client", "", "https://llm.example/openai"],
+    confirms: [true, false, true, true],
   });
 
   const saved: AuthentikStoredSettings[] = [];
@@ -76,6 +125,7 @@ test("runFirstRunSetup offers to auto-append /v1 after confirmation", async () =
       saved.push(settings);
     },
     testConnectivity: async (baseUrl) => ({ ok: true, normalizedUrl: baseUrl, modelCount: 1 }),
+    fetchDiscoveryMetadata: async () => exampleMetadata(),
   });
 
   assert.equal(saved[0]?.llmBaseUrl, "https://llm.example/openai/v1");
@@ -87,6 +137,7 @@ test("runFirstRunSetup rejects invalid LLM URLs with helpful examples and retrie
   const notifications: Array<{ message: string; level: string }> = [];
   const ui = createUi({
     inputs: [
+      "",
       "https://auth.example",
       "main-provider",
       "pi-client",
@@ -94,7 +145,7 @@ test("runFirstRunSetup rejects invalid LLM URLs with helpful examples and retrie
       "not-a-url",
       "https://llm.example/v1",
     ],
-    confirms: [false, false],
+    confirms: [true, false, false],
     notifications,
   });
 
@@ -106,6 +157,7 @@ test("runFirstRunSetup rejects invalid LLM URLs with helpful examples and retrie
       saved.push(settings);
     },
     testConnectivity: async (baseUrl) => ({ ok: true, normalizedUrl: baseUrl, modelCount: 1 }),
+    fetchDiscoveryMetadata: async () => exampleMetadata(),
   });
 
   assert.equal(saved[0]?.llmBaseUrl, "https://llm.example/v1");
@@ -116,13 +168,14 @@ test("runFirstRunSetup offers endpoint test before final save and can skip it", 
   const notifications: Array<{ message: string; level: string }> = [];
   const ui = createUi({
     inputs: [
+      "",
       "https://auth.example",
       "main-provider",
       "pi-client",
       "openid profile email offline_access",
       "https://llm.example/v1",
     ],
-    confirms: [false, false],
+    confirms: [true, false, false],
     notifications,
   });
 
@@ -138,11 +191,33 @@ test("runFirstRunSetup offers endpoint test before final save and can skip it", 
       connectivityCalled = true;
       return { ok: true, normalizedUrl: "https://llm.example/v1", modelCount: 1 };
     },
+    fetchDiscoveryMetadata: async () => exampleMetadata(),
   });
 
   assert.equal(connectivityCalled, false);
   assert.equal(saveCount, 1);
   assert.match(notifications.map(({ message }) => message).join("\n"), /skip.*connectivity test/i);
+});
+
+test("runFirstRunSetup does not save when loopback redirect confirmation is declined", async () => {
+  const ui = createUi({
+    inputs: ["https://auth.example/application/o/x/.well-known/openid-configuration"],
+    confirms: [false],
+  });
+
+  let saveCount = 0;
+
+  const result = await runFirstRunSetup({
+    ui,
+    saveSettings() {
+      saveCount += 1;
+    },
+    fetchDiscoveryMetadata: async () => exampleMetadata(),
+  });
+
+  assert.equal(saveCount, 0);
+  assert.equal(result.saved, false);
+  assert.equal(result.settings, null);
 });
 
 function createUi(options: {

--- a/extensions/pi-authentik/first-run.ts
+++ b/extensions/pi-authentik/first-run.ts
@@ -1,3 +1,6 @@
+import { deriveDiscoveryUrl } from "./auth-config.ts";
+import type { OidcDiscoveryMetadata } from "./discovery.ts";
+import { fetchOidcDiscoveryMetadata } from "./discovery.ts";
 import { testModelsEndpointConnectivity, validateOpenAIBaseUrl } from "./endpoint-validator.ts";
 import { DEFAULT_SCOPES } from "./settings.ts";
 import { saveCurrentGlobalSettings } from "./settings-store.ts";
@@ -22,6 +25,7 @@ export interface RunFirstRunSetupOptions {
   ui: FirstRunUi;
   saveSettings?: (settings: AuthentikStoredSettings) => void | Promise<void>;
   testConnectivity?: (baseUrl: string) => Promise<FirstRunConnectivityResult>;
+  fetchDiscoveryMetadata?: (discoveryUrl: string) => Promise<OidcDiscoveryMetadata>;
 }
 
 /** Outcome of the first-run setup flow. */
@@ -33,6 +37,19 @@ export interface FirstRunSetupResult {
 
 const LLM_URL_EXAMPLES = ["https://llm.example/v1", "https://llm.example/openai/v1"];
 
+const DISCOVERY_PLACEHOLDER = "https://id.example/application/o/my-provider/.well-known/openid-configuration";
+
+const LOOPBACK_REDIRECT_CONFIRM_TITLE = "Loopback OAuth redirect URIs configured?";
+
+const LOOPBACK_REDIRECT_CONFIRM_BODY = [
+  "Pi signs in with OIDC Authorization Code + PKCE and uses a temporary loopback URL:",
+  "  http://127.0.0.1:<random-port>/callback",
+  "",
+  'In Authentik, configure this OAuth2/OIDC provider to allow loopback redirects (exact rules depend on your Authentik version — see AUTHENTIK_SETUP.md in pi-authentik, section "Loopback redirect URI setup").',
+  "",
+  "This is not the reverse-proxy callback (for example URLs containing outpost.goauthentik.io on your API host). Use a dedicated public client here, not only the Embedded Outpost client used by your upstream proxy.",
+].join("\n");
+
 /**
  * Prompts for authentik and LLM endpoint settings, optionally tests connectivity,
  * and persists the resulting non-secret configuration.
@@ -43,10 +60,21 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   const { ui } = options;
   const saveSettings = options.saveSettings ?? saveCurrentGlobalSettings;
   const testConnectivity = options.testConnectivity ?? (async (baseUrl: string) => testModelsEndpointConnectivity({ baseUrl }));
+  const fetchDiscovery = options.fetchDiscoveryMetadata ?? ((discoveryUrl: string) => fetchOidcDiscoveryMetadata({ discoveryUrl }));
 
-  const authentikHost = await promptForAbsoluteUrl(ui, "Authentik host", "https://auth.example", "Authentik host");
-  const providerSlug = await promptForRequiredText(ui, "Provider slug", "default-provider");
-  const clientId = await promptForRequiredText(ui, "Client ID", "pi-client");
+  const resolved = await resolveOidcConfiguration(ui, fetchDiscovery);
+
+  const redirectOk = await ui.confirm(LOOPBACK_REDIRECT_CONFIRM_TITLE, LOOPBACK_REDIRECT_CONFIRM_BODY);
+  if (!redirectOk) {
+    ui.notify("Setup cancelled until loopback redirects are acknowledged.", "warning");
+    return {
+      saved: false,
+      settings: null,
+      connectivityTested: false,
+    };
+  }
+
+  const clientId = await promptForRequiredText(ui, "Client ID", "pi-desktop-client");
   const scopes = await promptForScopes(ui);
   const enableOfflineAccess = await ui.confirm(
     "Enable offline_access?",
@@ -64,8 +92,9 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   }
 
   const settings = sanitizeSetupSettings({
-    authentikHost,
-    providerSlug,
+    ...(resolved.discoveryUrl ? { discoveryUrl: resolved.discoveryUrl } : {}),
+    ...(resolved.authentikHost ? { authentikHost: resolved.authentikHost } : {}),
+    ...(resolved.providerSlug ? { providerSlug: resolved.providerSlug } : {}),
     clientId,
     scopes,
     enableOfflineAccess,
@@ -82,6 +111,55 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   };
 }
 
+interface ResolvedOidcConfiguration {
+  /** Stored only when supplied explicitly; omit when deriving from host + slug. */
+  discoveryUrl?: string;
+  authentikHost?: string;
+  providerSlug?: string;
+  metadata?: OidcDiscoveryMetadata;
+}
+
+async function resolveOidcConfiguration(
+  ui: FirstRunUi,
+  fetchDiscovery: (discoveryUrl: string) => Promise<OidcDiscoveryMetadata>,
+): Promise<ResolvedOidcConfiguration> {
+  for (;;) {
+    const pasted = await promptForOptionalDiscoveryUrl(ui);
+    if (pasted !== null) {
+      try {
+        const metadata = await fetchDiscovery(pasted);
+        ui.notify(`OIDC discovery OK. issuer: ${metadata.issuer}`, "info");
+        return { discoveryUrl: pasted, metadata };
+      } catch (error) {
+        ui.notify(
+          `Discovery failed (${error instanceof Error ? error.message : String(error)}). Check the URL and try again, or leave it empty to use Authentik host + provider slug.`,
+          "error",
+        );
+      }
+      continue;
+    }
+
+    const authentikHost = await promptForAbsoluteUrl(ui, "Authentik host", "https://auth.example", "Authentik host");
+    const providerSlug = await promptForRequiredText(ui, "Provider slug", "default-provider");
+    const discoveryUrlDerived = deriveDiscoveryUrl(authentikHost, providerSlug);
+
+    try {
+      const metadata = await fetchDiscovery(discoveryUrlDerived);
+      ui.notify(`OIDC discovery OK. issuer: ${metadata.issuer}`, "info");
+      return {
+        authentikHost,
+        providerSlug,
+        metadata,
+      };
+    } catch (error) {
+      ui.notify(
+        `Could not load discovery from ${discoveryUrlDerived} (${error instanceof Error ? error.message : String(error)}). Verify host and provider slug.`,
+        "error",
+      );
+    }
+  }
+}
+
 /**
  * Normalizes setup values before they are written to Pi settings storage.
  * @param settings - Raw settings gathered from the setup flow.
@@ -93,14 +171,60 @@ export function sanitizeSetupSettings(settings: AuthentikStoredSettings): Authen
     .filter(Boolean)
     .filter((scope) => scope !== "offline_access");
 
-  return {
-    authentikHost: settings.authentikHost?.trim(),
-    providerSlug: settings.providerSlug?.trim(),
+  const out: AuthentikStoredSettings = {
     clientId: settings.clientId?.trim(),
     scopes: filteredScopes.length > 0 ? Array.from(new Set(filteredScopes)) : [...DEFAULT_SCOPES],
     enableOfflineAccess: settings.enableOfflineAccess === true,
     llmBaseUrl: settings.llmBaseUrl?.trim(),
   };
+
+  const discoveryUrl = settings.discoveryUrl?.trim();
+  if (discoveryUrl) {
+    out.discoveryUrl = discoveryUrl;
+  }
+
+  const authentikHost = settings.authentikHost?.trim();
+  if (authentikHost) {
+    out.authentikHost = authentikHost;
+  }
+
+  const providerSlug = settings.providerSlug?.trim();
+  if (providerSlug) {
+    out.providerSlug = providerSlug;
+  }
+
+  return out;
+}
+
+async function promptForOptionalDiscoveryUrl(ui: FirstRunUi): Promise<string | null> {
+  for (;;) {
+    const raw = await ui.input(
+      "OIDC discovery URL (OpenID configuration)",
+      DISCOVERY_PLACEHOLDER,
+      "",
+    );
+    const trimmed = raw?.trim() ?? "";
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    try {
+      const url = new URL(trimmed);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new Error("Discovery URL must use http or https.");
+      }
+      if (url.search || url.hash) {
+        throw new Error("Discovery URL must not include a query string or hash fragment.");
+      }
+      url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+      return url.toString().replace(/\/$/, "");
+    } catch (error) {
+      ui.notify(
+        `${error instanceof Error ? error.message : "Discovery URL must be a valid absolute URL."}\nExample: ${DISCOVERY_PLACEHOLDER}`,
+        "error",
+      );
+    }
+  }
 }
 
 async function promptForRequiredText(ui: FirstRunUi, prompt: string, placeholder?: string): Promise<string> {

--- a/extensions/pi-authentik/index.test.ts
+++ b/extensions/pi-authentik/index.test.ts
@@ -17,6 +17,13 @@ const configuredSettings: AuthentikResolvedSettings = {
   modelFilters: ["gpt-*"],
 };
 
+const discoveryOnlySettings: AuthentikResolvedSettings = {
+  ...configuredSettings,
+  authentikHost: null,
+  providerSlug: null,
+  discoveryUrl: "https://auth.example/application/o/my-app/.well-known/openid-configuration",
+};
+
 test("session_start shows unauthenticated status when configured but no session exists", async () => {
   const harness = createHarness({
     settings: configuredSettings,
@@ -39,6 +46,20 @@ test("session_start shows missing endpoint guidance", async () => {
 
   assert.equal(harness.statuses.at(-1)?.value, "authentik: missing LLM endpoint");
   assert.match(harness.notifications.join("\n"), /authentik-endpoint|authentik-setup/);
+});
+
+test("session_start treats explicit discovery URL without host/slug as fully configured OIDC-wise", async () => {
+  const harness = createHarness({
+    settings: discoveryOnlySettings,
+    loadStoredSession: async () => null,
+  });
+
+  await harness.start();
+
+  assert.equal(harness.statuses.at(-1)?.value, "authentik: not signed in");
+  assert.match(harness.notifications.join("\n"), /authentik-login/);
+  await harness.run("authentik-status");
+  assert.match(harness.notifications.join("\n"), /Discovery:/);
 });
 
 test("session_start restores stored session, discovers models, filters them, and registers provider", async () => {
@@ -67,11 +88,19 @@ test("session_start refreshes an expired stored session when a refresh token exi
     now: () => 1_700_000_000_000,
     loadStoredSession: async () => ({
       ...exampleSession(),
-      tokens: { ...exampleSession().tokens, expiresAt: 1_699_999_900_000 },
+      tokens: {
+        ...exampleSession().tokens,
+        /** Expiry in epoch seconds — before `now` wall clock for refresh skew. */
+        expiresAt: 1_699_999_900,
+      },
     }),
     refreshSession: async () => ({
       ...exampleSession(),
-      tokens: { ...exampleSession().tokens, accessToken: "refreshed-token", expiresAt: 1_700_003_600_000 },
+      tokens: {
+        ...exampleSession().tokens,
+        accessToken: "refreshed-token",
+        expiresAt: 1_700_010_000,
+      },
     }),
     saveStoredSession: async (session) => {
       savedSessions.push(session);
@@ -310,7 +339,8 @@ function exampleSession(): AuthentikSessionRecord {
       accessToken: "access-token",
       idToken: "id-token",
       tokenType: "Bearer",
-      expiresAt: 1_700_003_600_000,
+      /** Stored in UNIX epoch seconds (`shouldRefresh`, token exchange). */
+      expiresAt: 1_700_005_500,
       refreshToken: "refresh-token",
       scope: "openid profile email",
     },
@@ -318,9 +348,9 @@ function exampleSession(): AuthentikSessionRecord {
       issuer: "https://auth.example/application/o/provider/",
       audience: ["pi-client"],
       subject: "user-123",
-      expiresAt: 1_700_003_600_000,
+      expiresAt: 1_700_005_500,
       nonce: "nonce",
-      issuedAt: 1_700_000_000_000,
+      issuedAt: 1_700_000_000,
       email: "user@example.com",
       name: "Example User",
       preferredUsername: "example",

--- a/extensions/pi-authentik/index.ts
+++ b/extensions/pi-authentik/index.ts
@@ -307,7 +307,6 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
       llmBaseUrl: result.normalizedUrl,
     };
     await runtime.saveSettings(toStoredSettings(state.settings));
-    state.discovery = null;
     if (state.session) {
       await registerProviderFromSession(ctx);
     } else {
@@ -417,8 +416,15 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
   }
 
   function renderStatusSummary(): string {
+    const oidcLine = state.settings.discoveryUrl
+      ? `Discovery: ${state.settings.discoveryUrl}`
+      : state.settings.authentikHost && state.settings.providerSlug
+        ? `Authentik: ${state.settings.authentikHost} (provider ${state.settings.providerSlug})`
+        : `OIDC: (incomplete — run /authentik-setup)`;
+
     return [
       `Configured: ${hasAuthConfig(state.settings) ? "yes" : "no"}`,
+      oidcLine,
       `Endpoint: ${state.settings.llmBaseUrl ?? "missing"}`,
       `Signed in: ${state.session ? "yes" : "no"}`,
       `Models: ${state.models.length}`,
@@ -464,7 +470,14 @@ export default function (pi: ExtensionAPI): void {
 }
 
 function hasAuthConfig(settings: AuthentikResolvedSettings): boolean {
-  return Boolean(settings.authentikHost && settings.providerSlug && settings.clientId);
+  if (!settings.clientId) {
+    return false;
+  }
+
+  const hasDerivedOidcEndpoints = Boolean(settings.authentikHost && settings.providerSlug);
+  const hasExplicitDiscovery = Boolean(settings.discoveryUrl);
+
+  return hasExplicitDiscovery || hasDerivedOidcEndpoints;
 }
 
 function shouldRefresh(session: AuthentikSessionRecord, nowMs: number): boolean {

--- a/extensions/pi-authentik/llm-client.ts
+++ b/extensions/pi-authentik/llm-client.ts
@@ -61,8 +61,8 @@ async function parseJson(response: Response): Promise<unknown> {
     return JSON.parse(text) as unknown;
   } catch {
     const trimmed = text.trimStart();
-    const looksLikeHtml =
-      trimmed.startsWith("<!DOCTYPE") || trimmed.toLowerCase().startsWith("<html");
+    const lower = trimmed.toLowerCase();
+    const looksLikeHtml = lower.startsWith("<!doctype") || lower.startsWith("<html");
     const hint = looksLikeHtml ? " — response was HTML, not JSON (often an SSO or login page)" : "";
     throw new Error(`Expected JSON response from ${response.url || "endpoint"}${hint}`);
   }

--- a/extensions/pi-authentik/llm-client.ts
+++ b/extensions/pi-authentik/llm-client.ts
@@ -60,7 +60,11 @@ async function parseJson(response: Response): Promise<unknown> {
   try {
     return JSON.parse(text) as unknown;
   } catch {
-    throw new Error(`Expected JSON response from ${response.url || "endpoint"}`);
+    const trimmed = text.trimStart();
+    const looksLikeHtml =
+      trimmed.startsWith("<!DOCTYPE") || trimmed.toLowerCase().startsWith("<html");
+    const hint = looksLikeHtml ? " — response was HTML, not JSON (often an SSO or login page)" : "";
+    throw new Error(`Expected JSON response from ${response.url || "endpoint"}${hint}`);
   }
 }
 

--- a/extensions/pi-authentik/pi-coding-agent.d.ts
+++ b/extensions/pi-authentik/pi-coding-agent.d.ts
@@ -3,6 +3,9 @@ declare module "@earendil-works/pi-coding-agent" {
     events: {
       emit(event: string, data?: unknown): void;
     };
+    on(event: string, handler: (...args: any[]) => any): void;
+    registerCommand(name: string, command: { description?: string; handler: (args: string | undefined, ctx: any) => Promise<void> | void }): void;
+    registerProvider(name: string, provider: Record<string, unknown>): void;
   }
 
   export function getAgentDir(): string;


### PR DESCRIPTION
- First-run prompts for OIDC discovery URL with host+slug fallback; validates via fetch.
- Require loopback redirect acknowledgment before save (cancel returns unsaved).
- hasAuthConfig accepts discoveryUrl-only; status shows discovery vs host/slug.
- Connectivity test uses redirect:manual, spots SSO redirects and HTML bodies.
- Improve JSON parse error hint for HTML responses.
- Do not clear cached OIDC discovery when only the LLM base URL changes (fixes logout).
- Fix example session expiries in tests to epoch seconds; fix exchangeCode assertion split.
- Update AUTHENTIK_SETUP for discovery-first settings.

Co-authored-by: Cursor <cursoragent@cursor.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive OIDC discovery setup: accept/validate discovery URL, derive from host+slug, confirm loopback redirect before saving.
  * Endpoint probing follows redirects and reports model availability more reliably.
  * Status summary now shows Discovery/Authentik info when available.

* **Bug Fixes**
  * Clearer errors when endpoints return HTML (SSO/login) instead of JSON.
  * Endpoint persistence and status display correctly reflect discovery/auth configuration.

* **Documentation**
  * Expanded setup guide with reordered, clearer discovery URL guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/184)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->