### PR TITLE
fix(pi-authentik): open browser or show URL on setup connectivity fail

### DIFF
--- a/extensions/pi-authentik/index.ts
+++ b/extensions/pi-authentik/index.ts
@@ -231,6 +231,7 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
         input: ctx.ui.input.bind(ctx.ui),
         confirm: ctx.ui.confirm.bind(ctx.ui),
         notify: ctx.ui.notify.bind(ctx.ui),
+        openUrl: (url) => runtime.openUrl(url),
       },
       saveSettings: runtime.saveSettings,
     });

--- a/extensions/pi-authentik/src/config/first-run.ts
+++ b/extensions/pi-authentik/src/config/first-run.ts
@@ -1,7 +1,7 @@
 import { deriveDiscoveryUrl } from "../auth/auth-config.ts";
 import type { OidcDiscoveryMetadata } from "../auth/discovery.ts";
 import { fetchOidcDiscoveryMetadata } from "../auth/discovery.ts";
-import { testModelsEndpointConnectivity, validateOpenAIBaseUrl } from "../llm/endpoint-validator.ts";
+import { testModelsEndpointConnectivity, validateOpenAIBaseUrl, type ConnectivityTestResult } from "../llm/endpoint-validator.ts";
 import { DEFAULT_SCOPES } from "./settings.ts";
 import { saveCurrentGlobalSettings } from "./settings-store.ts";
 import type { AuthentikStoredSettings } from "../shared/types.ts";
@@ -11,14 +11,11 @@ export interface FirstRunUi {
   input(prompt: string, placeholder?: string, defaultValue?: string): Promise<string | null | undefined>;
   confirm(title: string, message?: string): Promise<boolean>;
   notify(message: string, level?: "info" | "warning" | "error"): void;
+  openUrl?(url: string): Promise<void>;
 }
 
 /** Result returned after testing the configured models endpoint. */
-export interface FirstRunConnectivityResult {
-  ok: true;
-  normalizedUrl: string;
-  modelCount: number;
-}
+export type FirstRunConnectivityResult = ConnectivityTestResult;
 
 /** Dependencies used by the first-run wizard. */
 export interface RunFirstRunSetupOptions {
@@ -86,7 +83,26 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   if (await ui.confirm("Test LLM endpoint connectivity?", `Try GET ${llmBaseUrl}/models before saving.`)) {
     connectivityTested = true;
     const result = await testConnectivity(llmBaseUrl);
-    ui.notify(`LLM endpoint responded successfully. Found ${result.modelCount} models.`, "info");
+    if (result.ok) {
+      ui.notify(`LLM endpoint responded successfully. Found ${result.modelCount} models.`, "info");
+    } else {
+      ui.notify(`LLM endpoint connectivity test failed: ${result.error}`, "error");
+      if (result.authUrl) {
+        if (ui.openUrl) {
+          const open = await ui.confirm(
+            "Open login page?",
+            `The endpoint is behind authentication and redirected to:\n${result.authUrl}\n\nOpen this URL in your browser?`,
+          );
+          if (open) {
+            await ui.openUrl(result.authUrl).catch((error) => {
+              ui.notify(`Could not open login URL (${error instanceof Error ? error.message : String(error)})`, "warning");
+            });
+          }
+        } else {
+          ui.notify(`Login URL: ${result.authUrl}`, "info");
+        }
+      }
+    }
   } else {
     ui.notify("Skipping LLM endpoint connectivity test before save.", "warning");
   }

--- a/extensions/pi-authentik/src/llm/endpoint-validator.ts
+++ b/extensions/pi-authentik/src/llm/endpoint-validator.ts
@@ -123,6 +123,13 @@ async function probeModelsPayload(
 
         const next = new URL(location.trim(), response.url || currentUrl);
         if (locationSuggestsAuthenticationRedirect(next)) {
+          // Validate protocol to prevent injection of dangerous URL schemes
+          if (next.protocol !== "http:" && next.protocol !== "https:") {
+            return {
+              ok: false,
+              error: `GET /models redirected to ${next.protocol} URL (only http: and https: are allowed).`,
+            };
+          }
           return {
             ok: false,
             error: MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,

--- a/extensions/pi-authentik/src/llm/endpoint-validator.ts
+++ b/extensions/pi-authentik/src/llm/endpoint-validator.ts
@@ -22,12 +22,22 @@ export interface ConnectivityTestOptions {
   fetchImpl?: typeof fetch;
 }
 
-/** Result returned after probing the configured `/models` endpoint. */
-export interface ConnectivityTestResult {
+/** Successful probe of a models endpoint. */
+export interface ConnectivityTestSuccess {
   ok: true;
   normalizedUrl: string;
   modelCount: number;
 }
+
+/** Failed probe of a models endpoint, possibly due to required authentication. */
+export interface ConnectivityTestFailure {
+  ok: false;
+  error: string;
+  authUrl?: string;
+}
+
+/** Result returned after probing the configured `/models` endpoint. */
+export type ConnectivityTestResult = ConnectivityTestSuccess | ConnectivityTestFailure;
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
@@ -79,7 +89,7 @@ async function probeModelsPayload(
   normalizedBaseUrl: string,
   fetchImpl: typeof fetch,
   authStrategy?: LlmAuthStrategy,
-): Promise<{ modelCount: number; finalUrl: string }> {
+): Promise<ConnectivityTestResult> {
   const modelsUrl = `${normalizedBaseUrl.replace(/\/+$/, "")}/models`;
 
   let currentUrl = modelsUrl;
@@ -100,20 +110,24 @@ async function probeModelsPayload(
         response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual", signal: controller.signal });
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          throw new Error(`GET /models timed out after 30000ms`);
+          return { ok: false, error: `GET /models timed out after 30000ms` };
         }
-        throw error;
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
       }
 
       if (REDIRECT_STATUSES.has(response.status)) {
         const location = response.headers.get("location");
         if (!location || !location.trim()) {
-          throw new Error(`GET /models returned ${response.status} without a Location header.`);
+          return { ok: false, error: `GET /models returned ${response.status} without a Location header.` };
         }
 
         const next = new URL(location.trim(), response.url || currentUrl);
         if (locationSuggestsAuthenticationRedirect(next)) {
-          throw new Error(MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+          return {
+            ok: false,
+            error: MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,
+            authUrl: next.toString(),
+          };
         }
 
         currentUrl = next.toString();
@@ -123,36 +137,38 @@ async function probeModelsPayload(
       const text = await response.text();
 
       if (responseLooksLikeHtml(response, text)) {
-        throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
+        return { ok: false, error: MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE };
       }
 
       if (!response.ok) {
-        throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
+        return { ok: false, error: `GET /models failed: ${response.status} ${response.statusText}` };
       }
 
       let payload: unknown;
       try {
         payload = JSON.parse(text) as unknown;
       } catch {
-        throw new Error(
-          `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
-        );
+        return {
+          ok: false,
+          error: `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
+        };
       }
 
       if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
-        throw new Error(
-          `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
-        );
+        return {
+          ok: false,
+          error: `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
+        };
       }
 
       const data = (payload as { data: unknown[] }).data;
-      return { modelCount: data.length, finalUrl: response.url || currentUrl };
+      return { ok: true, normalizedUrl: normalizedBaseUrl, modelCount: data.length };
     } finally {
       clearTimeout(timeoutId);
     }
   }
 
-  throw new Error(`GET /models followed more than ${MAX_PROBE_REDIRECTS} redirects; aborting probe.`);
+  return { ok: false, error: `GET /models followed more than ${MAX_PROBE_REDIRECTS} redirects; aborting probe.` };
 }
 
 /**
@@ -237,24 +253,26 @@ export async function testModelsEndpointConnectivity(options: ConnectivityTestOp
 
   /** When Bearer auth already applies, reuse the structured client path (fewer probes). */
   if (options.authStrategy) {
-    const client = createOpenAICompatibleClient({
-      baseUrl: normalizedUrl,
-      authStrategy: options.authStrategy,
-      fetchImpl: options.fetchImpl,
-    });
-    const models = await client.listModels();
+    try {
+      const client = createOpenAICompatibleClient({
+        baseUrl: normalizedUrl,
+        authStrategy: options.authStrategy,
+        fetchImpl: options.fetchImpl,
+      });
+      const models = await client.listModels();
 
-    return {
-      ok: true,
-      normalizedUrl,
-      modelCount: models.length,
-    };
+      return {
+        ok: true,
+        normalizedUrl,
+        modelCount: models.length,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
-  const probe = await probeModelsPayload(normalizedUrl, fetchImpl);
-  return {
-    ok: true,
-    normalizedUrl,
-    modelCount: probe.modelCount,
-  };
+  return probeModelsPayload(normalizedUrl, fetchImpl);
 }

--- a/extensions/pi-authentik/src/tests/endpoint-validator.test.ts
+++ b/extensions/pi-authentik/src/tests/endpoint-validator.test.ts
@@ -68,14 +68,14 @@ test("testModelsEndpointConnectivity without auth rejects Authentik-style login 
     });
   };
 
-  await assert.rejects(
-    async () =>
-      testModelsEndpointConnectivity({
-        baseUrl: "https://proxy.example/services/llm/v1",
-        fetchImpl,
-      }),
-    (error: unknown) => error instanceof Error && error.message === MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,
-  );
+  const result = await testModelsEndpointConnectivity({
+    baseUrl: "https://proxy.example/services/llm/v1",
+    fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+  assert.equal(result.authUrl, "https://idp.example/if/flow/default-authentication-flow/?next=/");
 });
 
 test("testModelsEndpointConnectivity without auth rejects HTML bodies", async () => {
@@ -85,14 +85,13 @@ test("testModelsEndpointConnectivity without auth rejects HTML bodies", async ()
       headers: { "content-type": "text/html; charset=utf-8" },
     });
 
-  await assert.rejects(
-    async () =>
-      testModelsEndpointConnectivity({
-        baseUrl: "https://api.example/v1",
-        fetchImpl,
-      }),
-    (error: unknown) => error instanceof Error && error.message === MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE,
-  );
+  const result = await testModelsEndpointConnectivity({
+    baseUrl: "https://api.example/v1",
+    fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
 });
 
 test("testModelsEndpointConnectivity without auth follows benign redirects then parses JSON", async () => {

--- a/extensions/pi-authentik/src/tests/first-run.test.ts
+++ b/extensions/pi-authentik/src/tests/first-run.test.ts
@@ -220,11 +220,48 @@ test("runFirstRunSetup does not save when loopback redirect confirmation is decl
   assert.equal(result.settings, null);
 });
 
+test("runFirstRunSetup offers to open login page when connectivity test fails with an auth redirect", async () => {
+  const notifications: Array<{ message: string; level: string }> = [];
+  const openUrls: string[] = [];
+
+  const ui = createUi({
+    inputs: [
+      "",
+      "https://auth.example",
+      "main-provider",
+      "pi-client",
+      "openid",
+      "https://llm.example/v1",
+    ],
+    confirms: [true, false, true, true], // loopback, offline, test connectivity, open login page
+    notifications,
+    openUrl: async (url) => {
+      openUrls.push(url);
+    },
+  });
+
+  await runFirstRunSetup({
+    ui,
+    saveSettings: () => {},
+    testConnectivity: async () => ({
+      ok: false,
+      error: "Auth redirect",
+      authUrl: "https://auth.example/login",
+    }),
+    fetchDiscoveryMetadata: async () => exampleMetadata(),
+  });
+
+  assert.equal(openUrls.length, 1);
+  assert.equal(openUrls[0], "https://auth.example/login");
+  assert.match(notifications.map(({ message }) => message).join("\n"), /Open login page?/i);
+});
+
 function createUi(options: {
   inputs: string[];
   confirms: boolean[];
   prompts?: string[];
   notifications?: Array<{ message: string; level: string }>;
+  openUrl?: (url: string) => Promise<void>;
 }): FirstRunUi {
   const inputs = [...options.inputs];
   const confirms = [...options.confirms];
@@ -247,5 +284,6 @@ function createUi(options: {
     notify(message, level = "info") {
       notifications.push({ message, level });
     },
+    openUrl: options.openUrl,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-run setup can now open URLs directly, letting users navigate to login pages during configuration
  * Connectivity checks return clearer, user-friendly results for LLM endpoint failures

* **Bug Fixes**
  * Improved handling of authentication redirects during endpoint validation; errors surface instead of exceptions

* **Tests**
  * Added tests verifying structured connectivity results and the prompt to open login pages during first-run setup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/187)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->