### PR TITLE
feat(pi-authentik): automatically trigger login flow if auth redirect detected during setup

### DIFF
--- a/extensions/pi-authentik/index.ts
+++ b/extensions/pi-authentik/index.ts
@@ -239,6 +239,10 @@ export function createPiAuthentikExtension(pi: ExtensionAPI, deps: Partial<Authe
     state.settings = await runtime.resolveSettings(ctx.cwd);
     state.discovery = null;
     updateStatus(ctx);
+
+    if (result.loginRequested) {
+      await handleLogin(ctx);
+    }
   }
 
   async function handleLogin(ctx: CommandContextLike): Promise<void> {

--- a/extensions/pi-authentik/src/config/first-run.ts
+++ b/extensions/pi-authentik/src/config/first-run.ts
@@ -1,7 +1,7 @@
 import { deriveDiscoveryUrl } from "../auth/auth-config.ts";
 import type { OidcDiscoveryMetadata } from "../auth/discovery.ts";
 import { fetchOidcDiscoveryMetadata } from "../auth/discovery.ts";
-import { testModelsEndpointConnectivity, validateOpenAIBaseUrl } from "../llm/endpoint-validator.ts";
+import { testModelsEndpointConnectivity, validateOpenAIBaseUrl, type ConnectivityTestResult } from "../llm/endpoint-validator.ts";
 import { DEFAULT_SCOPES } from "./settings.ts";
 import { saveCurrentGlobalSettings } from "./settings-store.ts";
 import type { AuthentikStoredSettings } from "../shared/types.ts";
@@ -14,11 +14,7 @@ export interface FirstRunUi {
 }
 
 /** Result returned after testing the configured models endpoint. */
-export interface FirstRunConnectivityResult {
-  ok: true;
-  normalizedUrl: string;
-  modelCount: number;
-}
+export type FirstRunConnectivityResult = ConnectivityTestResult;
 
 /** Dependencies used by the first-run wizard. */
 export interface RunFirstRunSetupOptions {
@@ -33,6 +29,7 @@ export interface FirstRunSetupResult {
   saved: boolean;
   settings: AuthentikStoredSettings | null;
   connectivityTested: boolean;
+  loginRequested: boolean;
 }
 
 const LLM_URL_EXAMPLES = ["https://llm.example/v1", "https://llm.example/openai/v1"];
@@ -71,6 +68,7 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
       saved: false,
       settings: null,
       connectivityTested: false,
+      loginRequested: false,
     };
   }
 
@@ -83,10 +81,21 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   const llmBaseUrl = await promptForLlmBaseUrl(ui);
 
   let connectivityTested = false;
+  let loginRequested = false;
   if (await ui.confirm("Test LLM endpoint connectivity?", `Try GET ${llmBaseUrl}/models before saving.`)) {
     connectivityTested = true;
     const result = await testConnectivity(llmBaseUrl);
-    ui.notify(`LLM endpoint responded successfully. Found ${result.modelCount} models.`, "info");
+    if (result.ok) {
+      ui.notify(`LLM endpoint responded successfully. Found ${result.modelCount} models.`, "info");
+    } else {
+      ui.notify(`LLM endpoint connectivity test failed: ${result.error}`, "error");
+      if (result.authUrl) {
+        loginRequested = await ui.confirm(
+          "Authenticate now?",
+          "The endpoint is behind authentication. Would you like to log in now to verify full connectivity?",
+        );
+      }
+    }
   } else {
     ui.notify("Skipping LLM endpoint connectivity test before save.", "warning");
   }
@@ -108,6 +117,7 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
     saved: true,
     settings,
     connectivityTested,
+    loginRequested,
   };
 }
 

--- a/extensions/pi-authentik/src/llm/endpoint-validator.ts
+++ b/extensions/pi-authentik/src/llm/endpoint-validator.ts
@@ -22,12 +22,22 @@ export interface ConnectivityTestOptions {
   fetchImpl?: typeof fetch;
 }
 
-/** Result returned after probing the configured `/models` endpoint. */
-export interface ConnectivityTestResult {
+/** Successful probe of a models endpoint. */
+export interface ConnectivityTestSuccess {
   ok: true;
   normalizedUrl: string;
   modelCount: number;
 }
+
+/** Failed probe of a models endpoint, possibly due to required authentication. */
+export interface ConnectivityTestFailure {
+  ok: false;
+  error: string;
+  authUrl?: string;
+}
+
+/** Result returned after probing the configured `/models` endpoint. */
+export type ConnectivityTestResult = ConnectivityTestSuccess | ConnectivityTestFailure;
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
@@ -79,7 +89,7 @@ async function probeModelsPayload(
   normalizedBaseUrl: string,
   fetchImpl: typeof fetch,
   authStrategy?: LlmAuthStrategy,
-): Promise<{ modelCount: number; finalUrl: string }> {
+): Promise<ConnectivityTestResult> {
   const modelsUrl = `${normalizedBaseUrl.replace(/\/+$/, "")}/models`;
 
   let currentUrl = modelsUrl;
@@ -100,20 +110,24 @@ async function probeModelsPayload(
         response = await fetchImpl(currentUrl, { method: "GET", headers, redirect: "manual", signal: controller.signal });
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
-          throw new Error(`GET /models timed out after 30000ms`);
+          return { ok: false, error: `GET /models timed out after 30000ms` };
         }
-        throw error;
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
       }
 
       if (REDIRECT_STATUSES.has(response.status)) {
         const location = response.headers.get("location");
         if (!location || !location.trim()) {
-          throw new Error(`GET /models returned ${response.status} without a Location header.`);
+          return { ok: false, error: `GET /models returned ${response.status} without a Location header.` };
         }
 
         const next = new URL(location.trim(), response.url || currentUrl);
         if (locationSuggestsAuthenticationRedirect(next)) {
-          throw new Error(MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+          return {
+            ok: false,
+            error: MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,
+            authUrl: next.toString(),
+          };
         }
 
         currentUrl = next.toString();
@@ -123,36 +137,38 @@ async function probeModelsPayload(
       const text = await response.text();
 
       if (responseLooksLikeHtml(response, text)) {
-        throw new Error(MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
+        return { ok: false, error: MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE };
       }
 
       if (!response.ok) {
-        throw new Error(`GET /models failed: ${response.status} ${response.statusText}`);
+        return { ok: false, error: `GET /models failed: ${response.status} ${response.statusText}` };
       }
 
       let payload: unknown;
       try {
         payload = JSON.parse(text) as unknown;
       } catch {
-        throw new Error(
-          `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
-        );
+        return {
+          ok: false,
+          error: `GET /models did not return JSON (final URL: ${response.url || currentUrl}). If the endpoint is behind SSO, skip the connectivity test.`,
+        };
       }
 
       if (typeof payload !== "object" || payload === null || !Array.isArray((payload as { data?: unknown }).data)) {
-        throw new Error(
-          `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
-        );
+        return {
+          ok: false,
+          error: `/models returned an unexpected shape: expected an object with a data array, got ${JSON.stringify(payload)}`,
+        };
       }
 
       const data = (payload as { data: unknown[] }).data;
-      return { modelCount: data.length, finalUrl: response.url || currentUrl };
+      return { ok: true, normalizedUrl: normalizedBaseUrl, modelCount: data.length };
     } finally {
       clearTimeout(timeoutId);
     }
   }
 
-  throw new Error(`GET /models followed more than ${MAX_PROBE_REDIRECTS} redirects; aborting probe.`);
+  return { ok: false, error: `GET /models followed more than ${MAX_PROBE_REDIRECTS} redirects; aborting probe.` };
 }
 
 /**
@@ -237,24 +253,26 @@ export async function testModelsEndpointConnectivity(options: ConnectivityTestOp
 
   /** When Bearer auth already applies, reuse the structured client path (fewer probes). */
   if (options.authStrategy) {
-    const client = createOpenAICompatibleClient({
-      baseUrl: normalizedUrl,
-      authStrategy: options.authStrategy,
-      fetchImpl: options.fetchImpl,
-    });
-    const models = await client.listModels();
+    try {
+      const client = createOpenAICompatibleClient({
+        baseUrl: normalizedUrl,
+        authStrategy: options.authStrategy,
+        fetchImpl: options.fetchImpl,
+      });
+      const models = await client.listModels();
 
-    return {
-      ok: true,
-      normalizedUrl,
-      modelCount: models.length,
-    };
+      return {
+        ok: true,
+        normalizedUrl,
+        modelCount: models.length,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
-  const probe = await probeModelsPayload(normalizedUrl, fetchImpl);
-  return {
-    ok: true,
-    normalizedUrl,
-    modelCount: probe.modelCount,
-  };
+  return probeModelsPayload(normalizedUrl, fetchImpl);
 }

--- a/extensions/pi-authentik/src/tests/endpoint-validator.test.ts
+++ b/extensions/pi-authentik/src/tests/endpoint-validator.test.ts
@@ -68,14 +68,14 @@ test("testModelsEndpointConnectivity without auth rejects Authentik-style login 
     });
   };
 
-  await assert.rejects(
-    async () =>
-      testModelsEndpointConnectivity({
-        baseUrl: "https://proxy.example/services/llm/v1",
-        fetchImpl,
-      }),
-    (error: unknown) => error instanceof Error && error.message === MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE,
-  );
+  const result = await testModelsEndpointConnectivity({
+    baseUrl: "https://proxy.example/services/llm/v1",
+    fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, MODELS_ENDPOINT_AUTH_REDIRECT_MESSAGE);
+  assert.equal(result.authUrl, "https://idp.example/if/flow/default-authentication-flow/?next=/");
 });
 
 test("testModelsEndpointConnectivity without auth rejects HTML bodies", async () => {
@@ -85,14 +85,13 @@ test("testModelsEndpointConnectivity without auth rejects HTML bodies", async ()
       headers: { "content-type": "text/html; charset=utf-8" },
     });
 
-  await assert.rejects(
-    async () =>
-      testModelsEndpointConnectivity({
-        baseUrl: "https://api.example/v1",
-        fetchImpl,
-      }),
-    (error: unknown) => error instanceof Error && error.message === MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE,
-  );
+  const result = await testModelsEndpointConnectivity({
+    baseUrl: "https://api.example/v1",
+    fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, MODELS_ENDPOINT_HTML_RESPONSE_MESSAGE);
 });
 
 test("testModelsEndpointConnectivity without auth follows benign redirects then parses JSON", async () => {

--- a/extensions/pi-authentik/src/tests/first-run.test.ts
+++ b/extensions/pi-authentik/src/tests/first-run.test.ts
@@ -219,6 +219,25 @@ test("runFirstRunSetup does not save when loopback redirect confirmation is decl
   assert.equal(result.saved, false);
   assert.equal(result.settings, null);
 });
+test("runFirstRunSetup returns loginRequested: true when auth redirect detected and user accepts prompt", async () => {
+  const ui = createUi({
+    inputs: ["", "https://auth.example", "provider", "client", "openid", "https://llm.example/v1"],
+    confirms: [true, false, true, true], // acknowledge loopback, skip offline, test connectivity, login now
+  });
+
+  const result = await runFirstRunSetup({
+    ui,
+    saveSettings: () => {},
+    testConnectivity: async () => ({
+      ok: false,
+      error: "Auth required",
+      authUrl: "https://auth.example/login",
+    }),
+    fetchDiscoveryMetadata: async () => exampleMetadata(),
+  });
+
+  assert.equal(result.loginRequested, true);
+});
 
 function createUi(options: {
   inputs: string[];

--- a/extensions/pi-authentik/src/tests/index.test.ts
+++ b/extensions/pi-authentik/src/tests/index.test.ts
@@ -115,6 +115,61 @@ test("session_start refreshes an expired stored session when a refresh token exi
   assert.match(harness.notifications.join("\n"), /restored session from refresh token/i);
 });
 
+test("authentik-setup triggers handleLogin when runFirstRunSetup returns loginRequested: true", async () => {
+  let setupCalls = 0;
+  let loginCalls = 0;
+  const savedSessions: AuthentikSessionRecord[] = [];
+
+  const harness = createHarness({
+    settings: configuredSettings,
+    loadStoredSession: async () => null,
+    runFirstRunSetup: async () => {
+      setupCalls += 1;
+      return {
+        saved: true,
+        loginRequested: true,
+        settings: {
+          authentikHost: configuredSettings.authentikHost ?? undefined,
+          providerSlug: configuredSettings.providerSlug ?? undefined,
+          clientId: configuredSettings.clientId ?? undefined,
+          scopes: configuredSettings.scopes,
+          enableOfflineAccess: true,
+          llmBaseUrl: configuredSettings.llmBaseUrl ?? undefined,
+        },
+        connectivityTested: true,
+      };
+    },
+    runBrowserLogin: async () => {
+      loginCalls += 1;
+      return exampleSession();
+    },
+    saveStoredSession: async (session) => {
+      savedSessions.push(session);
+    },
+    fetchOidcDiscoveryMetadata: async () => ({
+      issuer: "https://auth.example/application/o/provider/",
+      authorization_endpoint: "https://auth.example/application/o/authorize/",
+      token_endpoint: "https://auth.example/application/o/token/",
+      jwks_uri: "https://auth.example/application/o/jwks/",
+      response_types_supported: ["code"],
+      subject_types_supported: ["public"],
+      id_token_signing_alg_values_supported: ["RS256"],
+      code_challenge_methods_supported: ["S256"],
+    }),
+    models: [{ id: "gpt-4.1" }],
+  });
+
+  await harness.start();
+  await harness.run("authentik-setup");
+
+  assert.equal(setupCalls, 1, "runFirstRunSetup should be called once");
+  assert.equal(loginCalls, 1, "handleLogin should be called once when loginRequested is true");
+  assert.equal(savedSessions.length, 1, "session should be saved after login");
+  assert.equal(savedSessions[0]?.tokens.accessToken, "access-token");
+  assert.equal(harness.providers.length, 1, "provider should be registered after login");
+  assert.match(harness.notifications.join("\n"), /Signed in successfully/);
+});
+
 test("commands handle setup, login, status, endpoint, refresh-models, and logout", async () => {
   const savedSettings: AuthentikStoredSettings[] = [];
   const savedSessions: AuthentikSessionRecord[] = [];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-run setup now continues directly into sign-in when an LLM connectivity check requests login, enabling immediate authentication after setup.

* **Bug Fixes**
  * Endpoint connectivity checks now return structured success/failure results with clearer error messages (including auth redirect info) and better handling of timeouts, redirects, and non-JSON responses.

* **Tests**
  * Added and updated unit and integration tests covering auth-required connectivity flows and the end-to-end setup→sign-in behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/188)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->