### PR TITLE
fix(pi-a2a): skip hub auto-registration when name is not set

### DIFF
--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -1009,8 +1009,8 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 
-		// Optional: register with A2A Hub
-		if (config.hub && config.hub.apiKey && (config.hub.autoRegister !== false)) {
+		// Optional: register with A2A Hub — requires an explicit name
+		if (config.name && config.hub && config.hub.apiKey && (config.hub.autoRegister !== false)) {
 			const result = await registerWithHub(agentPublicUrl, config.hub, log);
 			if (result) {
 				hubAgentId = result.agentId;


### PR DESCRIPTION
Auto-registering with the A2A Hub without an explicit `name` in settings.json causes the agent to appear with a generic default name. This change requires `config.name` to be explicitly set before allowing auto-registration.

- Adds `config.name` check to the hub registration condition in `session_start`
- Updated comment to reflect the new requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * A2A hub registration during session initialization now requires explicit agent name configuration. Hub registration and heartbeat setup operations are automatically skipped when agent name is not provided in configuration, preventing potential registration failures and ensuring system stability and reliable agent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/191)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->