### PR TITLE
feat(pi-authentik): simplify setup flow and document encryption requirement

### DIFF
--- a/extensions/pi-authentik/docs/AUTHENTIK_SETUP.md
+++ b/extensions/pi-authentik/docs/AUTHENTIK_SETUP.md
@@ -28,6 +28,27 @@ Configure the authentik provider/application as a standard OIDC public client:
 - Client type: public
 - Redirect URIs: allow loopback redirect URLs
 
+## Disable ID token encryption
+
+Pi expects **signed** (JWS) ID tokens, not **encrypted** (JWE) tokens. If the
+provider has an encryption key configured, Authentik returns JWE tokens that
+Pi cannot decrypt.
+
+**In the provider settings, make sure `Encryption Key` is empty (no key selected).**
+When left empty, Authentik issues standard RS256-signed JWTs.
+
+### How to verify
+
+After logging in, if you see an error like:
+
+```
+ID token verification failed: Invalid Compact JWS
+```
+
+Your provider is encrypting tokens. Go back to the provider settings in
+Authentik and clear the `Encryption Key` field, then run `/authentik-login`
+again.
+
 ## Loopback redirect URI setup
 
 Pi starts a temporary local callback server bound to `127.0.0.1` on a random port and uses `/callback` as the path.

--- a/extensions/pi-authentik/src/auth/jwt.ts
+++ b/extensions/pi-authentik/src/auth/jwt.ts
@@ -8,6 +8,18 @@ import type { AuthentikUserSession, VerifyIdTokenOptions } from "../shared/types
  * @returns Verified user session claims extracted from the ID token.
  */
 export async function verifyIdToken(options: VerifyIdTokenOptions): Promise<AuthentikUserSession> {
+  // Reject JWE tokens early with a helpful message. A JWE has 5 dot-separated
+  // parts (header.encrypted_key.iv.ciphertext.auth_tag) whereas a signed JWT
+  // (JWS) has 3 (header.payload.signature).
+  if (options.idToken.split(".").length !== 3) {
+    throw new Error(
+      "ID token is encrypted (JWE) instead of signed (JWS). " +
+      "In Authentik, open the provider settings and make sure 'Encryption Key' " +
+      "is empty so that ID tokens are signed only, not encrypted. " +
+      "See AUTHENTIK_SETUP.md for details.",
+    );
+  }
+
   const jwks = createRemoteJWKSet(new URL(options.jwksUri));
 
   let payload;

--- a/extensions/pi-authentik/src/config/first-run.ts
+++ b/extensions/pi-authentik/src/config/first-run.ts
@@ -48,10 +48,11 @@ const LOOPBACK_REDIRECT_CONFIRM_BODY = [
 ].join("\n");
 
 /**
- * Prompts for authentik and LLM endpoint settings, optionally tests connectivity,
- * and persists the resulting non-secret configuration.
+ * Prompts for authentik and LLM endpoint settings, tests connectivity
+ * automatically, and triggers login when the endpoint is behind authentication.
+ * Uses a public client (PKCE) — no client secret required.
  * @param options - UI and persistence dependencies for the setup flow.
- * @returns The saved settings and whether the connectivity test was run.
+ * @returns The saved settings and whether login was requested.
  */
 export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promise<FirstRunSetupResult> {
   const { ui } = options;
@@ -80,24 +81,21 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   );
   const llmBaseUrl = await promptForLlmBaseUrl(ui);
 
-  let connectivityTested = false;
+  // Test connectivity automatically — no prompt. The LLM endpoint is
+  // almost always behind Authentik, so the probe will detect the auth
+  // redirect and set loginRequested = true.
+  const result = await testConnectivity(llmBaseUrl);
   let loginRequested = false;
-  if (await ui.confirm("Test LLM endpoint connectivity?", `Try GET ${llmBaseUrl}/models before saving.`)) {
-    connectivityTested = true;
-    const result = await testConnectivity(llmBaseUrl);
-    if (result.ok) {
-      ui.notify(`LLM endpoint responded successfully. Found ${result.modelCount} models.`, "info");
-    } else {
-      ui.notify(`LLM endpoint connectivity test failed: ${result.error}`, "error");
-      if (result.authUrl) {
-        loginRequested = await ui.confirm(
-          "Authenticate now?",
-          "The endpoint is behind authentication. Would you like to log in now to verify full connectivity?",
-        );
-      }
-    }
+  if (result.ok) {
+    ui.notify(`LLM endpoint responded successfully. Found ${result.modelCount} models.`, "info");
+  } else if (result.authUrl) {
+    // Auth redirect — endpoint is behind Authentik. Trigger login.
+    ui.notify("LLM endpoint requires authentication. Opening browser to sign in.", "info");
+    loginRequested = true;
   } else {
-    ui.notify("Skipping LLM endpoint connectivity test before save.", "warning");
+    // Other failure (timeout, network error, HTML response) — save settings
+    // anyway; the user can run /authentik-login later.
+    ui.notify(`LLM endpoint probe failed: ${result.error}`, "warning");
   }
 
   const settings = sanitizeSetupSettings({
@@ -116,7 +114,7 @@ export async function runFirstRunSetup(options: RunFirstRunSetupOptions): Promis
   return {
     saved: true,
     settings,
-    connectivityTested,
+    connectivityTested: true,
     loginRequested,
   };
 }


### PR DESCRIPTION
- Auto-test LLM endpoint connectivity during setup (no confirm prompt)
- Automatically trigger browser login when endpoint is behind auth
- Remove client secret prompt — public client (PKCE) only
- Detect JWE tokens early with actionable error message
- Document 'Encryption Key must be empty' in AUTHENTIK_SETUP.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup flow now automatically tests LLM endpoint connectivity and initiates authentication when required.

* **Bug Fixes**
  * Enhanced token validation to detect misconfigured encryption settings and provide clear remediation instructions.

* **Documentation**
  * Added setup guidance for proper token configuration in Authentik provider settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/192)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->