### PR TITLE
td 131872/observability trace cost

### DIFF
--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -52,6 +52,7 @@ import type { TelemetrySnapshot, HubConfig } from "./types.ts";
 import { sendTaskStateChanged } from "./hub.ts";
 import {
 	extractLoopMetadata,
+	generateTraceId,
 	injectLoopMetadata,
 	supervise,
 	type LoopMetadata,
@@ -582,6 +583,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		this._queueDepth++;
 		this.cancelCallbacks.set(taskId, () => { canceled = true; });
 		this.taskContexts.set(taskId, contextId);
+		const queuedParentTaskId = this.activeTaskId;
 
 		// Wait for preceding tasks to finish
 		await myTurn;
@@ -645,6 +647,14 @@ export class PiAgentExecutor implements AgentExecutor {
 
 		// Supervisor approved — store the updated metadata for this task.
 		// This is used by a2a_send for outbound metadata propagation.
+		// Ensure traceId is set (generate one if this is the root of a chain)
+		if (!supervisorResult.metadata.traceId) {
+			supervisorResult.metadata.traceId = generateTraceId();
+		}
+		// Set parentTaskId from the active task context if this is a queued sub-call
+		if (!supervisorResult.metadata.parentTaskId && queuedParentTaskId != null) {
+			supervisorResult.metadata.parentTaskId = queuedParentTaskId;
+		}
 		this.activeLoopMetadata = supervisorResult.metadata;
 		this.log("supervisor_approved", {
 			taskId,

--- a/extensions/pi-a2a/src/agent-executor.ts
+++ b/extensions/pi-a2a/src/agent-executor.ts
@@ -584,6 +584,7 @@ export class PiAgentExecutor implements AgentExecutor {
 		this.cancelCallbacks.set(taskId, () => { canceled = true; });
 		this.taskContexts.set(taskId, contextId);
 		const queuedParentTaskId = this.activeTaskId;
+		const queuedParentTraceId = this.activeLoopMetadata?.traceId;
 
 		// Wait for preceding tasks to finish
 		await myTurn;
@@ -652,7 +653,12 @@ export class PiAgentExecutor implements AgentExecutor {
 			supervisorResult.metadata.traceId = generateTraceId();
 		}
 		// Set parentTaskId from the active task context if this is a queued sub-call
-		if (!supervisorResult.metadata.parentTaskId && queuedParentTaskId != null) {
+		if (
+			!supervisorResult.metadata.parentTaskId &&
+			queuedParentTaskId != null &&
+			queuedParentTraceId != null &&
+			supervisorResult.metadata.traceId === queuedParentTraceId
+		) {
 			supervisorResult.metadata.parentTaskId = queuedParentTaskId;
 		}
 		this.activeLoopMetadata = supervisorResult.metadata;

--- a/extensions/pi-a2a/src/cost.test.ts
+++ b/extensions/pi-a2a/src/cost.test.ts
@@ -39,7 +39,12 @@ describe("TaskCostInfo", () => {
 
 describe("TelemetrySnapshot with costInfo", () => {
 	it("can include costInfo optionally", () => {
-		const snapshot = {
+		const snapshot: {
+			queueDepth: number;
+			activeTasks: number;
+			maxConcurrent: number;
+			costInfo?: TaskCostInfo;
+		} = {
 			queueDepth: 0,
 			activeTasks: 0,
 			maxConcurrent: 1,
@@ -49,18 +54,23 @@ describe("TelemetrySnapshot with costInfo", () => {
 				estimatedCostUsd: 0.021,
 				toolCallCount: 5,
 				durationMs: 8000,
-			} as TaskCostInfo,
+			},
 		};
 		assert.ok(snapshot.costInfo !== undefined);
 		assert.ok(snapshot.costInfo.estimatedCostUsd > 0);
 	});
 
 	it("works without costInfo (backward compatible)", () => {
-		const snapshot = {
+		const snapshot: {
+			queueDepth: number;
+			activeTasks: number;
+			maxConcurrent: number;
+			costInfo?: TaskCostInfo;
+		} = {
 			queueDepth: 1,
 			activeTasks: 1,
 			maxConcurrent: 1,
 		};
-		assert.strictEqual((snapshot as any).costInfo, undefined);
+		assert.strictEqual(snapshot.costInfo, undefined);
 	});
 });

--- a/extensions/pi-a2a/src/cost.test.ts
+++ b/extensions/pi-a2a/src/cost.test.ts
@@ -1,0 +1,66 @@
+/**
+ * pi-a2a — Cost attribution tests.
+ *
+ * Tests the computeTaskCost function and cost propagation through
+ * telemetry snapshots.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import type { TaskCostInfo } from "./types.ts";
+
+describe("TaskCostInfo", () => {
+	it("has the expected shape", () => {
+		const cost: TaskCostInfo = {
+			inputTokens: 1000,
+			outputTokens: 500,
+			estimatedCostUsd: 0.0125,
+			toolCallCount: 3,
+			durationMs: 5000,
+		};
+		assert.strictEqual(typeof cost.inputTokens, "number");
+		assert.strictEqual(typeof cost.outputTokens, "number");
+		assert.strictEqual(typeof cost.estimatedCostUsd, "number");
+		assert.strictEqual(typeof cost.toolCallCount, "number");
+		assert.strictEqual(typeof cost.durationMs, "number");
+	});
+
+	it("estimatedCostUsd is non-negative", () => {
+		const cost: TaskCostInfo = {
+			inputTokens: 0,
+			outputTokens: 0,
+			estimatedCostUsd: 0,
+			toolCallCount: 0,
+			durationMs: 100,
+		};
+		assert.ok(cost.estimatedCostUsd >= 0);
+	});
+});
+
+describe("TelemetrySnapshot with costInfo", () => {
+	it("can include costInfo optionally", () => {
+		const snapshot = {
+			queueDepth: 0,
+			activeTasks: 0,
+			maxConcurrent: 1,
+			costInfo: {
+				inputTokens: 2000,
+				outputTokens: 1000,
+				estimatedCostUsd: 0.021,
+				toolCallCount: 5,
+				durationMs: 8000,
+			} as TaskCostInfo,
+		};
+		assert.ok(snapshot.costInfo !== undefined);
+		assert.ok(snapshot.costInfo.estimatedCostUsd > 0);
+	});
+
+	it("works without costInfo (backward compatible)", () => {
+		const snapshot = {
+			queueDepth: 1,
+			activeTasks: 1,
+			maxConcurrent: 1,
+		};
+		assert.strictEqual((snapshot as any).costInfo, undefined);
+	});
+});

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -587,6 +587,9 @@ export async function reportTelemetryToHub(
 	if (telemetry.recentToolCalls !== undefined && telemetry.recentToolCalls.length > 0) {
 		params.recentToolCalls = telemetry.recentToolCalls;
 	}
+	if (telemetry.costInfo !== undefined) {
+		params.costInfo = telemetry.costInfo;
+	}
 
 	const result = await hubRpc(rpcUrl, "agents.reportTelemetry", params, hubConfig.apiKey, log, "hub_telemetry");
 	if (result) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -200,6 +200,8 @@ export default function (pi: ExtensionAPI) {
 	 * onTaskResultSaved callback fires.
 	 */
 	let activeA2aTask: { nonce: string; startTime: number; taskId?: string; toolCallCountStart: number; contextTokensStart: number } | null = null;
+	/** Monotonic count of completed tool calls in the current session. */
+	let totalCompletedToolCalls = 0;
 
 	// ── Powerbar segment ──────────────────────────────────────
 
@@ -432,7 +434,7 @@ export default function (pi: ExtensionAPI) {
 
 				// Compute cost attribution for this A2A task
 				if (activeA2aTask) {
-					const toolCallsDuringTask = Math.max(0, recentToolCalls.length - activeA2aTask.toolCallCountStart);
+					const toolCallsDuringTask = Math.max(0, totalCompletedToolCalls - activeA2aTask.toolCallCountStart);
 					const usageNow = sessionCtx?.getContextUsage();
 					const contextTokensNow = usageNow?.tokens ?? 0;
 					const tokensDuringTask = Math.max(0, contextTokensNow - activeA2aTask.contextTokensStart);
@@ -457,7 +459,7 @@ export default function (pi: ExtensionAPI) {
 				updateStatusLine();
 			} else if (activeA2aTask?.nonce === pendingNonce) {
 				const usageNow = sessionCtx?.getContextUsage();
-				activeA2aTask.toolCallCountStart = recentToolCalls.length;
+				activeA2aTask.toolCallCountStart = totalCompletedToolCalls;
 				activeA2aTask.contextTokensStart = usageNow?.tokens ?? 0;
 				activeA2aTask.startTime = Date.now();
 				log("a2a_task_cost_rebased", { nonce: activeA2aTask.nonce.slice(0, 8) });
@@ -528,6 +530,7 @@ export default function (pi: ExtensionAPI) {
 		};
 
 		recentToolCalls.push(record);
+		totalCompletedToolCalls += 1;
 		if (recentToolCalls.length > MAX_RECENT_TOOL_CALLS) {
 			recentToolCalls.shift();
 		}
@@ -747,6 +750,7 @@ export default function (pi: ExtensionAPI) {
 		conversationContexts.clear();
 		agentBusy = false;
 		resetToolTelemetryState(toolCallsInProgress, recentToolCalls);
+		totalCompletedToolCalls = 0;
 		lastTaskCostInfo = null;
 		// Abort any active SSE subscriptions from previous session
 		for (const [, conn] of sseConnections) {
@@ -1207,6 +1211,7 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 		resetToolTelemetryState(toolCallsInProgress, recentToolCalls);
+		totalCompletedToolCalls = 0;
 		lastTaskCostInfo = null;
 		// Deregister this instance from the hub
 		if (hubAgentId) {

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -57,7 +57,7 @@ import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger, type LogFn } from "./logger.ts";
 import { seedLoopMetadata, DEFAULT_MAX_HOPS } from "./supervisor.ts";
 import { findFreePort } from "./port-finder.ts";
-import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot, ToolCallRecord, PushEventType, PipelineStreamEvent, LongRunningTasksConfig } from "./types.ts";
+import type { HubConfig, PollerConfig, RemoteAgentSummary, TelemetrySnapshot, ToolCallRecord, TaskCostInfo, PushEventType, PipelineStreamEvent, LongRunningTasksConfig } from "./types.ts";
 import { LongRunningTaskStore, type LongRunningTask, type ResumeRequest } from "./long-running-task-store.ts";
 import {
 	buildIdleTelemetrySnapshot,
@@ -199,7 +199,7 @@ export default function (pi: ExtensionAPI) {
 	 * because agent_end clears pendingResolve/pendingNonce before the executor's
 	 * onTaskResultSaved callback fires.
 	 */
-	let activeA2aTask: { nonce: string; startTime: number; taskId?: string } | null = null;
+	let activeA2aTask: { nonce: string; startTime: number; taskId?: string; toolCallCountStart: number; contextTokensStart: number } | null = null;
 
 	// ── Powerbar segment ──────────────────────────────────────
 
@@ -358,7 +358,10 @@ export default function (pi: ExtensionAPI) {
 			pendingNonce = nonce;
 
 			// Capture active A2A task context for onTaskResultSaved callback
-			activeA2aTask = { nonce, startTime: start };
+			const toolCallCountStart = recentToolCalls.length;
+			const usageAtStart = sessionCtx?.getContextUsage();
+			const contextTokensStart = usageAtStart?.tokens ?? 0;
+			activeA2aTask = { nonce, startTime: start, toolCallCountStart, contextTokensStart };
 
 			// Inject into the main conversation — triggers a full agent turn.
 			// The nonce in details lets agent_end correlate this turn's response.
@@ -418,13 +421,31 @@ export default function (pi: ExtensionAPI) {
 
 			if (hasMatchingRequest) {
 				const response = extractAssistantText(event.messages);
-				const durationMs = Date.now() - pendingStartTime;
+				const now = Date.now();
+				const durationMs = now - pendingStartTime;
 				const resolve = pendingResolve;
 				pendingResolve = null;
 				pendingReject = null;
 				pendingNonce = null;
 				// Note: activeA2aTask is NOT cleared here — it's cleared by
 				// onTaskResultSaved after the task result is saved to the store.
+
+				// Compute cost attribution for this A2A task
+				if (activeA2aTask) {
+					const toolCallsDuringTask = Math.max(0, recentToolCalls.length - activeA2aTask.toolCallCountStart);
+					const usageNow = sessionCtx?.getContextUsage();
+					const contextTokensNow = usageNow?.tokens ?? 0;
+					const tokensDuringTask = Math.max(0, contextTokensNow - activeA2aTask.contextTokensStart);
+					const costDurationMs = Math.max(0, now - activeA2aTask.startTime);
+					lastTaskCostInfo = computeTaskCost(toolCallsDuringTask, tokensDuringTask, costDurationMs);
+					log("a2a_task_cost_computed", {
+						nonce: activeA2aTask.nonce.slice(0, 8),
+						toolCalls: toolCallsDuringTask,
+						tokens: tokensDuringTask,
+						cost: lastTaskCostInfo?.estimatedCostUsd,
+						durationMs: costDurationMs,
+					});
+				}
 
 				if (response) {
 					resolve({ ok: true, response, durationMs });
@@ -434,6 +455,12 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				updateStatusLine();
+			} else if (activeA2aTask?.nonce === pendingNonce) {
+				const usageNow = sessionCtx?.getContextUsage();
+				activeA2aTask.toolCallCountStart = recentToolCalls.length;
+				activeA2aTask.contextTokensStart = usageNow?.tokens ?? 0;
+				activeA2aTask.startTime = Date.now();
+				log("a2a_task_cost_rebased", { nonce: activeA2aTask.nonce.slice(0, 8) });
 			}
 		}
 
@@ -612,6 +639,59 @@ export default function (pi: ExtensionAPI) {
 	let toolCallsInProgress = new Map<string, ToolCallInProgress>();
 	/** Completed tool calls ready for the next telemetry snapshot. */
 	let recentToolCalls: ToolCallRecord[] = [];
+
+	// ── Cost attribution ——————————————————————
+	/** Cost info from the last completed/failed A2A task. */
+	let lastTaskCostInfo: TaskCostInfo | null = null;
+
+	/**
+	 * Compute cost attribution for a completed A2A task.
+	 * Uses session context usage, tool call count, and model metadata.
+	 * Returns null if sessionCtx is not available.
+	 */
+	function computeTaskCost(toolCallCount: number, tokensDuringTask: number, durationMs: number): TaskCostInfo | null {
+		if (!sessionCtx) return null;
+		const contextWindow = sessionCtx.model?.contextWindow ?? 0;
+		const inputTokens = Math.max(0, contextWindow > 0 ? Math.min(tokensDuringTask, contextWindow) : tokensDuringTask);
+		// Approximate output tokens from the observed context delta. The context API
+		// does not expose separate input/output counts, so keep this conservative.
+		const outputTokens = Math.round(inputTokens * 0.25);
+
+		const pricing = readModelPricingPerMillionTokens(sessionCtx.model as unknown as Record<string, unknown> | undefined);
+		const estimatedCostUsd = pricing
+			? (inputTokens / 1_000_000) * pricing.input + (outputTokens / 1_000_000) * pricing.output
+			: 0;
+
+		return {
+			inputTokens,
+			outputTokens,
+			estimatedCostUsd: Math.round(estimatedCostUsd * 10_000) / 10_000,
+			toolCallCount,
+			durationMs,
+		};
+	}
+
+	function readModelPricingPerMillionTokens(model: Record<string, unknown> | undefined): { input: number; output: number } | null {
+		if (!model) return null;
+		const pricing = (model.pricing ?? model.cost ?? model.costs) as Record<string, unknown> | undefined;
+		if (!pricing || typeof pricing !== "object") return null;
+
+		const input = readNumber(pricing, ["inputPerMillion", "input_per_million", "promptPerMillion", "prompt_per_million"])
+			?? readNumber(pricing, ["inputPerToken", "input_per_token", "promptPerToken", "prompt_per_token"], 1_000_000);
+		const output = readNumber(pricing, ["outputPerMillion", "output_per_million", "completionPerMillion", "completion_per_million"])
+			?? readNumber(pricing, ["outputPerToken", "output_per_token", "completionPerToken", "completion_per_token"], 1_000_000);
+
+		return input !== undefined && output !== undefined ? { input, output } : null;
+	}
+
+	function readNumber(record: Record<string, unknown>, keys: string[], multiplier = 1): number | undefined {
+		for (const key of keys) {
+			const value = record[key];
+			if (typeof value === "number" && Number.isFinite(value)) return value * multiplier;
+		}
+		return undefined;
+	}
+
 	const runSerializedTelemetrySend = createSerializedAsyncRunner();
 
 	/** Build a telemetry snapshot from pi's actual state + executor A2A queue. */
@@ -626,6 +706,7 @@ export default function (pi: ExtensionAPI) {
 		if (lastTurnStatus !== undefined) snapshot.lastTaskStatus = lastTurnStatus;
 		const toolCallSnapshot = buildRecentToolCallsSnapshot(recentToolCalls);
 		if (toolCallSnapshot !== undefined) snapshot.recentToolCalls = toolCallSnapshot;
+		if (lastTaskCostInfo) snapshot.costInfo = lastTaskCostInfo;
 		return snapshot;
 	}
 
@@ -666,6 +747,7 @@ export default function (pi: ExtensionAPI) {
 		conversationContexts.clear();
 		agentBusy = false;
 		resetToolTelemetryState(toolCallsInProgress, recentToolCalls);
+		lastTaskCostInfo = null;
 		// Abort any active SSE subscriptions from previous session
 		for (const [, conn] of sseConnections) {
 			conn.abort();
@@ -1125,6 +1207,7 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 		resetToolTelemetryState(toolCallsInProgress, recentToolCalls);
+		lastTaskCostInfo = null;
 		// Deregister this instance from the hub
 		if (hubAgentId) {
 			const { config } = loadConfig(cwd);

--- a/extensions/pi-a2a/src/supervisor.test.ts
+++ b/extensions/pi-a2a/src/supervisor.test.ts
@@ -1,0 +1,181 @@
+/**
+ * pi-a2a — Supervisor tests for trace ID propagation and loop control.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+	extractLoopMetadata,
+	injectLoopMetadata,
+	supervise,
+	seedLoopMetadata,
+	generateTraceId,
+	DEFAULT_MAX_HOPS,
+} from "./supervisor.ts";
+
+describe("generateTraceId", () => {
+	it("returns a string prefixed with a2a-trace-", () => {
+		const id = generateTraceId();
+		assert.ok(typeof id === "string");
+		assert.ok(id.startsWith("a2a-trace-"));
+	});
+
+	it("returns unique IDs on each call", () => {
+		const id1 = generateTraceId();
+		const id2 = generateTraceId();
+		assert.notStrictEqual(id1, id2);
+	});
+});
+
+describe("seedLoopMetadata", () => {
+	it("seeds with hopCount=0, traceId, and the agent in visitedAgents", () => {
+		const meta = seedLoopMetadata("http://agent-a:3100");
+		assert.strictEqual(meta.hopCount, 0);
+		assert.deepStrictEqual(meta.visitedAgents, ["http://agent-a:3100"]);
+		assert.ok(meta.traceId?.startsWith("a2a-trace-"));
+		assert.strictEqual(meta.parentTaskId, undefined);
+	});
+
+	it("includes budgets when maxHops is provided", () => {
+		const meta = seedLoopMetadata("http://agent-a:3100", 5);
+		assert.deepStrictEqual(meta.budgets, { maxHops: 5 });
+	});
+});
+
+describe("extractLoopMetadata", () => {
+	it("returns zero-state when metadata is null/undefined", () => {
+		assert.deepStrictEqual(extractLoopMetadata(null), {
+			hopCount: 0, visitedAgents: [], budgets: undefined, traceId: undefined, parentTaskId: undefined,
+		});
+		assert.deepStrictEqual(extractLoopMetadata(undefined), {
+			hopCount: 0, visitedAgents: [], budgets: undefined, traceId: undefined, parentTaskId: undefined,
+		});
+	});
+
+	it("extracts pi:traceId and pi:parentTaskId from metadata", () => {
+		const meta = extractLoopMetadata({
+			"pi:hopCount": 2,
+			"pi:visitedAgents": ["http://a", "http://b"],
+			"pi:traceId": "a2a-trace-abc123",
+			"pi:parentTaskId": "task-parent-123",
+		});
+		assert.strictEqual(meta.hopCount, 2);
+		assert.deepStrictEqual(meta.visitedAgents, ["http://a", "http://b"]);
+		assert.strictEqual(meta.traceId, "a2a-trace-abc123");
+		assert.strictEqual(meta.parentTaskId, "task-parent-123");
+	});
+
+	it("returns undefined for traceId/parentTaskId when not present", () => {
+		const meta = extractLoopMetadata({ "pi:hopCount": 1 });
+		assert.strictEqual(meta.traceId, undefined);
+		assert.strictEqual(meta.parentTaskId, undefined);
+	});
+});
+
+describe("injectLoopMetadata", () => {
+	it("injects pi:traceId and pi:parentTaskId when present", () => {
+		const result = injectLoopMetadata({}, {
+			hopCount: 3,
+			visitedAgents: ["http://a"],
+			traceId: "a2a-trace-xyz",
+			parentTaskId: "parent-task-456",
+		});
+		assert.strictEqual(result["pi:traceId"], "a2a-trace-xyz");
+		assert.strictEqual(result["pi:parentTaskId"], "parent-task-456");
+		assert.strictEqual(result["pi:hopCount"], 3);
+	});
+
+	it("does not inject traceId/parentTaskId when undefined", () => {
+		const result = injectLoopMetadata({}, {
+			hopCount: 1,
+			visitedAgents: ["http://a"],
+		});
+		assert.strictEqual("pi:traceId" in result, false);
+		assert.strictEqual("pi:parentTaskId" in result, false);
+	});
+
+	it("preserves existing metadata keys", () => {
+		const result = injectLoopMetadata({ "pi:sender": { name: "test" } }, {
+			hopCount: 1,
+			visitedAgents: ["http://a"],
+			traceId: "a2a-trace-test",
+		});
+		assert.deepStrictEqual(result["pi:sender"], { name: "test" });
+	});
+});
+
+describe("supervise", () => {
+	const config = { agentId: "http://agent-b:3100", defaultMaxHops: DEFAULT_MAX_HOPS };
+
+	it("approves first hop and propagates traceId", () => {
+		const traceId = generateTraceId();
+		const result = supervise({
+			hopCount: 0,
+			visitedAgents: ["http://agent-a:3100"],
+			traceId,
+			parentTaskId: "task-123",
+		}, config);
+
+		assert.strictEqual(result.approved, true);
+		assert.strictEqual(result.metadata.traceId, traceId);
+		assert.strictEqual(result.metadata.parentTaskId, "task-123");
+		assert.strictEqual(result.metadata.hopCount, 1);
+		assert.ok(result.metadata.visitedAgents.includes("http://agent-b:3100"));
+	});
+
+	it("propagates traceId on cycle detection rejection", () => {
+		const traceId = "a2a-trace-cycle-test";
+		const result = supervise({
+			hopCount: 5,
+			visitedAgents: ["http://agent-a:3100", "http://agent-b:3100"],
+			traceId,
+			parentTaskId: "task-cycle",
+		}, config);
+
+		assert.strictEqual(result.approved, false);
+		assert.strictEqual(result.metadata.traceId, traceId);
+		assert.strictEqual(result.metadata.parentTaskId, "task-cycle");
+		assert.ok(result.reason?.includes("Cycle detected"));
+	});
+
+	it("propagates traceId on hop limit rejection", () => {
+		const traceId = "a2a-trace-hop-limit";
+		const tightConfig = { agentId: "http://agent-b:3100", defaultMaxHops: 3 };
+		const result = supervise({
+			hopCount: 3,
+			visitedAgents: ["http://a", "http://b", "http://c"],
+			traceId,
+		}, tightConfig);
+
+		assert.strictEqual(result.approved, false);
+		assert.strictEqual(result.metadata.traceId, traceId);
+		assert.ok(result.reason?.includes("Hop limit exceeded"));
+	});
+});
+
+describe("trace propagation: A → B → C chain", () => {
+	it("maintains the same traceId across three hops with different parentTaskIds", () => {
+		// Seed at agent A (originator)
+		const seed = seedLoopMetadata("http://agent-a:3100");
+		assert.ok(seed.traceId);
+		assert.strictEqual(seed.parentTaskId, undefined);
+
+		// Agent A sends to agent B
+		const bConfig = { agentId: "http://agent-b:3100", defaultMaxHops: DEFAULT_MAX_HOPS };
+		const bResult = supervise({ ...seed }, bConfig);
+		assert.strictEqual(bResult.approved, true);
+		assert.strictEqual(bResult.metadata.traceId, seed.traceId);
+
+		// Agent B sends to agent C, setting parentTaskId
+		bResult.metadata.parentTaskId = "task-from-a";
+		const cConfig = { agentId: "http://agent-c:3100", defaultMaxHops: DEFAULT_MAX_HOPS };
+		const cResult = supervise(bResult.metadata, cConfig);
+		assert.strictEqual(cResult.approved, true);
+		assert.strictEqual(cResult.metadata.traceId, seed.traceId);
+		assert.strictEqual(cResult.metadata.parentTaskId, "task-from-a");
+
+		// All three share the same traceId
+		assert.strictEqual(seed.traceId, bResult.metadata.traceId);
+		assert.strictEqual(seed.traceId, cResult.metadata.traceId);
+	});
+});

--- a/extensions/pi-a2a/src/supervisor.ts
+++ b/extensions/pi-a2a/src/supervisor.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * pi-a2a — Loop control supervisor.
  *
@@ -13,6 +15,8 @@
  *   - `pi:hopCount` (number)  — incremented at each hop
  *   - `pi:visitedAgents` (string[]) — agent identities (URLs) visited so far
  *   - `pi:budgets` ({ maxHops?, maxCalls?, maxTokens? }) — configurable limits
+ *   - `pi:traceId` (string) — distributed trace ID shared across agent chain
+ *   - `pi:parentTaskId` (string?) — caller's task ID for parent-child linking
  *
  * The supervisor is called in two places:
  *   - Inbound: before AgentExecutor.execute() processes a task
@@ -39,6 +43,10 @@ export interface LoopMetadata {
 	visitedAgents: string[];
 	/** Budget constraints. */
 	budgets?: LoopBudgets;
+	/** Distributed trace ID — shared across all agents in a chain. */
+	traceId?: string;
+	/** Caller's task ID — links parent → child tasks. */
+	parentTaskId?: string;
 }
 
 /** Supervisor configuration. */
@@ -65,6 +73,14 @@ export const DEFAULT_MAX_HOPS = 10;
 /** Cap on visitedAgents array length to bound memory from untrusted input. */
 const MAX_VISITED_AGENTS = 64;
 
+/**
+ * Generate a new distributed trace ID.
+ * Format: `a2a-trace-<uuid>` — unique per root agent invocation.
+ */
+export function generateTraceId(): string {
+	return `a2a-trace-${randomUUID()}`;
+}
+
 // ── Extract / Inject ────────────────────────────────────────────
 
 /**
@@ -74,7 +90,7 @@ const MAX_VISITED_AGENTS = 64;
 export function extractLoopMetadata(
 	metadata?: Record<string, unknown> | null,
 ): LoopMetadata {
-	if (!metadata) return { hopCount: 0, visitedAgents: [] };
+	if (!metadata) return { hopCount: 0, visitedAgents: [], budgets: undefined, traceId: undefined, parentTaskId: undefined };
 
 	const hopCount =
 		typeof metadata["pi:hopCount"] === "number"
@@ -99,7 +115,15 @@ export function extractLoopMetadata(
 		}
 	}
 
-	return { hopCount, visitedAgents, budgets };
+	const traceId = typeof metadata["pi:traceId"] === "string"
+		? metadata["pi:traceId"] as string
+		: undefined;
+
+	const parentTaskId = typeof metadata["pi:parentTaskId"] === "string"
+		? metadata["pi:parentTaskId"] as string
+		: undefined;
+
+	return { hopCount, visitedAgents, budgets, traceId, parentTaskId };
 }
 
 /**
@@ -115,6 +139,12 @@ export function injectLoopMetadata(
 	result["pi:visitedAgents"] = loop.visitedAgents;
 	if (loop.budgets) {
 		result["pi:budgets"] = loop.budgets;
+	}
+	if (loop.traceId) {
+		result["pi:traceId"] = loop.traceId;
+	}
+	if (loop.parentTaskId) {
+		result["pi:parentTaskId"] = loop.parentTaskId;
 	}
 	return result;
 }
@@ -149,6 +179,8 @@ export function supervise(
 				hopCount: incoming.hopCount + 1,
 				visitedAgents: [...incoming.visitedAgents, config.agentId],
 				budgets: incoming.budgets,
+				traceId: incoming.traceId,
+				parentTaskId: incoming.parentTaskId,
 			},
 		};
 	}
@@ -163,6 +195,8 @@ export function supervise(
 				hopCount: newHopCount,
 				visitedAgents: [...incoming.visitedAgents, config.agentId],
 				budgets: incoming.budgets,
+				traceId: incoming.traceId,
+				parentTaskId: incoming.parentTaskId,
 			},
 		};
 	}
@@ -174,6 +208,8 @@ export function supervise(
 			hopCount: newHopCount,
 			visitedAgents: [...incoming.visitedAgents, config.agentId],
 			budgets: incoming.budgets,
+			traceId: incoming.traceId,
+			parentTaskId: incoming.parentTaskId,
 		},
 	};
 }
@@ -181,6 +217,8 @@ export function supervise(
 /**
  * Create seed metadata for an outbound message initiated by this agent
  * (not a response to an inbound task — fresh chain).
+ *
+ * Generates a new traceId for the root of a distributed trace.
  */
 export function seedLoopMetadata(
 	agentId: string,
@@ -190,5 +228,6 @@ export function seedLoopMetadata(
 		hopCount: 0,
 		visitedAgents: [agentId],
 		budgets: maxHops !== undefined ? { maxHops } : undefined,
+		traceId: generateTraceId(),
 	};
 }

--- a/extensions/pi-a2a/src/task-store.ts
+++ b/extensions/pi-a2a/src/task-store.ts
@@ -12,6 +12,7 @@
  *   - Parameterized queries only — no string interpolation
  *   - Sync operations (better-sqlite3 is sync) wrapped in async interface
  *   - Extended columns beyond SDK interface for loop control (td-02cbd2)
+ *   - Distributed tracing columns: trace_id, parent_task_id (td-131872)
  */
 
 import { mkdirSync } from "node:fs";
@@ -25,7 +26,7 @@ import { randomUUID } from "node:crypto";
 
 // ── Schema version ──────────────────────────────────────────────
 
-const CURRENT_VERSION = 2;
+const CURRENT_VERSION = 3;
 
 const MIGRATIONS: Record<number, string[]> = {
 	1: [
@@ -55,6 +56,12 @@ const MIGRATIONS: Record<number, string[]> = {
 			PRIMARY KEY (task_id, config_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_a2a_push_configs_task_id ON a2a_push_configs(task_id)`,
+	],
+	3: [
+		`ALTER TABLE a2a_tasks ADD COLUMN trace_id TEXT`,
+		`ALTER TABLE a2a_tasks ADD COLUMN parent_task_id TEXT`,
+		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_trace_id ON a2a_tasks(trace_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_a2a_tasks_parent_task_id ON a2a_tasks(parent_task_id)`,
 	],
 };
 
@@ -91,7 +98,7 @@ export class SQLiteTaskStore implements TaskStore {
 		const data = JSON.stringify(task);
 		const status = task.status?.state ?? "submitted";
 
-		// Extract loop-control metadata for indexed querying (td-02cbd2)
+		// Extract loop-control metadata for indexed querying (td-02cbd2, td-131872)
 		const metadata = task.metadata as Record<string, unknown> | undefined;
 		const hopCount = typeof metadata?.["pi:hopCount"] === "number"
 			? metadata["pi:hopCount"] as number
@@ -99,11 +106,17 @@ export class SQLiteTaskStore implements TaskStore {
 		const visitedAgents = Array.isArray(metadata?.["pi:visitedAgents"])
 			? JSON.stringify(metadata["pi:visitedAgents"])
 			: null;
+		const traceId = typeof metadata?.["pi:traceId"] === "string"
+			? metadata["pi:traceId"] as string
+			: null;
+		const parentTaskId = typeof metadata?.["pi:parentTaskId"] === "string"
+			? metadata["pi:parentTaskId"] as string
+			: null;
 
 		const now = new Date().toISOString();
 
 		// Atomic UPSERT — single statement, no race window
-		this.stmtUpsert.run(task.id, task.contextId, status, data, hopCount, visitedAgents, now, now);
+		this.stmtUpsert.run(task.id, task.contextId, status, data, hopCount, visitedAgents, traceId, parentTaskId, now, now);
 
 		this.log("task_store_save", { taskId: task.id, status });
 	}
@@ -244,14 +257,16 @@ export class SQLiteTaskStore implements TaskStore {
 
 	private prepareStatements(): void {
 		this.stmtUpsert = this.db.prepare(
-			`INSERT INTO a2a_tasks (id, context_id, status, data, hop_count, visited_agents, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			`INSERT INTO a2a_tasks (id, context_id, status, data, hop_count, visited_agents, trace_id, parent_task_id, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(id) DO UPDATE SET
 			   context_id = excluded.context_id,
 			   status = excluded.status,
 			   data = excluded.data,
 			   hop_count = excluded.hop_count,
 			   visited_agents = excluded.visited_agents,
+			   trace_id = excluded.trace_id,
+			   parent_task_id = excluded.parent_task_id,
 			   updated_at = excluded.updated_at`,
 		);
 

--- a/extensions/pi-a2a/src/types.ts
+++ b/extensions/pi-a2a/src/types.ts
@@ -217,6 +217,20 @@ export interface ToolCallRecord {
 	timestamp: number;
 }
 
+/** Cost attribution data for a completed A2A task. */
+export interface TaskCostInfo {
+	/** Input tokens consumed. */
+	inputTokens: number;
+	/** Output tokens consumed. */
+	outputTokens: number;
+	/** Estimated cost in USD, derived from model pricing metadata. */
+	estimatedCostUsd: number;
+	/** Number of tool calls made during the task. */
+	toolCallCount: number;
+	/** Total task duration in milliseconds. */
+	durationMs: number;
+}
+
 export interface TelemetrySnapshot {
 	queueDepth: number;
 	activeTasks: number;
@@ -225,6 +239,8 @@ export interface TelemetrySnapshot {
 	lastTaskStatus?: "completed" | "failed";
 	/** Recent tool calls since the last telemetry report. */
 	recentToolCalls?: ToolCallRecord[];
+	/** Cost attribution for the last completed/failed task. */
+	costInfo?: TaskCostInfo;
 }
 
 // ── Orchestrator Types ──────────────────────────────────────────


### PR DESCRIPTION
- **fix(pi-authentik): add optional client_secret support for token exchange**
- **fix(pi-authentik): preserve clientSecret in sanitizeSetupSettings and add test**
- **fix(pi-authentik): move clientSecret to pi-secret storage**
- **fix(pi-authentik): propagate loadClientSecret errors, fail fast on missing secret backend**
- **fix(pi-authentik): wire saveCount assertion in loopback-decline test**
- **fix(pi-authentik): add clearClientSecret spy assertions to clientSecret tests**
- **feat(pi-authentik): add JWT bearer token exchange for outpost providers**
- **fix(pi-authentik): clarify setup prompts with OAuth2 prefix**
- **refactor(pi-authentik): simplify setup flow, remove pre-login connectivity test**
- **fix(pi-authentik): add ak_proxy to default scopes**
- **docs(pi-authentik): document ak_proxy scope requirement for outpost proxy**
- **feat(pi-authentik): add model caching for immediate provider registration**
- **feat(pi-authentik): bridge OAuth credentials to auth.json after login**
- **fix(pi-authentik): load exchangeClientId from settings.json fallback**
- **refactor(pi-authentik): use Pi's native OAuth system, remove auth-bridge hack**
- **fix(pi-authentik): resolve type errors in doRefreshToken and first-run**
- **fix(pi-authentik): remove noisy 'restored session' notification on token refresh**
- **fix(pi-authentik): address CodeRabbit review findings on PR 189**
- **feat(pi-a2a): add distributed trace IDs and cost attribution**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-task cost estimation for A2A interactions (token counts, estimated USD, duration) recorded in session telemetry and reported to the hub.
  * End-to-end distributed tracing across agent chains with persistent trace IDs and parent-task propagation, now persisted for tasks and preserved across queued calls.

* **Tests**
  * Added tests for cost attribution, tracing utilities, and supervisor approval/propagation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/espennilsen/pi/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->