### PR TITLE
feat(pi-a2a): add hub task leases

### DIFF
--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -176,7 +176,7 @@ Server binds to localhost, but advertises external URL for reverse proxy setups.
 
 ### Lease-aware Hub RPCs
 
-pi-a2a now understands the lease-oriented hub contracts from PR 35:
+pi-a2a now understands the lease-oriented hub contracts:
 
 - `tasks.claim` — atomically claim a specific task or the next eligible task
 - `tasks.heartbeat` — renew an active lease for the same `agentId` + `instanceId`

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -182,6 +182,8 @@ pi-a2a now understands the lease-oriented hub contracts:
 - `tasks.heartbeat` — renew an active lease for the same `agentId` + `instanceId`
 - `agents.reportTelemetry` — accepts optional `instanceId` to help the hub track lease ownership
 
+Both `tasks.claim` and `tasks.heartbeat` accept optional `leaseDurationSeconds` (default 900 seconds; clamped to the 1-86400 second range). `agents.reportTelemetry` may include `instanceId`, but it does not change lease duration limits.
+
 Task payloads include:
 - `leaseOwnerAgentId`
 - `leaseOwnerInstanceId`

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -174,6 +174,19 @@ Server binds to localhost, but advertises external URL for reverse proxy setups.
 | `hub.visibility` | string | `"public"` | `public`, `unlisted`, or `private` |
 | `hub.autoRegister` | boolean | `true` | Auto-register on session start |
 
+### Lease-aware Hub RPCs
+
+pi-a2a now understands the lease-oriented hub contracts from PR 35:
+
+- `tasks.claim` — atomically claim a specific task or the next eligible task
+- `tasks.heartbeat` — renew an active lease for the same `agentId` + `instanceId`
+- `agents.reportTelemetry` — accepts optional `instanceId` to help the hub track lease ownership
+
+Task payloads include:
+- `leaseOwnerAgentId`
+- `leaseOwnerInstanceId`
+- `leaseExpiresAt`
+
 ## Commands
 
 | Command | Description |

--- a/extensions/pi-a2a/src/hub.test.ts
+++ b/extensions/pi-a2a/src/hub.test.ts
@@ -74,6 +74,15 @@ describe("claimHubTask", () => {
 			(err: unknown) => err instanceof HubRpcError && err.message === "No response from hub",
 		);
 	});
+
+	it("throws when the hub claims a task without returning a task object", async () => {
+		mockFetch(() => rpcResponse({ task: null, claimed: true }));
+
+		await assert.rejects(
+			() => claimHubTask({ agentId: "agent-1", instanceId: "instance-1" }, hubConfig, log),
+			(err: unknown) => err instanceof HubRpcError && err.message === "Malformed claim response from hub",
+		);
+	});
 });
 
 describe("heartbeatHubTask", () => {

--- a/extensions/pi-a2a/src/hub.test.ts
+++ b/extensions/pi-a2a/src/hub.test.ts
@@ -1,0 +1,149 @@
+/**
+ * pi-a2a — Hub RPC tests for task claiming, leases, and telemetry.
+ */
+
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import { claimHubTask, heartbeatHubTask, reportTelemetryToHub, HubRpcError } from "./hub.ts";
+import type { HubConfig, TelemetrySnapshot } from "./types.ts";
+
+const hubConfig: HubConfig = {
+	url: "http://hub.local/api",
+	apiKey: "secret",
+};
+
+const log = () => {};
+
+let originalFetch: typeof fetch | null = null;
+
+afterEach(() => {
+	if (originalFetch) {
+		globalThis.fetch = originalFetch;
+		originalFetch = null;
+	}
+});
+
+function mockFetch(handler: (input: unknown, init?: RequestInit) => Promise<Response> | Response): void {
+	originalFetch = globalThis.fetch;
+	globalThis.fetch = handler as typeof fetch;
+}
+
+function rpcResponse(result: unknown): Response {
+	return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function rpcError(code: number, message: string, data?: unknown): Response {
+	return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code, message, data } }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("claimHubTask", () => {
+	it("returns no task when the hub has nothing eligible", async () => {
+		mockFetch(async (_input, init) => {
+			const body = JSON.parse(init?.body as string) as { method: string; params: Record<string, unknown> };
+			assert.strictEqual(body.method, "tasks.claim");
+			assert.strictEqual(body.params.agentId, "agent-1");
+			assert.strictEqual(body.params.instanceId, "instance-1");
+			assert.strictEqual(body.params.leaseDurationSeconds, 900);
+			return rpcResponse({ task: null, claimed: false });
+		});
+
+		const result = await claimHubTask({ agentId: "agent-1", instanceId: "instance-1" }, hubConfig, log);
+		assert.deepStrictEqual(result, { task: null, claimed: false });
+	});
+
+	it("throws conflict when a specific task cannot be claimed", async () => {
+		mockFetch(() => rpcError(-32003, "Task is already claimed"));
+
+		await assert.rejects(
+			() => claimHubTask({ agentId: "agent-1", instanceId: "instance-1", taskId: "task-1" }, hubConfig, log),
+			(err: unknown) => err instanceof HubRpcError && err.code === -32003,
+		);
+	});
+});
+
+describe("heartbeatHubTask", () => {
+	it("renews a task lease for the current agent instance", async () => {
+		mockFetch(async (_input, init) => {
+			const body = JSON.parse(init?.body as string) as { method: string; params: Record<string, unknown> };
+			assert.strictEqual(body.method, "tasks.heartbeat");
+			assert.strictEqual(body.params.agentId, "agent-1");
+			assert.strictEqual(body.params.instanceId, "instance-1");
+			assert.strictEqual(body.params.taskId, "task-1");
+			assert.strictEqual(body.params.leaseDurationSeconds, 1200);
+			return rpcResponse({
+				task: {
+					id: "task-1",
+					title: "Implement leases",
+					description: null,
+					project: "pi-a2a",
+					repo: null,
+					state: "planning",
+					priority: "normal",
+					assignedAgentId: "agent-1",
+					createdBy: "system",
+					externalTaskId: null,
+					branch: null,
+					prUrl: null,
+					prNumber: null,
+					reportPath: null,
+					blockedReason: null,
+					reviewRound: 0,
+					maxReviewRounds: 3,
+					metadata: {},
+					createdAt: "2026-01-01T00:00:00.000Z",
+					updatedAt: "2026-01-01T00:01:00.000Z",
+					startedAt: null,
+					completedAt: null,
+					leaseOwnerAgentId: "agent-1",
+					leaseOwnerInstanceId: "instance-1",
+					leaseExpiresAt: "2026-01-01T00:21:00.000Z",
+				},
+				renewed: true,
+			});
+		});
+
+		const result = await heartbeatHubTask({ agentId: "agent-1", instanceId: "instance-1", taskId: "task-1", leaseDurationSeconds: 1200 }, hubConfig, log);
+		assert.strictEqual(result.renewed, true);
+		assert.strictEqual(result.task.id, "task-1");
+		assert.strictEqual(result.task.leaseOwnerInstanceId, "instance-1");
+	});
+
+	it("throws conflict when the lease is invalid", async () => {
+		mockFetch(() => rpcError(-32003, "Lease expired"));
+
+		await assert.rejects(
+			() => heartbeatHubTask({ agentId: "agent-1", instanceId: "instance-1", taskId: "task-1" }, hubConfig, log),
+			(err: unknown) => err instanceof HubRpcError && err.code === -32003,
+		);
+	});
+});
+
+describe("reportTelemetryToHub", () => {
+	it("includes the instanceId in the telemetry payload", async () => {
+		mockFetch(async (_input, init) => {
+			const body = JSON.parse(init?.body as string) as { method: string; params: Record<string, unknown> };
+			assert.strictEqual(body.method, "agents.reportTelemetry");
+			assert.strictEqual(body.params.agentId, "agent-1");
+			assert.strictEqual(body.params.instanceId, "instance-1");
+			assert.strictEqual(body.params.queueDepth, 2);
+			assert.strictEqual(body.params.activeTasks, 1);
+			assert.strictEqual(body.params.maxConcurrent, 3);
+			return rpcResponse({ telemetryUpdatedAt: "2026-01-01T00:00:00.000Z" });
+		});
+
+		const telemetry: TelemetrySnapshot = {
+			queueDepth: 2,
+			activeTasks: 1,
+			maxConcurrent: 3,
+		};
+
+		const result = await reportTelemetryToHub("agent-1", telemetry, hubConfig, log, "instance-1");
+		assert.deepStrictEqual(result, { telemetryUpdatedAt: "2026-01-01T00:00:00.000Z" });
+	});
+});

--- a/extensions/pi-a2a/src/hub.test.ts
+++ b/extensions/pi-a2a/src/hub.test.ts
@@ -65,6 +65,15 @@ describe("claimHubTask", () => {
 			(err: unknown) => err instanceof HubRpcError && err.code === -32003,
 		);
 	});
+
+	it("throws when the hub is unavailable", async () => {
+		mockFetch(() => new Response("", { status: 500 }));
+
+		await assert.rejects(
+			() => claimHubTask({ agentId: "agent-1", instanceId: "instance-1" }, hubConfig, log),
+			(err: unknown) => err instanceof HubRpcError && err.message === "No response from hub",
+		);
+	});
 });
 
 describe("heartbeatHubTask", () => {
@@ -120,6 +129,15 @@ describe("heartbeatHubTask", () => {
 		await assert.rejects(
 			() => heartbeatHubTask({ agentId: "agent-1", instanceId: "instance-1", taskId: "task-1" }, hubConfig, log),
 			(err: unknown) => err instanceof HubRpcError && err.code === -32003,
+		);
+	});
+
+	it("throws when the hub returns an invalid heartbeat payload", async () => {
+		mockFetch(() => rpcResponse({ task: null, renewed: true }));
+
+		await assert.rejects(
+			() => heartbeatHubTask({ agentId: "agent-1", instanceId: "instance-1", taskId: "task-1" }, hubConfig, log),
+			(err: unknown) => err instanceof HubRpcError && err.message === "Malformed heartbeat response from hub",
 		);
 	});
 });

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -19,7 +19,9 @@ export interface HubTask {
 	id: string;
 	title: string;
 	description: string | null;
-	project: string;
+	projectId: string | null;
+	/** Legacy alias kept for existing UI rendering paths. */
+	project: string | null;
 	repo: string | null;
 	state: PipelineState;
 	priority: TaskPriority;
@@ -29,6 +31,7 @@ export interface HubTask {
 	branch: string | null;
 	prUrl: string | null;
 	prNumber: number | null;
+	reportPath: string | null;
 	blockedReason: string | null;
 	reviewRound: number;
 	maxReviewRounds: number;
@@ -37,6 +40,38 @@ export interface HubTask {
 	updatedAt: string;
 	startedAt: string | null;
 	completedAt: string | null;
+	leaseOwnerAgentId: string | null;
+	leaseOwnerInstanceId: string | null;
+	leaseExpiresAt: string | null;
+}
+
+export type PipelineTask = HubTask;
+
+export interface ClaimTaskParams {
+	agentId: string;
+	instanceId: string;
+	taskId?: string;
+	projectId?: string;
+	/** Defaults to 900 seconds, max 86400 seconds. */
+	leaseDurationSeconds?: number;
+}
+
+export interface ClaimTaskResult {
+	task: PipelineTask | null;
+	claimed: boolean;
+}
+
+export interface TaskHeartbeatParams {
+	agentId: string;
+	instanceId: string;
+	taskId: string;
+	/** Defaults to 900 seconds, max 86400 seconds. */
+	leaseDurationSeconds?: number;
+}
+
+export interface TaskHeartbeatResult {
+	task: PipelineTask;
+	renewed: boolean;
 }
 
 export interface HubTaskTransition {
@@ -59,20 +94,32 @@ interface HubRpcResponse {
 	id: number;
 }
 
+export class HubRpcError extends Error {
+	code: number;
+	data?: unknown;
+
+	constructor(code: number, message: string, data?: unknown) {
+		super(message);
+		this.name = "HubRpcError";
+		this.code = code;
+		this.data = data;
+	}
+}
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 function hubRpcUrl(hubConfig: HubConfig): string {
 	return `${hubConfig.url.replace(/\/$/, "")}/rpc`;
 }
 
-async function hubRpc(
+async function hubRpcResponse(
 	rpcUrl: string,
 	method: string,
 	params: Record<string, unknown>,
 	hubApiKey: string,
 	log: LogFn,
 	logPrefix: string,
-): Promise<Record<string, unknown> | null> {
+): Promise<HubRpcResponse | null> {
 	const payload = { jsonrpc: "2.0" as const, method, params, id: 1 };
 
 	try {
@@ -92,24 +139,36 @@ async function hubRpc(
 			return null;
 		}
 
-		const data = (await res.json()) as HubRpcResponse;
-
-		if (data.error) {
-			log(`${logPrefix}_rpc_error`, { code: data.error.code, message: data.error.message, data: data.error.data }, "ERROR");
-			return null;
-		}
-
-		if (data.result) {
-			return data.result;
-		}
-
-		log(`${logPrefix}_unexpected`, { response: JSON.stringify(data).slice(0, 500) }, "WARN");
-		return null;
+		return (await res.json()) as HubRpcResponse;
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 		log(`${logPrefix}_error`, { error: msg }, "ERROR");
 		return null;
 	}
+}
+
+async function hubRpc(
+	rpcUrl: string,
+	method: string,
+	params: Record<string, unknown>,
+	hubApiKey: string,
+	log: LogFn,
+	logPrefix: string,
+): Promise<Record<string, unknown> | null> {
+	const data = await hubRpcResponse(rpcUrl, method, params, hubApiKey, log, logPrefix);
+	if (!data) return null;
+
+	if (data.error) {
+		log(`${logPrefix}_rpc_error`, { code: data.error.code, message: data.error.message, data: data.error.data }, "ERROR");
+		return null;
+	}
+
+	if (data.result) {
+		return data.result;
+	}
+
+	log(`${logPrefix}_unexpected`, { response: JSON.stringify(data).slice(0, 500) }, "WARN");
+	return null;
 }
 
 // ── Public API ──────────────────────────────────────────────────
@@ -569,6 +628,7 @@ export async function reportTelemetryToHub(
 	telemetry: TelemetrySnapshot,
 	hubConfig: HubConfig,
 	log: LogFn,
+	instanceId?: string,
 ): Promise<{ telemetryUpdatedAt: string } | null> {
 	const rpcUrl = hubRpcUrl(hubConfig);
 
@@ -578,6 +638,9 @@ export async function reportTelemetryToHub(
 		activeTasks: telemetry.activeTasks,
 		maxConcurrent: telemetry.maxConcurrent,
 	};
+	if (instanceId !== undefined) {
+		params.instanceId = instanceId;
+	}
 	if (telemetry.lastTaskDurationMs !== undefined) {
 		params.lastTaskDurationMs = telemetry.lastTaskDurationMs;
 	}
@@ -601,12 +664,41 @@ export async function reportTelemetryToHub(
 // ── Pipeline Tasks ───────────────────────────────────────────
 
 function asTask(r: Record<string, unknown>): HubTask {
-	return r as unknown as HubTask;
+	const projectId = (r.projectId as string | null | undefined) ?? (r.project as string | null | undefined) ?? null;
+	const project = (r.project as string | null | undefined) ?? projectId;
+	return {
+		id: r.id as string,
+		title: r.title as string,
+		description: (r.description as string | null | undefined) ?? null,
+		projectId,
+		project: project ?? null,
+		repo: (r.repo as string | null | undefined) ?? null,
+		state: r.state as PipelineState,
+		priority: r.priority as TaskPriority,
+		assignedAgentId: (r.assignedAgentId as string | null | undefined) ?? null,
+		createdBy: r.createdBy as string,
+		externalTaskId: (r.externalTaskId as string | null | undefined) ?? null,
+		branch: (r.branch as string | null | undefined) ?? null,
+		prUrl: (r.prUrl as string | null | undefined) ?? null,
+		prNumber: (r.prNumber as number | null | undefined) ?? null,
+		reportPath: (r.reportPath as string | null | undefined) ?? null,
+		blockedReason: (r.blockedReason as string | null | undefined) ?? null,
+		reviewRound: (r.reviewRound as number | undefined) ?? 0,
+		maxReviewRounds: (r.maxReviewRounds as number | undefined) ?? 0,
+		metadata: (r.metadata as Record<string, unknown> | undefined) ?? {},
+		createdAt: r.createdAt as string,
+		updatedAt: r.updatedAt as string,
+		startedAt: (r.startedAt as string | null | undefined) ?? null,
+		completedAt: (r.completedAt as string | null | undefined) ?? null,
+		leaseOwnerAgentId: (r.leaseOwnerAgentId as string | null | undefined) ?? null,
+		leaseOwnerInstanceId: (r.leaseOwnerInstanceId as string | null | undefined) ?? null,
+		leaseExpiresAt: (r.leaseExpiresAt as string | null | undefined) ?? null,
+	};
 }
 
 function asTaskList(r: Record<string, unknown>): { tasks: HubTask[]; total: number; page: number; limit: number } {
 	return {
-		tasks: ((r.tasks as unknown[]) ?? []).map((t) => t as HubTask),
+		tasks: ((r.tasks as unknown[]) ?? []).map((t) => asTask(t as Record<string, unknown>)),
 		total: (r.total as number) ?? 0,
 		page: (r.page as number) ?? 1,
 		limit: (r.limit as number) ?? 0,
@@ -755,6 +847,102 @@ export async function reportHubTaskStatus(
 	const rpcUrl = hubRpcUrl(hubConfig);
 	const result = await hubRpc(rpcUrl, "tasks.reportStatus", params as Record<string, unknown>, hubConfig.apiKey, log, "tasks_report_status");
 	return result ? asTask(result) : null;
+}
+
+function normalizeLeaseDurationSeconds(leaseDurationSeconds?: number): number {
+	const defaultLeaseDurationSeconds = 900;
+	const maxLeaseDurationSeconds = 86_400;
+	if (leaseDurationSeconds === undefined || Number.isNaN(leaseDurationSeconds)) {
+		return defaultLeaseDurationSeconds;
+	}
+	return Math.min(Math.max(Math.floor(leaseDurationSeconds), 1), maxLeaseDurationSeconds);
+}
+
+function asClaimResult(r: Record<string, unknown>): ClaimTaskResult {
+	return {
+		task: (r.task as Record<string, unknown> | null | undefined) ? asTask(r.task as Record<string, unknown>) : null,
+		claimed: (r.claimed as boolean) ?? false,
+	};
+}
+
+function asHeartbeatResult(r: Record<string, unknown>): TaskHeartbeatResult {
+	return {
+		task: asTask(r.task as Record<string, unknown>),
+		renewed: (r.renewed as boolean) ?? false,
+	};
+}
+
+export async function claimHubTask(
+	params: ClaimTaskParams,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<ClaimTaskResult> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpcResponse(
+		rpcUrl,
+		"tasks.claim",
+		{
+			agentId: params.agentId,
+			instanceId: params.instanceId,
+			...(params.taskId !== undefined ? { taskId: params.taskId } : {}),
+			...(params.projectId !== undefined ? { projectId: params.projectId } : {}),
+			leaseDurationSeconds: normalizeLeaseDurationSeconds(params.leaseDurationSeconds),
+		},
+		hubConfig.apiKey,
+		log,
+		"tasks_claim",
+	);
+
+	if (!result) {
+		return { task: null, claimed: false };
+	}
+
+	if (result.error) {
+		log("tasks_claim_rpc_error", { code: result.error.code, message: result.error.message, data: result.error.data }, "ERROR");
+		throw new HubRpcError(result.error.code, result.error.message, result.error.data);
+	}
+
+	if (!result.result) {
+		return { task: null, claimed: false };
+	}
+
+	return asClaimResult(result.result);
+}
+
+export async function heartbeatHubTask(
+	params: TaskHeartbeatParams,
+	hubConfig: HubConfig,
+	log: LogFn,
+): Promise<TaskHeartbeatResult> {
+	const rpcUrl = hubRpcUrl(hubConfig);
+	const result = await hubRpcResponse(
+		rpcUrl,
+		"tasks.heartbeat",
+		{
+			agentId: params.agentId,
+			instanceId: params.instanceId,
+			taskId: params.taskId,
+			leaseDurationSeconds: normalizeLeaseDurationSeconds(params.leaseDurationSeconds),
+		},
+		hubConfig.apiKey,
+		log,
+		"tasks_heartbeat",
+	);
+
+	if (!result) {
+		throw new HubRpcError(-1, "No response from hub");
+	}
+
+	if (result.error) {
+		log("tasks_heartbeat_rpc_error", { code: result.error.code, message: result.error.message, data: result.error.data }, "ERROR");
+		throw new HubRpcError(result.error.code, result.error.message, result.error.data);
+	}
+
+	if (!result.result) {
+		throw new HubRpcError(-1, "Malformed heartbeat response from hub");
+	}
+
+	return asHeartbeatResult(result.result);
 }
 
 // ── Push Notifications (Agent → Hub) ───────────────────────────────────────────

--- a/extensions/pi-a2a/src/hub.ts
+++ b/extensions/pi-a2a/src/hub.ts
@@ -859,15 +859,27 @@ function normalizeLeaseDurationSeconds(leaseDurationSeconds?: number): number {
 }
 
 function asClaimResult(r: Record<string, unknown>): ClaimTaskResult {
+	const claimed = (r.claimed as boolean) ?? false;
+	const rawTask = r.task;
+	if (rawTask !== null && rawTask !== undefined && typeof rawTask !== "object") {
+		throw new HubRpcError(-1, "Malformed claim response from hub");
+	}
+	if (claimed && (!rawTask || typeof rawTask !== "object")) {
+		throw new HubRpcError(-1, "Malformed claim response from hub");
+	}
 	return {
-		task: (r.task as Record<string, unknown> | null | undefined) ? asTask(r.task as Record<string, unknown>) : null,
-		claimed: (r.claimed as boolean) ?? false,
+		task: rawTask && typeof rawTask === "object" ? asTask(rawTask as Record<string, unknown>) : null,
+		claimed,
 	};
 }
 
 function asHeartbeatResult(r: Record<string, unknown>): TaskHeartbeatResult {
+	const rawTask = r.task;
+	if (!rawTask || typeof rawTask !== "object") {
+		throw new HubRpcError(-1, "Malformed heartbeat response from hub");
+	}
 	return {
-		task: asTask(r.task as Record<string, unknown>),
+		task: asTask(rawTask as Record<string, unknown>),
 		renewed: (r.renewed as boolean) ?? false,
 	};
 }
@@ -894,7 +906,7 @@ export async function claimHubTask(
 	);
 
 	if (!result) {
-		return { task: null, claimed: false };
+		throw new HubRpcError(-1, "No response from hub");
 	}
 
 	if (result.error) {
@@ -902,8 +914,8 @@ export async function claimHubTask(
 		throw new HubRpcError(result.error.code, result.error.message, result.error.data);
 	}
 
-	if (!result.result) {
-		return { task: null, claimed: false };
+	if (!result.result || typeof result.result !== "object") {
+		throw new HubRpcError(-1, "Malformed claim response from hub");
 	}
 
 	return asClaimResult(result.result);

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -51,7 +51,7 @@ import { loadConfig } from "./config.ts";
 import { buildAgentCard, enrichAgentCard } from "./agent-card.ts";
 import { PiAgentExecutor, type ProcessResult } from "./agent-executor.ts";
 import { startServer, stopServer, isRunning, updateAgentCard, getAgentCard } from "./server.ts";
-import { registerWithHub, deregisterFromHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, registerPushEndpoint, sendPushEvent, sendTaskStateChanged, sendTaskProgress, sendTaskError, sendHeartbeat, selectAgent, listStrategies, getProject, listProjects, createProject, updateProject, connectToPipelineStream, listenToSSEStream, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
+import { registerWithHub, deregisterFromHub, setCredentialOnHub, discoverAgentsOnHub, getAgentFromHub, getCredentialFromHub, reportTelemetryToHub, requestClarification, pollClarification, cancelClarification, listAnsweredClarifications, acknowledgeClarification, type AnsweredClarification, createHubTask, getHubTask, listHubTasks, updateHubTask, transitionHubTask, deleteHubTask, getHubTaskHistory, getHubTaskBoard, reportHubTaskStatus, claimHubTask, heartbeatHubTask, HubRpcError, registerPushEndpoint, sendPushEvent, sendTaskStateChanged, sendTaskProgress, sendTaskError, sendHeartbeat, selectAgent, listStrategies, getProject, listProjects, createProject, updateProject, connectToPipelineStream, listenToSSEStream, type HubTask, type PipelineState, type TaskPriority } from "./hub.ts";
 import { sendA2AMessage, getRemoteTask, type SenderIdentity } from "./client.ts";
 import { StaticAgentRegistry, extractSkills } from "./static-agents.ts";
 import { createLogger, type LogFn } from "./logger.ts";
@@ -214,6 +214,8 @@ export default function (pi: ExtensionAPI) {
 	let expiryInterval: ReturnType<typeof setInterval> | null = null;
 	let longRunningTaskPollerInterval: ReturnType<typeof setInterval> | null = null;
 	let hubAgentId: string | null = null;
+	/** Stable instance ID for this extension process, used by hub lease telemetry. */
+	const hubInstanceId = randomUUID();
 	let staticRegistry: StaticAgentRegistry | null = null;
 	/** Active SQLite task store — closed on session restart/shutdown. */
 	let taskStore: SQLiteTaskStore | null = null;
@@ -723,7 +725,7 @@ export default function (pi: ExtensionAPI) {
 			if (!hubAgentId) return;
 			const snapshot = buildTelemetrySnapshot();
 			const sentCount = snapshot.recentToolCalls?.length ?? 0;
-			const result = await reportTelemetryToHub(hubAgentId, snapshot, config.hub!, log);
+			const result = await reportTelemetryToHub(hubAgentId, snapshot, config.hub!, log, hubInstanceId);
 			if (result && sentCount > 0) {
 				drainRecentToolCalls(recentToolCalls, sentCount);
 			}
@@ -1203,6 +1205,7 @@ export default function (pi: ExtensionAPI) {
 						idleSnap,
 						hubConfig,
 						log,
+						hubInstanceId,
 					).catch(() => false);
 					if (result && sentCount > 0) {
 						drainRecentToolCalls(recentToolCalls, sentCount);
@@ -2594,6 +2597,8 @@ export default function (pi: ExtensionAPI) {
 			"  create     — Create a task (title + project required; optional: description, repo, priority, assignedAgentId)\n" +
 			"  update     — Update task fields (taskId required; any of: title, description, priority, assignedAgentId, externalTaskId, branch, prUrl, prNumber, blockedReason)\n" +
 			"  transition — Move through pipeline (taskId + toState; optional note). States: queued→planning→building→reviewing→pr_ready→approved | blocked | cancelled\n" +
+			"  claim      — Atomically claim a task (taskId optional; project optional; uses the current agent instance)\n" +
+			"  heartbeat  — Renew a claimed lease (taskId required; uses the current agent instance)\n" +
 			"  delete     — Delete a task (taskId required)\n" +
 			"  history    — State transition log for a task (taskId required)\n" +
 			"  report     — Agent self-reports pipeline status (hubTaskId + toState; optional: externalTaskId, branch, prUrl, prNumber, blockedReason)",
@@ -2605,6 +2610,8 @@ export default function (pi: ExtensionAPI) {
 				Type.Literal("create"),
 				Type.Literal("update"),
 				Type.Literal("transition"),
+				Type.Literal("claim"),
+				Type.Literal("heartbeat"),
 				Type.Literal("delete"),
 				Type.Literal("history"),
 				Type.Literal("report"),
@@ -2616,7 +2623,9 @@ export default function (pi: ExtensionAPI) {
 			title: Type.Optional(Type.String({ description: "Task title" })),
 			description: Type.Optional(Type.String({ description: "Task description" })),
 			project: Type.Optional(Type.String({ description: "Project name e.g. 'aivena', 'e9n.dev'" })),
+			projectId: Type.Optional(Type.String({ description: "Project identifier for claim/heartbeat operations" })),
 			repo: Type.Optional(Type.String({ description: "Git repo URL" })),
+			leaseDurationSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds (default 900, max 86400)" })),
 			priority: Type.Optional(Type.Union([
 				Type.Literal("low"), Type.Literal("normal"), Type.Literal("high"), Type.Literal("critical"),
 			], { description: "Task priority (default: normal)" })),
@@ -2653,6 +2662,49 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			switch (params.action) {
+
+				case "claim": {
+					if (!hubAgentId) return txt("❌ No hub agent ID yet. Register with the hub first.");
+					try {
+						const result = await claimHubTask({
+							agentId: hubAgentId,
+							instanceId: hubInstanceId,
+							taskId: params.taskId,
+							projectId: params.projectId ?? params.project,
+							leaseDurationSeconds: params.leaseDurationSeconds,
+						}, hubConfig, log);
+						if (!result.claimed || !result.task) {
+							return txt("No eligible task could be claimed.");
+						}
+						const lease = result.task.leaseExpiresAt ? `\n**Lease:** ${result.task.leaseExpiresAt}` : "";
+						return txt(`✅ Claimed\n**ID:** ${result.task.id}\n**Title:** ${result.task.title}\n**Project:** ${result.task.project ?? result.task.projectId ?? "—"}${lease}`);
+					} catch (err) {
+						if (err instanceof HubRpcError) {
+							return txt(`❌ Claim failed (${err.code}): ${err.message}`);
+						}
+						throw err;
+					}
+				}
+
+				case "heartbeat": {
+					if (!hubAgentId) return txt("❌ No hub agent ID yet. Register with the hub first.");
+					if (!params.taskId) return txt("❌ taskId required.");
+					try {
+						const result = await heartbeatHubTask({
+							agentId: hubAgentId,
+							instanceId: hubInstanceId,
+							taskId: params.taskId,
+							leaseDurationSeconds: params.leaseDurationSeconds,
+						}, hubConfig, log);
+						const lease = result.task.leaseExpiresAt ? `\n**Lease:** ${result.task.leaseExpiresAt}` : "";
+						return txt(`✅ Lease renewed\n**ID:** ${result.task.id}\n**Title:** ${result.task.title}${lease}`);
+					} catch (err) {
+						if (err instanceof HubRpcError) {
+							return txt(`❌ Heartbeat failed (${err.code}): ${err.message}`);
+						}
+						throw err;
+					}
+				}
 
 				case "board": {
 					const board = await getHubTaskBoard(

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2628,7 +2628,12 @@ export default function (pi: ExtensionAPI) {
 			project: Type.Optional(Type.String({ description: "Project name e.g. 'aivena', 'e9n.dev'" })),
 			projectId: Type.Optional(Type.String({ description: "Project identifier for claim operations" })),
 			repo: Type.Optional(Type.String({ description: "Git repo URL" })),
-			leaseDurationSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds for claim/heartbeat (default 900, min 1, max 86400)" })),
+			leaseDurationSeconds: Type.Optional(Type.Number({
+				description: "Lease duration in seconds for claim/heartbeat (default 900, min 1, max 86400)",
+				minimum: 1,
+				maximum: 86_400,
+				default: 900,
+			})),
 			priority: Type.Optional(Type.Union([
 				Type.Literal("low"), Type.Literal("normal"), Type.Literal("high"), Type.Literal("critical"),
 			], { description: "Task priority (default: normal)" })),

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -2597,8 +2597,8 @@ export default function (pi: ExtensionAPI) {
 			"  create     — Create a task (title + project required; optional: description, repo, priority, assignedAgentId)\n" +
 			"  update     — Update task fields (taskId required; any of: title, description, priority, assignedAgentId, externalTaskId, branch, prUrl, prNumber, blockedReason)\n" +
 			"  transition — Move through pipeline (taskId + toState; optional note). States: queued→planning→building→reviewing→pr_ready→approved | blocked | cancelled\n" +
-			"  claim      — Atomically claim a task (taskId optional; project optional; uses the current agent instance)\n" +
-			"  heartbeat  — Renew a claimed lease (taskId required; uses the current agent instance)\n" +
+			"  claim      — Atomically claim a task (taskId optional; projectId optional; leaseDurationSeconds optional; uses the current agent instance)\n" +
+			"  heartbeat  — Renew a claimed lease (taskId required; leaseDurationSeconds optional; uses the current agent instance)\n" +
 			"  delete     — Delete a task (taskId required)\n" +
 			"  history    — State transition log for a task (taskId required)\n" +
 			"  report     — Agent self-reports pipeline status (hubTaskId + toState; optional: externalTaskId, branch, prUrl, prNumber, blockedReason)",
@@ -2617,15 +2617,15 @@ export default function (pi: ExtensionAPI) {
 				Type.Literal("report"),
 			], { description: "Action to perform" }),
 			// Task identity
-			taskId: Type.Optional(Type.String({ description: "Hub task ID (required for get/update/transition/delete/history)" })),
+			taskId: Type.Optional(Type.String({ description: "Hub task ID (required for get/update/transition/heartbeat/delete/history)" })),
 			hubTaskId: Type.Optional(Type.String({ description: "Hub task ID (for report action)" })),
 			// Create / update fields
 			title: Type.Optional(Type.String({ description: "Task title" })),
 			description: Type.Optional(Type.String({ description: "Task description" })),
 			project: Type.Optional(Type.String({ description: "Project name e.g. 'aivena', 'e9n.dev'" })),
-			projectId: Type.Optional(Type.String({ description: "Project identifier for claim/heartbeat operations" })),
+			projectId: Type.Optional(Type.String({ description: "Project identifier for claim operations" })),
 			repo: Type.Optional(Type.String({ description: "Git repo URL" })),
-			leaseDurationSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds (default 900, max 86400)" })),
+			leaseDurationSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds for claim/heartbeat (default 900, max 86400)" })),
 			priority: Type.Optional(Type.Union([
 				Type.Literal("low"), Type.Literal("normal"), Type.Literal("high"), Type.Literal("critical"),
 			], { description: "Task priority (default: normal)" })),
@@ -2870,7 +2870,7 @@ export default function (pi: ExtensionAPI) {
 				}
 
 				default:
-					return txt("Unknown action. Use: board, list, get, create, update, transition, delete, history, report");
+					return txt("Unknown action. Use: board, list, get, create, update, transition, claim, heartbeat, delete, history, report");
 			}
 		},
 	});

--- a/extensions/pi-a2a/src/index.ts
+++ b/extensions/pi-a2a/src/index.ts
@@ -732,7 +732,17 @@ export default function (pi: ExtensionAPI) {
 		});
 	}
 
-    const sseConnections = new Map<string, { abort: () => void }>();
+	/** Persist hub registration state for lease tools, deregistration, and telemetry. */
+	function activateHubRegistration(agentId: string, config: ReturnType<typeof loadConfig>["config"]): void {
+		hubAgentId = agentId;
+		executor?.setHubAgentId(agentId);
+		if (!telemetryInterval) {
+			telemetryInterval = setInterval(() => { sendTelemetry(config).catch(() => {}); }, 30_000);
+		}
+		sendTelemetry(config).catch(() => {});
+	}
+
+	const sseConnections = new Map<string, { abort: () => void }>();
 
 	// ── Lifecycle ─────────────────────────────────────────────
 
@@ -1101,8 +1111,7 @@ export default function (pi: ExtensionAPI) {
 		if (config.hub && config.hub.apiKey && (config.hub.autoRegister !== false)) {
 			const result = await registerWithHub(agentPublicUrl, config.hub, log);
 			if (result) {
-				hubAgentId = result.agentId;
-				executor?.setHubAgentId(result.agentId);
+				activateHubRegistration(result.agentId, config);
 				ctx.ui.notify(`pi-a2a: Registered with hub (${result.status})`, "info");
 
 				// Always push credential via setCredential — registration may
@@ -1111,14 +1120,6 @@ export default function (pi: ExtensionAPI) {
 				if (config.local?.apiKey) {
 					await setCredentialOnHub(result.agentId, config.local.apiKey, config.hub, log);
 				}
-
-				// Periodic heartbeat (30s) — keeps hub from resetting
-				// telemetry to unknown. Real-time updates come from
-				// agent_start/agent_end hooks.
-				telemetryInterval = setInterval(() => { sendTelemetry(config).catch(() => {}); }, 30_000);
-
-				// Send initial telemetry report
-				sendTelemetry(config).catch(() => {});
 			}
 		}
 
@@ -2442,7 +2443,8 @@ export default function (pi: ExtensionAPI) {
 
 				const result = await registerWithHub(agentPublicUrl, config.hub, log);
 				if (result) {
-					ctx.ui.notify(`Registered with hub: agentId=${result.agentId}, status=${result.status}`, "info");
+					activateHubRegistration(result.agentId, config);
+					ctx.ui.notify(`Registered with hub: agentId=${result.agentId}, instanceId=${hubInstanceId}, status=${result.status}`, "info");
 					if (config.local?.apiKey) {
 						await setCredentialOnHub(result.agentId, config.local.apiKey, config.hub, log);
 						ctx.ui.notify("Credential pushed to hub", "info");
@@ -2471,6 +2473,7 @@ export default function (pi: ExtensionAPI) {
 					return;
 				}
 
+				activateHubRegistration(reg.agentId, config);
 				const result = await setCredentialOnHub(reg.agentId, config.local.apiKey, config.hub, log);
 				if (result) {
 					ctx.ui.notify(
@@ -2597,8 +2600,8 @@ export default function (pi: ExtensionAPI) {
 			"  create     — Create a task (title + project required; optional: description, repo, priority, assignedAgentId)\n" +
 			"  update     — Update task fields (taskId required; any of: title, description, priority, assignedAgentId, externalTaskId, branch, prUrl, prNumber, blockedReason)\n" +
 			"  transition — Move through pipeline (taskId + toState; optional note). States: queued→planning→building→reviewing→pr_ready→approved | blocked | cancelled\n" +
-			"  claim      — Atomically claim a task (taskId optional; projectId optional; leaseDurationSeconds optional; uses the current agent instance)\n" +
-			"  heartbeat  — Renew a claimed lease (taskId required; leaseDurationSeconds optional; uses the current agent instance)\n" +
+			"  claim      — Atomically claim a task (taskId optional; project/projectId optional; leaseDurationSeconds optional, default 900, range 1-86400; uses the current agent instance)\n" +
+			"  heartbeat  — Renew a claimed lease (taskId required; leaseDurationSeconds optional, default 900, range 1-86400; uses the current agent instance)\n" +
 			"  delete     — Delete a task (taskId required)\n" +
 			"  history    — State transition log for a task (taskId required)\n" +
 			"  report     — Agent self-reports pipeline status (hubTaskId + toState; optional: externalTaskId, branch, prUrl, prNumber, blockedReason)",
@@ -2625,7 +2628,7 @@ export default function (pi: ExtensionAPI) {
 			project: Type.Optional(Type.String({ description: "Project name e.g. 'aivena', 'e9n.dev'" })),
 			projectId: Type.Optional(Type.String({ description: "Project identifier for claim operations" })),
 			repo: Type.Optional(Type.String({ description: "Git repo URL" })),
-			leaseDurationSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds for claim/heartbeat (default 900, max 86400)" })),
+			leaseDurationSeconds: Type.Optional(Type.Number({ description: "Lease duration in seconds for claim/heartbeat (default 900, min 1, max 86400)" })),
 			priority: Type.Optional(Type.Union([
 				Type.Literal("low"), Type.Literal("normal"), Type.Literal("high"), Type.Literal("critical"),
 			], { description: "Task priority (default: normal)" })),


### PR DESCRIPTION
Adds lease-aware hub RPC support for multi-instance autonomous agents.

- tasks.claim / tasks.heartbeat wrappers
- stable instanceId telemetry
- hub task lease fields and display normalization
- hub_tasks tool actions for claim/heartbeat
- tests + README updates

Verification: npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task lease claiming and heartbeat renewal via the hub; tool actions added for claim and heartbeat, with lease expiry shown
  * Instance-scoped telemetry with a stable per-process instance ID (now surfaced on registration)

* **Tests**
  * Added comprehensive hub RPC helper tests covering claim, heartbeat, and telemetry flows

* **Documentation**
  * Added lease-aware hub RPCs section documenting claim/heartbeat/telemetry and task lease fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->