### PR TITLE
fix(review): make /gmail-auth launch OAuth reliably

### DIFF
--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `/gmail-auth` now discovers a running pi-webserver, refreshes the OAuth callback origin after manual server startup, uses shell-free browser launchers, and always provides a clickable, copyable local URL fallback
+- Authentication now accurately asks users to start pi-webserver when no callback server is running and directs unconfigured users to `settings.json` rather than unsupported environment variables
+
 ## [0.3.0] - 2026-05-08
 
 ### Changed

--- a/extensions/pi-gmail/README.md
+++ b/extensions/pi-gmail/README.md
@@ -34,11 +34,11 @@ Add to `~/.pi/agent/settings.json`:
 }
 ```
 
-Values can use `env:VAR_NAME` syntax to read from environment variables.
+Set `clientId` and `clientSecret` directly in `settings.json`; `env:VAR_NAME` substitution is not supported.
 
 ### 3. Authenticate
 
-Run `/gmail-auth` in pi to start the OAuth flow — opens a browser for Google sign-in and stores tokens locally.
+Start pi-webserver with `/web`, then run `/gmail-auth`. Pi requests the default browser and also prints a clickable, copyable local authentication URL in the conversation as a fallback. The running webserver handles the OAuth callback and Gmail stores the resulting tokens locally.
 
 ### Settings
 

--- a/extensions/pi-gmail/index.ts
+++ b/extensions/pi-gmail/index.ts
@@ -27,17 +27,16 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.ts";
 import { registerGmailTool } from "./tool.ts";
-import { mountGmailRoutes, unmountGmailRoutes } from "./web.ts";
+import { mountGmailRoutes, unmountGmailRoutes, updateGmailWebInfo } from "./web.ts";
 import {
 	isAuthenticated,
 	getAuthenticatedEmail,
-	getConsentUrl,
 	clearTokens,
 } from "./auth.ts";
 import type { GmailSettings } from "./types.ts";
 import * as client from "./client.ts";
 import { formatSearchResult } from "./formatter.ts";
-import { openUrl } from "./utils.ts";
+import { openUrl, terminalLink } from "./utils.ts";
 
 // ── Settings ────────────────────────────────────────────────────
 
@@ -232,45 +231,46 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("gmail-auth", {
 		description: "Connect your Gmail account via OAuth",
 		handler: async (_args: string | undefined, ctx: any) => {
-			const agentDir = getAgentDir();
 			const settings = getSettings(ctx.cwd);
 			const clientId = settings.clientId ?? "";
 
 			if (!clientId) {
 				ctx.ui.notify(
-					"Gmail not configured. Set GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET env vars, " +
-					'or add "pi-gmail" section to settings.json.',
+					'Gmail not configured. Add clientId and clientSecret to the "pi-gmail" section of settings.json.',
 					"error",
 				);
 				return;
 			}
 
-			// Check if webserver is running
-			let webPort: number | null = null;
+			// Discovery replies synchronously only while pi-webserver is listening.
+			const discovery: { info: { port: number; url: string } | null } = { info: null };
 			pi.events.emit("web:info", {
-				reply: (info: any) => {
-					if (info?.port) webPort = info.port;
+				reply: (info: unknown) => {
+					const candidate = info as { port?: unknown; url?: unknown };
+					if (typeof candidate?.port === "number" && typeof candidate.url === "string") {
+						discovery.info = { port: candidate.port, url: candidate.url };
+					}
 				},
 			});
 
-			if (webPort) {
-				// Open browser to auth page
-				const url = `http://localhost:${webPort}/gmail/auth`;
-				ctx.ui.notify(`Opening browser: ${url}`, "info");
+			if (discovery.info !== null && updateGmailWebInfo(discovery.info)) {
+				// Routes may have mounted before a manually started webserver. The updater
+				// refreshes the OAuth redirect origin before the browser requests this URL.
+				const url = new URL("/gmail/auth", discovery.info.url).toString();
+				pi.sendMessage({
+					customType: "gmail_auth",
+					content: `Opening Gmail authentication in your browser. If it does not appear, open this link:\n${terminalLink(url)}`,
+					display: true,
+					details: { type: "info" },
+				});
 				openUrl(url);
-			} else {
-				// No webserver — show the URL for manual copy
-				try {
-					const redirectUri = "http://localhost:3100/gmail/callback";
-					const url = getConsentUrl(settings, redirectUri);
-					ctx.ui.notify(
-						`Open this URL in your browser:\n${url}\n\nNote: pi-webserver must be running to handle the callback.`,
-						"info",
-					);
-				} catch (err: any) {
-					ctx.ui.notify(`Auth error: ${err.message}`, "error");
-				}
+				return;
 			}
+
+			ctx.ui.notify(
+				"Gmail OAuth requires pi-webserver to handle the callback. Start it with /web, then run /gmail-auth again.",
+				"info",
+			);
 		},
 	});
 

--- a/extensions/pi-gmail/index.ts
+++ b/extensions/pi-gmail/index.ts
@@ -36,7 +36,7 @@ import {
 import type { GmailSettings } from "./types.ts";
 import * as client from "./client.ts";
 import { formatSearchResult } from "./formatter.ts";
-import { openUrl, terminalLink } from "./utils.ts";
+import { openUrl } from "./utils.ts";
 
 // ── Settings ────────────────────────────────────────────────────
 
@@ -259,7 +259,7 @@ export default function (pi: ExtensionAPI) {
 				const url = new URL("/gmail/auth", discovery.info.url).toString();
 				pi.sendMessage({
 					customType: "gmail_auth",
-					content: `Opening Gmail authentication in your browser. If it does not appear, open this link:\n${terminalLink(url)}`,
+					content: `Opening Gmail authentication in your browser. If it does not appear, open this link:\n${url}`,
 					display: true,
 					details: { type: "info" },
 				});

--- a/extensions/pi-gmail/utils.test.ts
+++ b/extensions/pi-gmail/utils.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { SpawnOptions } from "node:child_process";
+import { getBrowserCommand, openUrl, terminalLink } from "./utils.ts";
+
+describe("getBrowserCommand", () => {
+	const url = "https://accounts.google.com/o/oauth2/auth?x=1&y=2";
+
+	it("uses shell-free platform launchers", () => {
+		assert.deepEqual(getBrowserCommand(url, "darwin"), {
+			command: "open",
+			args: [url],
+		});
+		assert.deepEqual(getBrowserCommand(url, "win32"), {
+			command: "rundll32",
+			args: ["url.dll,FileProtocolHandler", url],
+		});
+		assert.deepEqual(getBrowserCommand(url, "linux"), {
+			command: "xdg-open",
+			args: [url],
+		});
+	});
+});
+
+describe("openUrl", () => {
+	it("detaches the launcher, ignores stdio, and handles async errors", () => {
+		let errorHandler: (() => void) | undefined;
+		let unrefCalled = false;
+		let observed: { command: string; args: string[]; options: SpawnOptions } | undefined;
+		const fakeSpawn = (command: string, args: string[], options: SpawnOptions) => {
+			observed = { command, args, options };
+			return {
+				once(event: "error", handler: (error: Error) => void) {
+					assert.equal(event, "error");
+					errorHandler = () => handler(new Error("ENOENT"));
+					return this;
+				},
+				unref() {
+					unrefCalled = true;
+					return this;
+				},
+			};
+		};
+
+		openUrl("https://example.com/?a=1&b=2", "win32", fakeSpawn);
+		assert.deepEqual(observed, {
+			command: "rundll32",
+			args: ["url.dll,FileProtocolHandler", "https://example.com/?a=1&b=2"],
+			options: { detached: true, stdio: "ignore", shell: false },
+		});
+		assert.equal(unrefCalled, true);
+		assert.doesNotThrow(() => errorHandler?.());
+	});
+
+	it("does not throw when the launcher is missing", () => {
+		assert.doesNotThrow(() => {
+			openUrl("https://example.com", "linux", () => {
+				throw new Error("ENOENT");
+			});
+		});
+	});
+});
+
+describe("terminalLink", () => {
+	it("uses BEL-terminated OSC 8 and retains visible URL text", () => {
+		const url = "http://localhost:3100/gmail/auth";
+		assert.equal(terminalLink(url), `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`);
+	});
+});

--- a/extensions/pi-gmail/utils.test.ts
+++ b/extensions/pi-gmail/utils.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { SpawnOptions } from "node:child_process";
-import { getBrowserCommand, openUrl, terminalLink } from "./utils.ts";
+import { getBrowserCommand, openUrl } from "./utils.ts";
 
 describe("getBrowserCommand", () => {
 	const url = "https://accounts.google.com/o/oauth2/auth?x=1&y=2";
@@ -58,12 +58,5 @@ describe("openUrl", () => {
 				throw new Error("ENOENT");
 			});
 		});
-	});
-});
-
-describe("terminalLink", () => {
-	it("uses BEL-terminated OSC 8 and retains visible URL text", () => {
-		const url = "http://localhost:3100/gmail/auth";
-		assert.equal(terminalLink(url), `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`);
 	});
 });

--- a/extensions/pi-gmail/utils.ts
+++ b/extensions/pi-gmail/utils.ts
@@ -2,7 +2,8 @@
  * Shared utilities for pi-gmail.
  */
 
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
+import type { SpawnOptions } from "node:child_process";
 
 // ── HTML escaping ───────────────────────────────────────────────
 
@@ -23,21 +24,64 @@ export function escapeHtml(str: string): string {
 
 // ── Cross-platform URL opener ───────────────────────────────────
 
-/**
- * Open a URL in the default browser, cross-platform.
- * Uses execFile with argument array to prevent shell injection.
- */
-export function openUrl(url: string): void {
-	switch (process.platform) {
+export interface BrowserCommand {
+	command: string;
+	args: string[];
+}
+
+interface SpawnedBrowser {
+	once(event: "error", listener: (error: Error) => void): unknown;
+	unref(): unknown;
+}
+
+type SpawnBrowser = (
+	command: string,
+	args: string[],
+	options: SpawnOptions,
+) => SpawnedBrowser;
+
+/** Select the platform browser launcher without invoking a shell. */
+export function getBrowserCommand(
+	url: string,
+	platform: NodeJS.Platform = process.platform,
+): BrowserCommand {
+	switch (platform) {
 		case "darwin":
-			execFile("open", [url]);
-			break;
+			return { command: "open", args: [url] };
 		case "win32":
-			execFile("cmd", ["/c", "start", "", url]);
-			break;
+			return {
+				command: "rundll32",
+				args: ["url.dll,FileProtocolHandler", url],
+			};
 		default:
-			// Linux and other Unix-like
-			execFile("xdg-open", [url]);
-			break;
+			return { command: "xdg-open", args: [url] };
+	}
+}
+
+/** Format a terminal link while keeping the URL visible without OSC 8 support. */
+export function terminalLink(url: string): string {
+	return `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`;
+}
+
+/**
+ * Best-effort browser launch. Launcher failures are deliberately ignored because
+ * callers always provide a visible URL fallback.
+ */
+export function openUrl(
+	url: string,
+	platform: NodeJS.Platform = process.platform,
+	spawnBrowser: SpawnBrowser = spawn,
+): void {
+	const { command, args } = getBrowserCommand(url, platform);
+	try {
+		const child = spawnBrowser(command, args, {
+			detached: true,
+			stdio: "ignore",
+			shell: false,
+		});
+		child.once("error", () => {});
+		child.unref();
+	} catch {
+		// A missing or unavailable launcher must not crash Pi.
 	}
 }

--- a/extensions/pi-gmail/utils.ts
+++ b/extensions/pi-gmail/utils.ts
@@ -58,11 +58,6 @@ export function getBrowserCommand(
 	}
 }
 
-/** Format a terminal link while keeping the URL visible without OSC 8 support. */
-export function terminalLink(url: string): string {
-	return `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`;
-}
-
 /**
  * Best-effort browser launch. Launcher failures are deliberately ignored because
  * callers always provide a visible URL fallback.

--- a/extensions/pi-gmail/web.test.ts
+++ b/extensions/pi-gmail/web.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, it } from "node:test";
+import { mountGmailRoutes, updateGmailWebInfo } from "./web.ts";
+
+type RouteHandler = (
+	req: IncomingMessage,
+	res: ServerResponse,
+	subPath: string,
+) => void | Promise<void>;
+
+describe("Gmail OAuth web routes", () => {
+	it("uses the discovered manual-start server origin in the consent redirect", async () => {
+		let gmailHandler: RouteHandler | undefined;
+		const bus = {
+			on() {},
+			emit(event: string, data: unknown) {
+				// Simulate mounting before pi-webserver starts: web:info has no reply.
+				if (event === "web:mount") {
+					gmailHandler = (data as { handler: RouteHandler }).handler;
+				}
+			},
+		};
+
+		updateGmailWebInfo({ port: 3100, url: "http://localhost:3100" });
+		mountGmailRoutes(bus, { clientId: "test-client" }, "/tmp/pi-gmail-test");
+
+		// /gmail-auth discovers this after /web was started manually.
+		assert.equal(
+			updateGmailWebInfo({ port: 42873, url: "http://localhost:42873" }),
+			true,
+		);
+
+		let status: number | undefined;
+		let location: string | undefined;
+		let ended = false;
+		const response = {
+			writeHead(nextStatus: number, headers: Record<string, string>) {
+				status = nextStatus;
+				location = headers.Location;
+			},
+			end() {
+				ended = true;
+			},
+		} as unknown as ServerResponse;
+
+		assert.ok(gmailHandler);
+		const handler = gmailHandler as RouteHandler;
+		await handler(
+			{ method: "GET", url: "/gmail/auth" } as IncomingMessage,
+			response,
+			"/auth",
+		);
+
+		assert.equal(status, 302);
+		assert.equal(ended, true);
+		assert.ok(location);
+		const consentUrl = new URL(location as string);
+		assert.equal(
+			consentUrl.searchParams.get("redirect_uri"),
+			"http://localhost:42873/gmail/callback",
+		);
+	});
+});

--- a/extensions/pi-gmail/web.ts
+++ b/extensions/pi-gmail/web.ts
@@ -49,12 +49,29 @@ interface EventBus {
 	on(event: string, handler: (...args: any[]) => void): void;
 }
 
-// ── Detect server port from webserver ───────────────────────────
+// ── Detect server origin from webserver ─────────────────────────
 
-let serverPort = 3100; // default
+export interface GmailWebInfo {
+	port: number;
+	url: string;
+}
+
+let serverOrigin = "http://localhost:3100"; // fallback until pi-webserver replies
+
+/** Keep OAuth redirects aligned with the currently listening pi-webserver. */
+export function updateGmailWebInfo(info: GmailWebInfo): boolean {
+	try {
+		const url = new URL(info.url);
+		if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+		serverOrigin = url.origin;
+		return true;
+	} catch {
+		return false;
+	}
+}
 
 function getRedirectUri(): string {
-	return `http://localhost:${serverPort}/gmail/callback`;
+	return new URL("/gmail/callback", `${serverOrigin}/`).toString();
 }
 
 // ── CSRF token for logout form ──────────────────────────────────
@@ -188,7 +205,9 @@ export function mountGmailRoutes(
 	// Try to detect the webserver port
 	bus.emit("web:info", {
 		reply: (info: any) => {
-			if (info?.port) serverPort = info.port;
+			if (typeof info?.port === "number" && typeof info.url === "string") {
+				updateGmailWebInfo(info);
+			}
 		},
 	});
 
@@ -223,7 +242,7 @@ export function mountGmailRoutes(
 
 			// OAuth callback
 			if (req.method === "GET" && p === "/callback") {
-				const url = new URL(req.url ?? "/", `http://localhost:${serverPort}`);
+				const url = new URL(req.url ?? "/", `${serverOrigin}/`);
 				const code = url.searchParams.get("code");
 				const error = url.searchParams.get("error");
 				const state = url.searchParams.get("state");

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added a synchronous `web:info` event reply with the actual listening port and URL for extension discovery
+
 ## [0.3.0] - 2026-05-08
 
 ### Changed

--- a/extensions/pi-webserver/README.md
+++ b/extensions/pi-webserver/README.md
@@ -102,6 +102,7 @@ pi.events.emit("web:mount-api", {
 | Event | Direction | Payload |
 |-------|-----------|---------|
 | `web:ready` | ← emitted by webserver on session start | `{}` |
+| `web:info` | → webserver replies synchronously when listening | `{ reply: ({ port, url }) => void }` |
 | `web:mount` | → webserver listens | `MountConfig` |
 | `web:unmount` | → webserver listens | `{ name: string }` |
 | `web:mount-api` | → webserver listens | `MountConfig` |

--- a/extensions/pi-webserver/index.ts
+++ b/extensions/pi-webserver/index.ts
@@ -14,6 +14,7 @@ import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { start, stop, mount, unmount, mountApi, unmountApi, isRunning, getUrl, getPort, getMounts, getApiMounts, setAuth, getAuth, setApiToken, setApiReadToken, getApiTokenStatus, setLogger } from "./server.ts";
 import { createLogger } from "./logger.ts";
 import type { MountConfig } from "./server.ts";
+import { registerWebInfoListener } from "./web-info.ts";
 
 interface WebServerSettings {
 	autostart: boolean;
@@ -66,6 +67,12 @@ export default function (pi: ExtensionAPI) {
 
 	pi.events.on("web:unmount-api", (data: unknown) => {
 		unmountApi((data as { name: string }).name);
+	});
+
+	registerWebInfoListener(pi.events, () => {
+		const port = getPort();
+		const url = getUrl();
+		return port !== null && url !== null ? { port, url } : null;
 	});
 
 	// ── /web command ─────────────────────────────────────────────

--- a/extensions/pi-webserver/server.ts
+++ b/extensions/pi-webserver/server.ts
@@ -54,7 +54,6 @@ export function setLogger(fn: LogFn): void {
 // ── State ───────────────────────────────────────────────────────
 
 let server: http.Server | null = null;
-let serverPort: number | null = null;
 const mounts = new Map<string, MountConfig>();
 let authCredentials: { username: string; password: string } | null = null;
 let apiToken: string | null = null;
@@ -345,15 +344,18 @@ function handleLoginPost(req: http.IncomingMessage, res: http.ServerResponse): v
 // ── Server Lifecycle ────────────────────────────────────────────
 
 export function isRunning(): boolean {
-	return server !== null;
-}
-
-export function getUrl(): string | null {
-	return serverPort ? `http://localhost:${serverPort}` : null;
+	return server?.listening ?? false;
 }
 
 export function getPort(): number | null {
-	return serverPort;
+	if (!server?.listening) return null;
+	const address = server.address();
+	return address && typeof address === "object" ? address.port : null;
+}
+
+export function getUrl(): string | null {
+	const port = getPort();
+	return port === null ? null : `http://localhost:${port}`;
 }
 
 /**
@@ -506,7 +508,6 @@ export function start(port: number = 4100): string {
 	});
 
 	server.listen(port);
-	serverPort = port;
 	return `http://localhost:${port}`;
 }
 
@@ -516,6 +517,5 @@ export function stop(): boolean {
 	server.closeAllConnections();
 	server.close();
 	server = null;
-	serverPort = null;
 	return true;
 }

--- a/extensions/pi-webserver/web-info.test.ts
+++ b/extensions/pi-webserver/web-info.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getPort, getUrl, isRunning, start, stop } from "./server.ts";
+import { registerWebInfoListener, type WebInfo } from "./web-info.ts";
+
+class FakeEvents {
+	private handler: ((request: unknown) => void) | undefined;
+
+	on(event: "web:info", handler: (request: unknown) => void): void {
+		assert.equal(event, "web:info");
+		this.handler = handler;
+	}
+
+	emit(request: unknown): void {
+		this.handler?.(request);
+	}
+}
+
+describe("registerWebInfoListener", () => {
+	it("replies synchronously with the running server address", () => {
+		const events = new FakeEvents();
+		const expected = { port: 3100, url: "http://localhost:3100" };
+		registerWebInfoListener(events, () => expected);
+
+		let reply: WebInfo | undefined;
+		events.emit({ reply: (info: WebInfo) => { reply = info; } });
+		assert.deepEqual(reply, expected);
+	});
+
+	it("does not reply when no server is listening", () => {
+		const events = new FakeEvents();
+		registerWebInfoListener(events, () => null);
+
+		let replied = false;
+		events.emit({ reply: () => { replied = true; } });
+		assert.equal(replied, false);
+	});
+
+	it("replies with the dynamic port and URL from the listening server", async () => {
+		const events = new FakeEvents();
+		registerWebInfoListener(events, () => {
+			const port = getPort();
+			const url = getUrl();
+			return port !== null && url !== null ? { port, url } : null;
+		});
+
+		try {
+			start(0);
+			for (let attempt = 0; attempt < 20 && !isRunning(); attempt++) {
+				await new Promise<void>((resolve) => setImmediate(resolve));
+			}
+
+			let reply: WebInfo | undefined;
+			events.emit({ reply: (info: WebInfo) => { reply = info; } });
+
+			assert.ok(reply);
+			const info = reply as WebInfo;
+			assert.ok(info.port > 0);
+			assert.equal(info.port, getPort());
+			assert.equal(info.url, getUrl());
+			assert.equal(info.url, `http://localhost:${info.port}`);
+		} finally {
+			stop();
+		}
+	});
+});

--- a/extensions/pi-webserver/web-info.ts
+++ b/extensions/pi-webserver/web-info.ts
@@ -1,0 +1,25 @@
+export interface WebInfo {
+	port: number;
+	url: string;
+}
+
+export interface WebInfoRequest {
+	reply: (info: WebInfo) => void;
+}
+
+interface WebEvents {
+	on(event: "web:info", handler: (request: unknown) => void): void;
+}
+
+/** Register the synchronous discovery contract used by other extensions. */
+export function registerWebInfoListener(
+	events: WebEvents,
+	getInfo: () => WebInfo | null,
+): void {
+	events.on("web:info", (request: unknown) => {
+		const reply = (request as Partial<WebInfoRequest> | null)?.reply;
+		if (typeof reply !== "function") return;
+		const info = getInfo();
+		if (info) reply(info);
+	});
+}


### PR DESCRIPTION
@espennilsen to make more usable the oauth flow, hope you look at it. Cheers!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gmail authentication now discovers the active web server automatically and opens the correct authorization page.
  - Displays a local OAuth URL when a browser cannot be launched.
  - Web server status and URL can be discovered while running.

- **Bug Fixes**
  - Improved OAuth callback handling for dynamically assigned ports and validated server URLs.
  - Browser launching is more reliable across macOS, Windows, and Linux.

- **Documentation**
  - Updated Gmail setup instructions, authentication steps, and web server event documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->