### PR TITLE
chore: pin Pi Corepack policy to pnpm 11.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pi-agent-home",
+  "private": true,
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f996d19a1d78615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119998a66e7b29fedf588c7ccc7bdc8"
+}


### PR DESCRIPTION
## Summary
- add a minimal private Pi-root package manifest
- pin Corepack to pnpm 11.17.0 with the npm registry integrity hash
- avoid adding an empty lockfile because the repository has no root dependencies

## Verification
- `corepack pnpm --version` → `11.17.0`
- `corepack pnpm --dir extensions/pi-a2a --version` → `11.17.0`
- `corepack pnpm install --frozen-lockfile` completed successfully (the generated empty lockfile was intentionally removed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project package metadata.
  * Standardized the package manager and pinned its version for consistent development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->