### PR TITLE
feat(skills): add Herdr setup and operations guides

### DIFF
--- a/.pi/skills/herdr-operations/SKILL.md
+++ b/.pi/skills/herdr-operations/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: herdr-operations
+description: Use when inspecting or operating Herdr sessions, workspaces, tabs, panes, agents, terminal output, agent messaging, or waits.
+---
+
+# Herdr Operations
+
+Inspect state before acting. Use the installed CLI help as the authority for the current version.
+
+## Safe discovery
+
+```bash
+herdr status
+herdr session list --json
+herdr workspace list
+herdr pane list
+herdr agent list
+```
+
+If one command fails, do not try invented alternatives. Run `herdr --help`, then the relevant command group's `--help`; if needed, use [the upstream docs fallback](references/upstream-docs.md).
+
+## Choose the right target
+
+| Need | Use |
+| --- | --- |
+| Coding-agent state, output, or message | `herdr agent …` |
+| Server, test, shell, or low-level terminal control | `herdr pane …` |
+| Submit a shell command atomically | `herdr pane run <pane_id> <command>` |
+| Read logs without soft wrapping | `--source recent-unwrapped` |
+
+## Common workflows
+
+Inspect an agent, then use the installed agent-message command:
+
+```bash
+herdr agent list
+herdr agent get <target>
+herdr agent read <target> --source recent-unwrapped --lines 120
+herdr agent --help
+herdr agent <installed-message-command> <target> "<message>"
+```
+
+For example, documented releases have used `agent send`; newer releases may expose another message command. Use the spelling and argument order from local help.
+
+Create an unfocused workspace or split pane so current work remains visible:
+
+```bash
+herdr workspace create --cwd <path> --label <label> --no-focus
+herdr pane split <pane_id> --direction right --no-focus
+```
+
+Wait rather than polling:
+
+```bash
+herdr agent wait <target> --status idle --timeout 300000
+herdr wait output <pane_id> --match "<text>" --timeout 300000
+```
+
+## Safety
+
+- Read output before sending input to an agent.
+- Use `pane run` instead of separate text and Enter events for shell commands.
+- Ask before stopping/deleting sessions or closing workspaces, tabs, or panes.
+- Treat agent messages as literal terminal input; do not send destructive instructions without explicit user approval.

--- a/.pi/skills/herdr-operations/SKILL.md
+++ b/.pi/skills/herdr-operations/SKILL.md
@@ -52,8 +52,8 @@ herdr pane split <pane_id> --direction right --no-focus
 Wait rather than polling:
 
 ```bash
-herdr agent wait <target> --status idle --timeout 300000
-herdr wait output <pane_id> --match "<text>" --timeout 300000
+herdr agent wait <target> --until idle --timeout 300000
+herdr pane wait-output <pane_id> --match "<text>" --timeout 300000
 ```
 
 ## Safety

--- a/.pi/skills/herdr-operations/references/upstream-docs.md
+++ b/.pi/skills/herdr-operations/references/upstream-docs.md
@@ -1,0 +1,16 @@
+# Upstream documentation fallback
+
+When installed `herdr --help` does not provide enough information, use the upstream documentation repository:
+
+- Documentation root: https://github.com/ogulcancelik/herdr/tree/master/docs/versions
+- Versioned docs pattern: `https://github.com/ogulcancelik/herdr/tree/master/docs/versions/<version>/website/src/content/docs`
+- CLI reference: `.../cli-reference.mdx`
+- Install/update: `.../install.mdx`
+- Agents and integrations: `.../agents.mdx`
+- Releases: https://github.com/ogulcancelik/herdr/releases
+
+## Procedure
+
+1. Run `herdr --version` and use that version's docs directory if it exists.
+2. If it does not, inspect the nearest documented release and the current docs, but label the advice as potentially version-dependent.
+3. Confirm exact command spelling and flags with local `--help` before executing anything mutating.

--- a/.pi/skills/herdr-operations/references/upstream-docs.md
+++ b/.pi/skills/herdr-operations/references/upstream-docs.md
@@ -4,9 +4,9 @@ When installed `herdr --help` does not provide enough information, use the upstr
 
 - Documentation root: https://github.com/ogulcancelik/herdr/tree/master/docs/versions
 - Versioned docs pattern: `https://github.com/ogulcancelik/herdr/tree/master/docs/versions/<version>/website/src/content/docs`
-- CLI reference: `.../cli-reference.mdx`
-- Install/update: `.../install.mdx`
-- Agents and integrations: `.../agents.mdx`
+- CLI reference: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/cli-reference.mdx`
+- Install/update: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/install.mdx`
+- Agents and integrations: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/agents.mdx`
 - Releases: https://github.com/ogulcancelik/herdr/releases
 
 ## Procedure

--- a/.pi/skills/herdr-operations/references/upstream-docs.md
+++ b/.pi/skills/herdr-operations/references/upstream-docs.md
@@ -6,7 +6,8 @@ When installed `herdr --help` does not provide enough information, use the upstr
 - Versioned docs pattern: `https://github.com/ogulcancelik/herdr/tree/master/docs/versions/<version>/website/src/content/docs`
 - CLI reference: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/cli-reference.mdx`
 - Install/update: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/install.mdx`
-- Agents and integrations: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/agents.mdx`
+- Agents: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/agents.mdx`
+- Integrations: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/integrations.mdx`
 - Releases: https://github.com/ogulcancelik/herdr/releases
 
 ## Procedure

--- a/.pi/skills/herdr-setup/SKILL.md
+++ b/.pi/skills/herdr-setup/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: herdr-setup
+description: Use when installing, updating, configuring, or troubleshooting Herdr, including missing commands, PATH errors, version differences, or Pi integration setup.
+---
+
+# Herdr Setup
+
+Use the installed binary as the source of truth. Do not assume a command or flag from a different version exists.
+
+## Inspect first
+
+```bash
+command -v herdr
+herdr --version
+herdr --help
+herdr integration status
+```
+
+If `herdr` is absent, explain that it supports Linux and macOS (use WSL on Windows). Ask before running the upstream installer:
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+```
+
+After installation, start a new shell if PATH has not refreshed, then rerun `herdr --version`.
+
+## Integrate Pi
+
+Inspect integration state before changing it:
+
+```bash
+herdr integration status
+```
+
+Install or update the Pi integration only when requested:
+
+```bash
+herdr integration install pi
+```
+
+Use `herdr integration status --outdated-only` to identify stale integrations. Do not remove an integration without confirmation.
+
+## Updates and configuration
+
+- Use `herdr update` only when the user asks to update.
+- Use `herdr --default-config` to inspect defaults before editing configuration.
+- Treat `HERDR_CONFIG_PATH`, `HERDR_SESSION`, and `HERDR_SOCKET_PATH` as explicit overrides; report their values before troubleshooting a surprising target/session.
+
+## Command or version mismatch
+
+1. Stop guessing after an unknown-command or unknown-flag error.
+2. Run `herdr --help`, then `<known-group> --help` for the installed command tree.
+3. Read [the upstream docs fallback](references/upstream-docs.md), selecting the installed release version when available.
+4. If the installed help and matching version docs disagree, prefer installed help and report the discrepancy.
+
+## Safety
+
+`herdr server stop`, `session stop`, `session delete`, and `workspace/tab/pane close` affect live work. List or inspect state first and ask for confirmation before running them.

--- a/.pi/skills/herdr-setup/SKILL.md
+++ b/.pi/skills/herdr-setup/SKILL.md
@@ -16,7 +16,11 @@ herdr --help
 herdr integration status
 ```
 
-If `herdr` is absent, explain that it supports Linux and macOS (use WSL on Windows). Ask before running the upstream installer:
+If `herdr` is absent, explain that it supports Linux and macOS. On Windows, the native preview installer is available; use WSL only if the native preview is unsuitable. Ask before running either upstream installer:
+
+```powershell
+irm https://herdr.dev/install.ps1 | iex
+```
 
 ```bash
 curl -fsSL https://herdr.dev/install.sh | sh

--- a/.pi/skills/herdr-setup/references/upstream-docs.md
+++ b/.pi/skills/herdr-setup/references/upstream-docs.md
@@ -1,0 +1,16 @@
+# Upstream documentation fallback
+
+When installed `herdr --help` does not provide enough information, use the upstream documentation repository:
+
+- Documentation root: https://github.com/ogulcancelik/herdr/tree/master/docs/versions
+- Versioned docs pattern: `https://github.com/ogulcancelik/herdr/tree/master/docs/versions/<version>/website/src/content/docs`
+- CLI reference: `.../cli-reference.mdx`
+- Install/update: `.../install.mdx`
+- Agents and integrations: `.../agents.mdx`
+- Releases: https://github.com/ogulcancelik/herdr/releases
+
+## Procedure
+
+1. Run `herdr --version` and use that version's docs directory if it exists.
+2. If it does not, inspect the nearest documented release and the current docs, but label the advice as potentially version-dependent.
+3. Confirm exact command spelling and flags with local `--help` before executing anything mutating.

--- a/.pi/skills/herdr-setup/references/upstream-docs.md
+++ b/.pi/skills/herdr-setup/references/upstream-docs.md
@@ -4,9 +4,9 @@ When installed `herdr --help` does not provide enough information, use the upstr
 
 - Documentation root: https://github.com/ogulcancelik/herdr/tree/master/docs/versions
 - Versioned docs pattern: `https://github.com/ogulcancelik/herdr/tree/master/docs/versions/<version>/website/src/content/docs`
-- CLI reference: `.../cli-reference.mdx`
-- Install/update: `.../install.mdx`
-- Agents and integrations: `.../agents.mdx`
+- CLI reference: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/cli-reference.mdx`
+- Install/update: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/install.mdx`
+- Agents and integrations: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/agents.mdx`
 - Releases: https://github.com/ogulcancelik/herdr/releases
 
 ## Procedure

--- a/.pi/skills/herdr-setup/references/upstream-docs.md
+++ b/.pi/skills/herdr-setup/references/upstream-docs.md
@@ -6,7 +6,8 @@ When installed `herdr --help` does not provide enough information, use the upstr
 - Versioned docs pattern: `https://github.com/ogulcancelik/herdr/tree/master/docs/versions/<version>/website/src/content/docs`
 - CLI reference: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/cli-reference.mdx`
 - Install/update: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/install.mdx`
-- Agents and integrations: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/agents.mdx`
+- Agents: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/agents.mdx`
+- Integrations: `https://github.com/ogulcancelik/herdr/blob/master/docs/versions/<version>/website/src/content/docs/integrations.mdx`
 - Releases: https://github.com/ogulcancelik/herdr/releases
 
 ## Procedure


### PR DESCRIPTION
## Summary
- add version-agnostic `herdr-setup` and `herdr-operations` project skills
- use installed `--help` as command authority and version-matched upstream docs as fallback
- document safe inspection, agent/pane workflows, and destructive-action confirmation

## Verification
- validated both skills with the skill-creator validator
- `git diff --check`
- baseline and post-skill operations scenarios were exercised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance for installing, configuring, updating, and troubleshooting the Herdr CLI and Pi integration.
  * Added operational guidance for managing Herdr sessions, workspaces, tabs, panes, agents, terminal output, messaging, and wait operations.
  * Documented safe workflows for inspecting output, running commands, and handling potentially destructive actions.
  * Added upstream documentation references, version-selection guidance, and instructions for validating commands with local help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->