### PR TITLE
docs: finalize 0.3.0 extension changelogs

### DIFF
--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
+## [0.3.0] - 2026-08-10
+
 ### Fixed
 
 - `/gmail-auth` now discovers a running pi-webserver, refreshes the OAuth callback origin after manual server startup, uses shell-free browser launchers, and always provides a clickable, copyable local URL fallback
 - Authentication now accurately asks users to start pi-webserver when no callback server is running and directs unconfigured users to `settings.json` rather than unsupported environment variables
-
-## [0.3.0] - 2026-05-08
 
 ### Changed
 

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
+## [0.3.0] - 2026-08-10
+
 ### Added
 
 - Added a synchronous `web:info` event reply with the actual listening port and URL for extension discovery
-
-## [0.3.0] - 2026-05-08
 
 ### Changed
 


### PR DESCRIPTION
Move the published Gmail OAuth and webserver discovery notes from `Unreleased` into the `0.3.0` release sections and correct the release date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added version 0.3.0 release entries to the Gmail and web server extension changelogs.
  - Updated release dates to August 10, 2026.
  - Documented the existing web server information event response under the appropriate “Added” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->