### PR TITLE
release: publish extension changelog corrections

### DIFF
--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.3.1] - 2026-08-10
+
+### Changed
+
+- Publish the finalized 0.3.0 release notes in the package tarball
+
 ## [0.3.0] - 2026-08-10
 
 ### Fixed

--- a/extensions/pi-gmail/package.json
+++ b/extensions/pi-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-gmail",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Gmail extension for pi — read, search, compose, and send emails via Gmail API",
   "type": "module",
   "keywords": [

--- a/extensions/pi-webserver/CHANGELOG.md
+++ b/extensions/pi-webserver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.3.1] - 2026-08-10
+
+### Changed
+
+- Publish the finalized 0.3.0 release notes in the package tarball
+
 ## [0.3.0] - 2026-08-10
 
 ### Added

--- a/extensions/pi-webserver/package.json
+++ b/extensions/pi-webserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e9n/pi-webserver",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Shared HTTP server for pi — authenticated web host with extension mount points",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Bump `@e9n/pi-gmail` and `@e9n/pi-webserver` to 0.3.1 so the corrected 0.3.0 changelogs are included in the npm tarballs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Gmail and Web Server extensions have been updated to version 0.3.1.
  * Finalized release notes for version 0.3.0 are now included with the published package materials.

* **Documentation**
  * Added changelog entries documenting the 0.3.1 release and included release-note updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->