### PR TITLE
docs(pi-a2a): mark extension discontinued

### DIFF
--- a/extensions/pi-a2a/CHANGELOG.md
+++ b/extensions/pi-a2a/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Deprecated
+- Mark `pi-a2a` as discontinued; it will no longer receive fixes or releases
+
 ### Added
 - Dual-mode peer authentication negotiation for legacy API keys, OAuth 2.0 client credentials, and capability-gated OAuth+mTLS
 - Fail-closed modern-only skill policy, Agent Card auth capability publication, and redacted structured authentication logs

--- a/extensions/pi-a2a/README.md
+++ b/extensions/pi-a2a/README.md
@@ -1,5 +1,7 @@
 # pi-a2a
 
+> **Discontinued:** This extension is no longer maintained and will not receive future fixes or releases.
+
 A2A (Agent-to-Agent) protocol v0.3.0 extension for [Pi](https://github.com/mariozechner/pi-coding-agent). Makes your Pi agent discoverable and callable by other A2A-compliant agents.
 
 ## What It Does


### PR DESCRIPTION
Mark `pi-a2a` as discontinued in its README and changelog. No replacement repository is linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the `pi-a2a` extension as discontinued and no longer maintained.
  * Added an Unreleased changelog entry confirming that no further fixes or releases are planned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->