### PR TITLE
feat(pi-gmail): add read-only send guard

### DIFF
--- a/extensions/pi-gmail/AGENTS.md
+++ b/extensions/pi-gmail/AGENTS.md
@@ -41,6 +41,7 @@ OAuth tokens persisted as `db/gmail-tokens.json` under agent home directory. Sim
     "clientId": "env:GMAIL_CLIENT_ID",        // Google OAuth client ID
     "clientSecret": "env:GMAIL_CLIENT_SECRET", // Google OAuth client secret
     "maxResults": 20,                          // Default max results per query
+    "readOnly": true,                          // Block send and send_draft actions
     "notifications": {
       "enabled": false,                        // Enable email polling
       "query": "is:unread",                    // Gmail query for notifications

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `readOnly` setting to disable `send` and `send_draft` actions while preserving inbox and draft access
+
 ## [0.3.0] - 2026-05-08
 
 ### Changed

--- a/extensions/pi-gmail/README.md
+++ b/extensions/pi-gmail/README.md
@@ -29,7 +29,8 @@ Add to `~/.pi/agent/settings.json`:
 {
   "pi-gmail": {
     "clientId": "your-client-id.apps.googleusercontent.com",
-    "clientSecret": "your-client-secret"
+    "clientSecret": "your-client-secret",
+    "readOnly": true
   }
 }
 ```
@@ -46,6 +47,7 @@ Run `/gmail-auth` in pi to start the OAuth flow — opens a browser for Google s
 |-----|------|---------|-------------|
 | `clientId` | string | — | Google OAuth client ID (required) |
 | `clientSecret` | string | — | Google OAuth client secret (required) |
+| `readOnly` | boolean | `false` | Disable the `send` and `send_draft` actions; composing and reading drafts remains available |
 | `notifications.enabled` | boolean | `false` | Enable background polling for new mail |
 | `notifications.intervalMinutes` | number | `5` | Polling interval in minutes |
 | `notifications.query` | string | `"is:unread"` | Gmail search query for notifications |
@@ -66,8 +68,8 @@ All actions are accessed through a single `gmail` tool with an `action` paramete
 | `list_labels` | List all Gmail labels | — |
 | `compose` | Create a draft email | `to`, `subject`, `body`, `cc`, `bcc` |
 | `reply` | Reply to a thread | `thread_id`, `body`, `reply_all` |
-| `send` | Compose and send immediately | `to`, `subject`, `body` |
-| `send_draft` | Send an existing draft | `draft_id` |
+| `send` | Compose and send immediately (disabled when `readOnly` is `true`) | `to`, `subject`, `body` |
+| `send_draft` | Send an existing draft (disabled when `readOnly` is `true`) | `draft_id` |
 | `list_drafts` | List all drafts | — |
 | `delete_draft` | Delete a draft | `draft_id` |
 | `archive` | Archive messages (remove from inbox) | `id` or `ids` |

--- a/extensions/pi-gmail/index.ts
+++ b/extensions/pi-gmail/index.ts
@@ -14,6 +14,7 @@
  *     "clientId": "your-client-id",
  *     "clientSecret": "your-client-secret",
  *     "maxResults": 20,
+ *     "readOnly": true,
  *     "notifications": {
  *       "enabled": false,
  *       "query": "is:unread",

--- a/extensions/pi-gmail/package.json
+++ b/extensions/pi-gmail/package.json
@@ -35,6 +35,7 @@
     "formatter.ts",
     "index.ts",
     "logger.ts",
+    "policy.ts",
     "tool.ts",
     "types.ts",
     "utils.ts",

--- a/extensions/pi-gmail/policy.test.ts
+++ b/extensions/pi-gmail/policy.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isSendActionBlocked, sendingDisabledMessage } from "./policy.ts";
+
+test("readOnly settings block both email send actions", () => {
+	assert.equal(isSendActionBlocked({ readOnly: true }, "send"), true);
+	assert.equal(isSendActionBlocked({ readOnly: true }, "send_draft"), true);
+	assert.equal(sendingDisabledMessage(), "❌ Sending email is disabled because pi-gmail is in read-only mode.");
+});
+
+test("readOnly settings preserve draft creation and inbox actions", () => {
+	assert.equal(isSendActionBlocked({ readOnly: true }, "compose"), false);
+	assert.equal(isSendActionBlocked({ readOnly: true }, "reply"), false);
+	assert.equal(isSendActionBlocked({ readOnly: true }, "search"), false);
+});
+
+test("sending is allowed unless readOnly is explicitly enabled", () => {
+	assert.equal(isSendActionBlocked({}, "send"), false);
+	assert.equal(isSendActionBlocked({ readOnly: false }, "send_draft"), false);
+});

--- a/extensions/pi-gmail/policy.test.ts
+++ b/extensions/pi-gmail/policy.test.ts
@@ -12,6 +12,7 @@ test("readOnly settings preserve draft creation and inbox actions", () => {
 	assert.equal(isSendActionBlocked({ readOnly: true }, "compose"), false);
 	assert.equal(isSendActionBlocked({ readOnly: true }, "reply"), false);
 	assert.equal(isSendActionBlocked({ readOnly: true }, "search"), false);
+	assert.equal(isSendActionBlocked({ readOnly: true }, "list_inbox"), false);
 });
 
 test("sending is allowed unless readOnly is explicitly enabled", () => {

--- a/extensions/pi-gmail/policy.ts
+++ b/extensions/pi-gmail/policy.ts
@@ -1,0 +1,13 @@
+import type { GmailSettings } from "./types.ts";
+
+const SENDING_ACTIONS = new Set(["send", "send_draft"]);
+
+/** Returns whether an action must be blocked by the configured send policy. */
+export function isSendActionBlocked(settings: GmailSettings, action: string): boolean {
+	return settings.readOnly === true && SENDING_ACTIONS.has(action);
+}
+
+/** User-facing explanation for a send action blocked by read-only mode. */
+export function sendingDisabledMessage(): string {
+	return "❌ Sending email is disabled because pi-gmail is in read-only mode.";
+}

--- a/extensions/pi-gmail/tool.test.ts
+++ b/extensions/pi-gmail/tool.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerGmailTool } from "./tool.ts";
+
+test("readOnly blocks send actions before confirmation or Gmail API access", async () => {
+	let execute: ((...args: any[]) => Promise<any>) | undefined;
+	const pi = {
+		registerTool(tool: { execute: (...args: any[]) => Promise<any> }) {
+			execute = tool.execute;
+		},
+	} as any;
+	registerGmailTool(pi, () => ({ readOnly: true }), {
+		getAgentDir: () => "/unused",
+		isAuthenticated: () => true,
+	});
+	assert.ok(execute);
+
+	for (const action of ["send", "send_draft"]) {
+		const result = await execute!("call", { action }, new AbortController().signal, () => {}, {
+			ui: { confirm: () => { throw new Error("confirmation must not be requested"); } },
+		});
+		assert.equal(result.content[0].text, "❌ Sending email is disabled because pi-gmail is in read-only mode.");
+	}
+});

--- a/extensions/pi-gmail/tool.ts
+++ b/extensions/pi-gmail/tool.ts
@@ -22,6 +22,7 @@ import {
 	formatSize,
 } from "./formatter.ts";
 import { isAuthenticated, getAuthenticatedEmail } from "./auth.ts";
+import { isSendActionBlocked, sendingDisabledMessage } from "./policy.ts";
 import type { GmailSettings, GmailMessage, GmailDraft } from "./types.ts";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -51,9 +52,15 @@ function text(s: string) {
 	return { content: [{ type: "text" as const, text: s }], details: {} };
 }
 
+interface GmailToolDependencies {
+	getAgentDir: () => string;
+	isAuthenticated: (agentDir: string) => boolean;
+}
+
 export function registerGmailTool(
 	pi: ExtensionAPI,
 	getSettings: () => GmailSettings,
+	dependencies: GmailToolDependencies = { getAgentDir, isAuthenticated },
 ): void {
 	pi.registerTool({
 		name: "gmail",
@@ -129,14 +136,18 @@ export function registerGmailTool(
 		}),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const agentDir = getAgentDir();
+			const agentDir = dependencies.getAgentDir();
 			const settings = getSettings();
 
-			if (!isAuthenticated(agentDir)) {
+			if (!dependencies.isAuthenticated(agentDir)) {
 				return text("❌ Not authenticated. Run `/gmail-auth` to connect your Gmail account.");
 			}
 
 			const maxResults = params.max_results ?? settings.maxResults ?? 20;
+
+			if (isSendActionBlocked(settings, params.action)) {
+				return text(sendingDisabledMessage());
+			}
 
 			switch (params.action) {
 				// ── Read operations ─────────────────────────────

--- a/extensions/pi-gmail/types.ts
+++ b/extensions/pi-gmail/types.ts
@@ -115,4 +115,6 @@ export interface GmailSettings {
 	clientId?: string;
 	clientSecret?: string;
 	maxResults?: number;
+	/** Prevent send and send_draft actions while leaving drafts and inbox access available. */
+	readOnly?: boolean;
 }


### PR DESCRIPTION
## Summary
- add a `readOnly` setting that blocks Gmail `send` and `send_draft` actions
- preserve inbox access and draft composition
- cover the policy and tool-level no-confirmation guard with tests

## Enable read-only mode
Add this to `~/.pi/agent/settings.json` (or the project `settings.json`):

```json
{
  "pi-gmail": {
    "clientId": "your-client-id.apps.googleusercontent.com",
    "clientSecret": "your-client-secret",
    "readOnly": true
  }
}
```

`readOnly` defaults to `false`.

> [!IMPORTANT]
> This is a tool-level safety guard, not an API security boundary. An agent with direct filesystem or shell access could use the stored OAuth token to call Gmail directly. Enforce server-side read-only access by authorizing a separate Gmail OAuth token with only the `gmail.readonly` scope; that also prevents drafts, labels, and other mailbox changes.

## Verification
- `npm test`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gmail read-only mode to block sending emails and sending drafts while preserving inbox, compose, and draft access.
  * Read-only mode is enabled by default for safer Gmail interactions.
  * Blocked send actions now display a clear explanation.

* **Documentation**
  * Updated Gmail configuration and changelog documentation with read-only mode details.

* **Tests**
  * Added coverage for blocked and permitted Gmail actions in read-only and standard modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->