### PR TITLE
fix(pi-webserver): include web-info in package

### DIFF
--- a/extensions/pi-webserver/package.json
+++ b/extensions/pi-webserver/package.json
@@ -36,6 +36,7 @@
     "helpers.ts",
     "index.ts",
     "logger.ts",
-    "server.ts"
+    "server.ts",
+    "web-info.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- Include `web-info.ts` in the `@e9n/pi-webserver` package `files` list
- Fixes startup failure from the published package missing a file imported by `index.ts`

Fixes #217

## Testing

- `npm pack --dry-run --json ./extensions/pi-webserver` confirmed `web-info.ts` is included in the package
- `npm test` in `extensions/pi-webserver` passed
- `npm run typecheck` in `extensions/pi-webserver` could not run locally because `tsc` was not installed in the local environment
- Installed the package locally with `pi install /Users/joaomarcelo/Dev/Pessoal/pi/extensions/pi-webserver` and confirmed `pi --help` loads successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Included an additional web information file in the package’s published distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->