### PR TITLE
feat(pi-gmail): add multi-account support and fix profile email resolution (closes #209)

### DIFF
--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -10,6 +10,10 @@
 - `/gmail-auth [account]` and `/gmail-logout [account]` commands for managing individual accounts without disconnecting others
 - `readOnly` setting to disable `send` and `send_draft` actions while preserving inbox and draft access
 
+### Changed
+
+- Email notification polling now dispatches notifications via `channel:send` with `{ route, text, source: "pi-gmail" }` payload to align with pi-channels
+
 ### Fixed
 
 - Authenticated email address detection in `fetchUserEmail` now queries the Gmail `users/me/profile` endpoint (covered by `gmail.readonly`), resolving `unknown` email statuses on new authentications

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -54,3 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Trash operation now handles per-message failures gracefully — reports partial success instead of failing the entire batch
 - Logout form body parsing no longer destroys the request socket on oversized payloads; returns HTTP 413 instead
+
+### Removed
+
+- `resolveEnv()` utility function (no longer needed after removing `env:` pattern support)
+
+## [0.1.0] - 2026-02-17 (7839f93)
+
+### Added
+
+- Initial release.

--- a/extensions/pi-gmail/CHANGELOG.md
+++ b/extensions/pi-gmail/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 ### Added
 
+- Multi-account support: configure multiple accounts under `settings.json` (`accounts` map and `defaultAccount`), connect tokens independently per account (`gmail-tokens-[account].json`), and pass `account` option to the `gmail` tool (closes #209)
+- `/gmail-switch [account]` command to switch active Gmail account or list accounts when run without arguments
+- `/gmail-accounts` command to list all configured and connected accounts with their authentication status
+- `/gmail-auth [account]` and `/gmail-logout [account]` commands for managing individual accounts without disconnecting others
 - `readOnly` setting to disable `send` and `send_draft` actions while preserving inbox and draft access
+
+### Fixed
+
+- Authenticated email address detection in `fetchUserEmail` now queries the Gmail `users/me/profile` endpoint (covered by `gmail.readonly`), resolving `unknown` email statuses on new authentications
+- `loadTokens` reads fresh token state from disk to avoid stale in-memory cached tokens across account switches
 
 ## [0.3.1] - 2026-08-10
 
@@ -45,13 +54,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Trash operation now handles per-message failures gracefully — reports partial success instead of failing the entire batch
 - Logout form body parsing no longer destroys the request socket on oversized payloads; returns HTTP 413 instead
-
-### Removed
-
-- `resolveEnv()` utility function (no longer needed after removing `env:` pattern support)
-
-## [0.1.0] - 2026-02-17 (7839f93)
-
-### Added
-
-- Initial release.

--- a/extensions/pi-gmail/README.md
+++ b/extensions/pi-gmail/README.md
@@ -8,6 +8,7 @@ Full Gmail integration for [pi](https://github.com/mariozechner/pi-coding-agent)
 - **Compose & reply** — create drafts, reply to threads, send immediately
 - **Manage** — archive, trash, label, mark read/unread
 - **Attachments** — download attachments to disk
+- **Multi-account support** — connect multiple Gmail accounts, switch between them on the fly, or specify account per tool call
 - **Notifications** — optional background polling with TUI alerts for new mail
 - **Web UI** — OAuth flow and auth status page via pi-webserver
 
@@ -25,12 +26,33 @@ Full Gmail integration for [pi](https://github.com/mariozechner/pi-coding-agent)
 
 Add to `~/.pi/agent/settings.json`:
 
+#### Single account:
 ```json
 {
   "pi-gmail": {
     "clientId": "your-client-id.apps.googleusercontent.com",
     "clientSecret": "your-client-secret",
-    "readOnly": true
+    "readOnly": false
+  }
+}
+```
+
+#### Multiple accounts:
+```json
+{
+  "pi-gmail": {
+    "defaultAccount": "personal",
+    "accounts": {
+      "personal": {
+        "clientId": "personal-client-id.apps.googleusercontent.com",
+        "clientSecret": "personal-client-secret"
+      },
+      "work": {
+        "clientId": "work-client-id.apps.googleusercontent.com",
+        "clientSecret": "work-client-secret",
+        "readOnly": true
+      }
+    }
   }
 }
 ```
@@ -39,14 +61,16 @@ Set `clientId` and `clientSecret` directly in `settings.json`; `env:VAR_NAME` su
 
 ### 3. Authenticate
 
-Start pi-webserver with `/web`, then run `/gmail-auth`. Pi requests the default browser and also prints a clickable, copyable local authentication URL in the conversation as a fallback. The running webserver handles the OAuth callback and Gmail stores the resulting tokens locally.
+Start pi-webserver with `/web`, then run `/gmail-auth` (or `/gmail-auth <account_name>`). Pi opens the default browser and prints a clickable authentication URL fallback. The webserver handles the OAuth callback and stores account tokens locally in `~/.pi/agent/db/`.
 
 ### Settings
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `clientId` | string | — | Google OAuth client ID (required) |
-| `clientSecret` | string | — | Google OAuth client secret (required) |
+| `clientId` | string | — | Google OAuth client ID (for single account) |
+| `clientSecret` | string | — | Google OAuth client secret (for single account) |
+| `defaultAccount` | string | — | Name of the default account in multi-account setups |
+| `accounts` | object | — | Map of account configurations (`{ [name]: { clientId, clientSecret, readOnly? } }`) |
 | `readOnly` | boolean | `false` | Disable the `send` and `send_draft` actions; composing and reading drafts remains available |
 | `notifications.enabled` | boolean | `false` | Enable background polling for new mail |
 | `notifications.intervalMinutes` | number | `5` | Polling interval in minutes |
@@ -54,45 +78,47 @@ Start pi-webserver with `/web`, then run `/gmail-auth`. Pi requests the default 
 
 ## Tool: `gmail`
 
-All actions are accessed through a single `gmail` tool with an `action` parameter.
+All actions are accessed through a single `gmail` tool with an `action` parameter. In multi-account setups, an optional `account` parameter can target a specific account.
 
 ### Actions
 
 | Action | Description | Key params |
 |--------|-------------|------------|
-| `search` | Search emails with Gmail query syntax | `query`, `max_results` |
-| `read` | Read a single email by ID | `id` |
-| `read_thread` | Read a full conversation thread | `thread_id` |
-| `list_inbox` | List recent inbox messages | `max_results` |
-| `list_unread` | List unread messages | `max_results` |
-| `list_labels` | List all Gmail labels | — |
-| `compose` | Create a draft email | `to`, `subject`, `body`, `cc`, `bcc` |
-| `reply` | Reply to a thread | `thread_id`, `body`, `reply_all` |
-| `send` | Compose and send immediately (disabled when `readOnly` is `true`) | `to`, `subject`, `body` |
-| `send_draft` | Send an existing draft (disabled when `readOnly` is `true`) | `draft_id` |
-| `list_drafts` | List all drafts | — |
-| `delete_draft` | Delete a draft | `draft_id` |
-| `archive` | Archive messages (remove from inbox) | `id` or `ids` |
-| `trash` | Move messages to trash | `id` or `ids` |
-| `label` | Add or remove labels | `id`, `add_labels`, `remove_labels` |
-| `mark_read` | Mark messages as read | `id` or `ids` |
-| `mark_unread` | Mark messages as unread | `id` or `ids` |
-| `download_attachment` | Save an attachment to disk | `id`, `attachment_id`, `save_path` |
+| `search` | Search emails with Gmail query syntax | `query`, `max_results`, `account?` |
+| `read` | Read a single email by ID | `id`, `account?` |
+| `read_thread` | Read a full conversation thread | `thread_id`, `account?` |
+| `list_inbox` | List recent inbox messages | `max_results`, `account?` |
+| `list_unread` | List unread messages | `max_results`, `account?` |
+| `list_labels` | List all Gmail labels | `account?` |
+| `compose` | Create a draft email | `to`, `subject`, `body`, `cc`, `bcc`, `account?` |
+| `reply` | Reply to a thread | `thread_id`, `body`, `reply_all`, `account?` |
+| `send` | Compose and send immediately (disabled when `readOnly` is `true`) | `to`, `subject`, `body`, `account?` |
+| `send_draft` | Send an existing draft (disabled when `readOnly` is `true`) | `draft_id`, `account?` |
+| `list_drafts` | List all drafts | `account?` |
+| `delete_draft` | Delete a draft | `draft_id`, `account?` |
+| `archive` | Archive messages (remove from inbox) | `id` or `ids`, `account?` |
+| `trash` | Move messages to trash | `id` or `ids`, `account?` |
+| `label` | Add or remove labels | `id`, `add_labels`, `remove_labels`, `account?` |
+| `mark_read` | Mark messages as read | `id` or `ids`, `account?` |
+| `mark_unread` | Mark messages as unread | `id` or `ids`, `account?` |
+| `download_attachment` | Save an attachment to disk | `id`, `attachment_id`, `save_path`, `account?` |
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/gmail-auth` | Start OAuth authentication flow |
-| `/gmail-logout` | Disconnect Gmail account |
-| `/gmail-status` | Show current authentication status |
+| `/gmail-auth [account]` | Start OAuth authentication flow for active or named account |
+| `/gmail-switch [account]` | Switch active account, or list configured accounts if no argument is given |
+| `/gmail-accounts` | List all configured and connected Gmail accounts |
+| `/gmail-logout [account]` | Disconnect specified or active Gmail account |
+| `/gmail-status` | Show current authentication status for active account |
 
 ## Web UI
 
 When [pi-webserver](../pi-webserver) is running, the extension mounts:
 
 - `/gmail` — Auth status page with connect/disconnect
-- `/gmail/auth` — OAuth redirect to Google
+- `/gmail/auth` — OAuth redirect to Google (supports `?account=<name>`)
 - `/gmail/callback` — OAuth callback handler
 - `/api/gmail/status` — JSON auth status endpoint
 

--- a/extensions/pi-gmail/README.md
+++ b/extensions/pi-gmail/README.md
@@ -26,7 +26,8 @@ Full Gmail integration for [pi](https://github.com/mariozechner/pi-coding-agent)
 
 Add to `~/.pi/agent/settings.json`:
 
-#### Single account:
+#### Single account
+
 ```json
 {
   "pi-gmail": {
@@ -37,7 +38,8 @@ Add to `~/.pi/agent/settings.json`:
 }
 ```
 
-#### Multiple accounts:
+#### Multiple accounts
+
 ```json
 {
   "pi-gmail": {
@@ -71,10 +73,12 @@ Start pi-webserver with `/web`, then run `/gmail-auth` (or `/gmail-auth <account
 | `clientSecret` | string | — | Google OAuth client secret (for single account) |
 | `defaultAccount` | string | — | Name of the default account in multi-account setups |
 | `accounts` | object | — | Map of account configurations (`{ [name]: { clientId, clientSecret, readOnly? } }`) |
-| `readOnly` | boolean | `false` | Disable the `send` and `send_draft` actions; composing and reading drafts remains available |
+| `maxResults` | number | `20` | Default maximum results returned for message listings and searches |
+| `readOnly` | boolean | `false` | Disable `send` and `send_draft` actions; composing/reading drafts remains available. Overridden per-account by `accounts[name].readOnly` |
 | `notifications.enabled` | boolean | `false` | Enable background polling for new mail |
 | `notifications.intervalMinutes` | number | `5` | Polling interval in minutes |
 | `notifications.query` | string | `"is:unread"` | Gmail search query for notifications |
+| `notifications.channel` | string | `"default"` | Target pi-channels route for notification dispatch |
 
 ## Tool: `gmail`
 
@@ -117,10 +121,10 @@ All actions are accessed through a single `gmail` tool with an `action` paramete
 
 When [pi-webserver](../pi-webserver) is running, the extension mounts:
 
-- `/gmail` — Auth status page with connect/disconnect
+- `/gmail` — Auth status page with connect/disconnect (supports `?account=<name>`)
 - `/gmail/auth` — OAuth redirect to Google (supports `?account=<name>`)
 - `/gmail/callback` — OAuth callback handler
-- `/api/gmail/status` — JSON auth status endpoint
+- `/api/gmail/status` — JSON auth status endpoint (supports `?account=<name>`)
 
 ## Install
 

--- a/extensions/pi-gmail/auth.ts
+++ b/extensions/pi-gmail/auth.ts
@@ -328,25 +328,25 @@ export function listAccounts(
 ): AccountInfo[] {
 	const names = new Set<string>();
 
-	if (settings.accounts) {
+	if (settings.accounts && Object.keys(settings.accounts).length > 0) {
 		for (const name of Object.keys(settings.accounts)) {
 			names.add(name);
 		}
-	}
-
-	const dbDir = path.join(agentDir, "db");
-	if (fs.existsSync(dbDir)) {
-		try {
-			const files = fs.readdirSync(dbDir);
-			for (const file of files) {
-				if (file === "gmail-tokens.json") {
-					names.add("default");
-				} else if (file.startsWith("gmail-tokens-") && file.endsWith(".json")) {
-					const name = file.slice("gmail-tokens-".length, -".json".length);
-					if (name) names.add(name);
+	} else {
+		const dbDir = path.join(agentDir, "db");
+		if (fs.existsSync(dbDir)) {
+			try {
+				const files = fs.readdirSync(dbDir);
+				for (const file of files) {
+					if (file === "gmail-tokens.json") {
+						names.add("default");
+					} else if (file.startsWith("gmail-tokens-") && file.endsWith(".json")) {
+						const name = file.slice("gmail-tokens-".length, -".json".length);
+						if (name) names.add(name);
+					}
 				}
-			}
-		} catch {}
+			} catch {}
+		}
 	}
 
 	if (names.size === 0 && (settings.clientId || isAuthenticated(agentDir))) {

--- a/extensions/pi-gmail/auth.ts
+++ b/extensions/pi-gmail/auth.ts
@@ -50,6 +50,7 @@ interface OAuthStateEntry {
 
 const pendingOAuthStates = new Map<string, OAuthStateEntry>();
 const OAUTH_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_PENDING_OAUTH_STATES = 100;
 
 export function generateOAuthState(accountName?: string): string {
 	validateAccountName(accountName);
@@ -60,6 +61,12 @@ export function generateOAuthState(accountName?: string): string {
 		if (now - val.createdAt > OAUTH_STATE_TTL_MS) {
 			pendingOAuthStates.delete(key);
 		}
+	}
+
+	// Enforce maximum capacity by evicting oldest entry if limit reached
+	if (pendingOAuthStates.size >= MAX_PENDING_OAUTH_STATES) {
+		const oldestKey = pendingOAuthStates.keys().next().value;
+		if (oldestKey) pendingOAuthStates.delete(oldestKey);
 	}
 
 	const state = crypto.randomBytes(32).toString("hex");

--- a/extensions/pi-gmail/auth.ts
+++ b/extensions/pi-gmail/auth.ts
@@ -2,7 +2,8 @@
  * OAuth 2.0 authentication for Gmail API.
  *
  * Handles:
- *   - Token storage in a JSON file (~/.pi/agent/db/gmail-tokens.json)
+ *   - Token storage in JSON files (~/.pi/agent/db/gmail-tokens.json or gmail-tokens-[account].json)
+ *   - Multi-account configuration & dynamic account switching
  *   - OAuth consent URL generation
  *   - Authorization code exchange
  *   - Automatic access token refresh
@@ -11,8 +12,7 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
 import * as crypto from "node:crypto";
-import type { OAuthTokens, GmailSettings } from "./types.ts";
-
+import type { OAuthTokens, GmailSettings, GmailAccountConfig, AccountInfo } from "./types.ts";
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -28,67 +28,104 @@ const SCOPES = [
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const TOKENS_FILENAME = "gmail-tokens.json";
 
-let cachedTokens: OAuthTokens | null = null;
-
 // ── OAuth state for CSRF protection ─────────────────────────────
 
 let pendingOAuthState: string | null = null;
 
-export function generateOAuthState(): string {
-	const state = crypto.randomBytes(32).toString("hex");
-	pendingOAuthState = state;
-	return state;
+export function generateOAuthState(accountName?: string): string {
+	const random = crypto.randomBytes(32).toString("hex");
+	pendingOAuthState = accountName ? `${accountName}:${random}` : random;
+	return pendingOAuthState;
 }
 
-export function verifyOAuthState(state: string | null): boolean {
-	if (!state || !pendingOAuthState) return false;
+export function verifyOAuthState(state: string | null): { valid: boolean; account?: string } {
+	if (!state || !pendingOAuthState) return { valid: false };
 	const stateBuffer = Buffer.from(state);
 	const expectedBuffer = Buffer.from(pendingOAuthState);
 	// timingSafeEqual throws RangeError if lengths differ
 	if (stateBuffer.length !== expectedBuffer.length) {
 		pendingOAuthState = null;
-		return false;
+		return { valid: false };
 	}
 	const valid = crypto.timingSafeEqual(stateBuffer, expectedBuffer);
+	const savedState = pendingOAuthState;
 	pendingOAuthState = null; // consume — single use
-	return valid;
+	if (!valid) return { valid: false };
+
+	const colonIdx = savedState.indexOf(":");
+	if (colonIdx !== -1) {
+		return { valid: true, account: savedState.slice(0, colonIdx) };
+	}
+	return { valid: true };
 }
 
-// ── Token refresh mutex ─────────────────────────────────────────
+// ── Token refresh mutex per account ─────────────────────────────
 
-let refreshPromise: Promise<string> | null = null;
+const refreshPromises = new Map<string, Promise<string>>();
+
+// ── Account config resolution ───────────────────────────────────
+
+export function getAccountConfig(
+	settings: GmailSettings,
+	accountName?: string,
+): GmailAccountConfig {
+	const target = accountName || settings.account || settings.defaultAccount;
+	if (target && settings.accounts?.[target]) {
+		const acc = settings.accounts[target];
+		return {
+			clientId: acc.clientId ?? settings.clientId,
+			clientSecret: acc.clientSecret ?? settings.clientSecret,
+			readOnly: acc.readOnly ?? settings.readOnly,
+		};
+	}
+	return {
+		clientId: settings.clientId,
+		clientSecret: settings.clientSecret,
+		readOnly: settings.readOnly,
+	};
+}
 
 // ── Token file path ─────────────────────────────────────────────
 
-function getTokensPath(agentDir: string): string {
+export function getTokensPath(agentDir: string, accountName?: string): string {
+	const name = accountName?.trim();
+	if (name && name !== "default") {
+		return path.join(agentDir, "db", `gmail-tokens-${name}.json`);
+	}
 	return path.join(agentDir, "db", TOKENS_FILENAME);
 }
 
 // ── Token storage ───────────────────────────────────────────────
 
-export function loadTokens(agentDir: string): OAuthTokens | null {
-	if (cachedTokens) return cachedTokens;
-
-	const tokensPath = getTokensPath(agentDir);
+export function loadTokens(agentDir: string, accountName?: string): OAuthTokens | null {
+	const tokensPath = getTokensPath(agentDir, accountName);
 	try {
 		const data = fs.readFileSync(tokensPath, "utf-8");
-		cachedTokens = JSON.parse(data) as OAuthTokens;
-		return cachedTokens;
+		return JSON.parse(data) as OAuthTokens;
 	} catch {
+		// Fallback to default tokens file if account-specific file is missing and no explicit account specified
+		if (!accountName || accountName === "default") {
+			const fallbackPath = path.join(agentDir, "db", TOKENS_FILENAME);
+			try {
+				const data = fs.readFileSync(fallbackPath, "utf-8");
+				return JSON.parse(data) as OAuthTokens;
+			} catch {
+				return null;
+			}
+		}
 		return null;
 	}
 }
 
-export function saveTokens(agentDir: string, tokens: OAuthTokens): void {
-	const tokensPath = getTokensPath(agentDir);
+export function saveTokens(agentDir: string, tokens: OAuthTokens, accountName?: string): void {
+	const tokensPath = getTokensPath(agentDir, accountName);
 	fs.mkdirSync(path.dirname(tokensPath), { recursive: true });
 	fs.writeFileSync(tokensPath, JSON.stringify(tokens, null, 2), { encoding: "utf-8", mode: 0o600 });
-	cachedTokens = tokens;
 }
 
-export async function clearTokens(agentDir: string): Promise<void> {
+export async function clearTokens(agentDir: string, accountName?: string): Promise<void> {
 	// Revoke refresh token at Google before deleting locally
-	const tokens = loadTokens(agentDir);
+	const tokens = loadTokens(agentDir, accountName);
 	if (tokens?.refresh_token) {
 		try {
 			await fetch(`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(tokens.refresh_token)}`, {
@@ -100,22 +137,26 @@ export async function clearTokens(agentDir: string): Promise<void> {
 		}
 	}
 
-	const tokensPath = getTokensPath(agentDir);
+	const tokensPath = getTokensPath(agentDir, accountName);
 	try {
 		fs.unlinkSync(tokensPath);
 	} catch {
 		// file may not exist
 	}
-	cachedTokens = null;
 }
 
 // ── OAuth flow ──────────────────────────────────────────────────
 
-export function getConsentUrl(settings: GmailSettings, redirectUri: string): string {
-	const clientId = settings.clientId ?? "";
-	if (!clientId) throw new Error("Gmail clientId not configured");
+export function getConsentUrl(
+	settings: GmailSettings,
+	redirectUri: string,
+	accountName?: string,
+): string {
+	const config = getAccountConfig(settings, accountName);
+	const clientId = config.clientId ?? "";
+	if (!clientId) throw new Error(`Gmail clientId not configured${accountName ? ` for account "${accountName}"` : ""}`);
 
-	const state = generateOAuthState();
+	const state = generateOAuthState(accountName);
 
 	const params = new URLSearchParams({
 		client_id: clientId,
@@ -123,7 +164,7 @@ export function getConsentUrl(settings: GmailSettings, redirectUri: string): str
 		response_type: "code",
 		scope: SCOPES,
 		access_type: "offline",
-		prompt: "consent",
+		prompt: "select_account consent",
 		state,
 	});
 
@@ -135,12 +176,14 @@ export async function exchangeCode(
 	code: string,
 	redirectUri: string,
 	agentDir: string,
+	accountName?: string,
 ): Promise<OAuthTokens> {
-	const clientId = settings.clientId ?? "";
-	const clientSecret = settings.clientSecret ?? "";
+	const config = getAccountConfig(settings, accountName);
+	const clientId = config.clientId ?? "";
+	const clientSecret = config.clientSecret ?? "";
 
 	if (!clientId || !clientSecret) {
-		throw new Error("Gmail clientId/clientSecret not configured");
+		throw new Error(`Gmail clientId/clientSecret not configured${accountName ? ` for account "${accountName}"` : ""}`);
 	}
 
 	const resp = await fetch(GOOGLE_TOKEN_URL, {
@@ -160,7 +203,7 @@ export async function exchangeCode(
 		throw new Error(`Token exchange failed: ${resp.status} ${err}`);
 	}
 
-	const data = await resp.json() as any;
+	const data = (await resp.json()) as any;
 
 	// Get user email from the access token
 	const email = await fetchUserEmail(data.access_token);
@@ -173,7 +216,7 @@ export async function exchangeCode(
 		scope: data.scope ?? SCOPES,
 	};
 
-	saveTokens(agentDir, tokens);
+	saveTokens(agentDir, tokens, accountName);
 	return tokens;
 }
 
@@ -182,35 +225,47 @@ export async function exchangeCode(
 export async function getAccessToken(
 	settings: GmailSettings,
 	agentDir: string,
+	accountName?: string,
 ): Promise<string> {
-	const tokens = loadTokens(agentDir);
-	if (!tokens) throw new Error("Not authenticated. Run /gmail-auth to connect.");
+	const accountKey = accountName || settings.account || "default";
+	const tokens = loadTokens(agentDir, accountName || settings.account);
+	if (!tokens) {
+		throw new Error(
+			`Not authenticated${accountName || settings.account ? ` for account "${accountName || settings.account}"` : ""}. Run /gmail-auth to connect.`,
+		);
+	}
 
 	// Check if token is still valid (with buffer)
 	if (Date.now() < tokens.expires_at - REFRESH_BUFFER_MS) {
 		return tokens.access_token;
 	}
 
-	// Use mutex to prevent concurrent refresh races
-	if (refreshPromise) return refreshPromise;
+	// Use mutex per account to prevent concurrent refresh races
+	const existing = refreshPromises.get(accountKey);
+	if (existing) return existing;
 
-	refreshPromise = refreshAccessToken(settings, agentDir, tokens).finally(() => {
-		refreshPromise = null;
+	const promise = refreshAccessToken(settings, agentDir, tokens, accountName || settings.account).finally(() => {
+		refreshPromises.delete(accountKey);
 	});
 
-	return refreshPromise;
+	refreshPromises.set(accountKey, promise);
+	return promise;
 }
 
 async function refreshAccessToken(
 	settings: GmailSettings,
 	agentDir: string,
 	tokens: OAuthTokens,
+	accountName?: string,
 ): Promise<string> {
-	const clientId = settings.clientId ?? "";
-	const clientSecret = settings.clientSecret ?? "";
+	const config = getAccountConfig(settings, accountName);
+	const clientId = config.clientId ?? "";
+	const clientSecret = config.clientSecret ?? "";
 
 	if (!clientId || !clientSecret) {
-		throw new Error("Gmail clientId/clientSecret not configured for token refresh");
+		throw new Error(
+			`Gmail clientId/clientSecret not configured for token refresh${accountName ? ` (account "${accountName}")` : ""}`,
+		);
 	}
 
 	const resp = await fetch(GOOGLE_TOKEN_URL, {
@@ -229,13 +284,15 @@ async function refreshAccessToken(
 		// On 4xx errors (revoked token, invalid grant), clear stale tokens
 		// to break the retry loop and guide the user to re-authenticate
 		if (resp.status >= 400 && resp.status < 500) {
-			await clearTokens(agentDir);
-			throw new Error(`Gmail refresh token revoked or invalid (${resp.status}). Run /gmail-auth to reconnect.`);
+			await clearTokens(agentDir, accountName);
+			throw new Error(
+				`Gmail refresh token revoked or invalid (${resp.status})${accountName ? ` for account "${accountName}"` : ""}. Run /gmail-auth to reconnect.`,
+			);
 		}
 		throw new Error(`Token refresh failed: ${resp.status} ${err}`);
 	}
 
-	const data = await resp.json() as any;
+	const data = (await resp.json()) as any;
 
 	const updated: OAuthTokens = {
 		...tokens,
@@ -248,27 +305,98 @@ async function refreshAccessToken(
 		updated.refresh_token = data.refresh_token;
 	}
 
-	saveTokens(agentDir, updated);
+	saveTokens(agentDir, updated, accountName);
 	return updated.access_token;
 }
 
-export function isAuthenticated(agentDir: string): boolean {
-	const tokens = loadTokens(agentDir);
+export function isAuthenticated(agentDir: string, accountName?: string): boolean {
+	const tokens = loadTokens(agentDir, accountName);
 	return tokens !== null;
 }
 
-export function getAuthenticatedEmail(agentDir: string): string | null {
-	const tokens = loadTokens(agentDir);
+export function getAuthenticatedEmail(agentDir: string, accountName?: string): string | null {
+	const tokens = loadTokens(agentDir, accountName);
 	return tokens?.email ?? null;
+}
+
+// ── Multi-account discovery & listing ───────────────────────────
+
+export function listAccounts(
+	settings: GmailSettings,
+	agentDir: string,
+	activeAccount?: string,
+): AccountInfo[] {
+	const names = new Set<string>();
+
+	if (settings.accounts) {
+		for (const name of Object.keys(settings.accounts)) {
+			names.add(name);
+		}
+	}
+
+	const dbDir = path.join(agentDir, "db");
+	if (fs.existsSync(dbDir)) {
+		try {
+			const files = fs.readdirSync(dbDir);
+			for (const file of files) {
+				if (file === "gmail-tokens.json") {
+					names.add("default");
+				} else if (file.startsWith("gmail-tokens-") && file.endsWith(".json")) {
+					const name = file.slice("gmail-tokens-".length, -".json".length);
+					if (name) names.add(name);
+				}
+			}
+		} catch {}
+	}
+
+	if (names.size === 0 && (settings.clientId || isAuthenticated(agentDir))) {
+		names.add("default");
+	}
+
+	const defaultName = settings.defaultAccount || "default";
+	const currentActive = activeAccount || settings.account || defaultName;
+
+	const list: AccountInfo[] = [];
+	for (const name of names) {
+		const targetName = name === "default" ? undefined : name;
+		const email = getAuthenticatedEmail(agentDir, targetName);
+		const authed = isAuthenticated(agentDir, targetName);
+		list.push({
+			name,
+			email,
+			authenticated: authed,
+			isDefault: name === defaultName,
+			isActive: name === currentActive,
+		});
+	}
+
+	return list.sort((a, b) => (a.name === defaultName ? -1 : b.name === defaultName ? 1 : a.name.localeCompare(b.name)));
 }
 
 // ── Helpers ─────────────────────────────────────────────────────
 
-async function fetchUserEmail(accessToken: string): Promise<string> {
-	const resp = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
-		headers: { Authorization: `Bearer ${accessToken}` },
-	});
-	if (!resp.ok) return "unknown";
-	const data = await resp.json() as any;
-	return data.email ?? "unknown";
+export async function fetchUserEmail(accessToken: string): Promise<string> {
+	// 1. Try Gmail user profile API (covered by gmail.readonly scope)
+	try {
+		const resp = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
+			headers: { Authorization: `Bearer ${accessToken}` },
+		});
+		if (resp.ok) {
+			const data = (await resp.json()) as any;
+			if (data.emailAddress) return data.emailAddress;
+		}
+	} catch {}
+
+	// 2. Try UserInfo endpoint
+	try {
+		const resp = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+			headers: { Authorization: `Bearer ${accessToken}` },
+		});
+		if (resp.ok) {
+			const data = (await resp.json()) as any;
+			if (data.email) return data.email;
+		}
+	} catch {}
+
+	return "unknown";
 }

--- a/extensions/pi-gmail/auth.ts
+++ b/extensions/pi-gmail/auth.ts
@@ -4,7 +4,7 @@
  * Handles:
  *   - Token storage in JSON files (~/.pi/agent/db/gmail-tokens.json or gmail-tokens-[account].json)
  *   - Multi-account configuration & dynamic account switching
- *   - OAuth consent URL generation
+ *   - OAuth consent URL generation with concurrent state isolation
  *   - Authorization code exchange
  *   - Automatic access token refresh
  */
@@ -26,37 +26,60 @@ const SCOPES = [
 
 // Token refresh buffer — refresh 5 minutes before expiry
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
 const TOKENS_FILENAME = "gmail-tokens.json";
+const SAFE_ACCOUNT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-// ── OAuth state for CSRF protection ─────────────────────────────
+// ── Account name validation ─────────────────────────────────────
 
-let pendingOAuthState: string | null = null;
+export function validateAccountName(name?: string): void {
+	if (!name || name === "default") return;
+	if (!SAFE_ACCOUNT_NAME_RE.test(name)) {
+		throw new Error(
+			`Invalid account name "${name}". Account names may only contain letters, numbers, underscores, and hyphens.`,
+		);
+	}
+}
+
+// ── OAuth state for CSRF protection & concurrency ───────────────
+
+interface OAuthStateEntry {
+	account?: string;
+	createdAt: number;
+}
+
+const pendingOAuthStates = new Map<string, OAuthStateEntry>();
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 export function generateOAuthState(accountName?: string): string {
-	const random = crypto.randomBytes(32).toString("hex");
-	pendingOAuthState = accountName ? `${accountName}:${random}` : random;
-	return pendingOAuthState;
+	validateAccountName(accountName);
+
+	// Prune expired states
+	const now = Date.now();
+	for (const [key, val] of pendingOAuthStates) {
+		if (now - val.createdAt > OAUTH_STATE_TTL_MS) {
+			pendingOAuthStates.delete(key);
+		}
+	}
+
+	const state = crypto.randomBytes(32).toString("hex");
+	pendingOAuthStates.set(state, {
+		account: accountName && accountName !== "default" ? accountName : undefined,
+		createdAt: now,
+	});
+	return state;
 }
 
 export function verifyOAuthState(state: string | null): { valid: boolean; account?: string } {
-	if (!state || !pendingOAuthState) return { valid: false };
-	const stateBuffer = Buffer.from(state);
-	const expectedBuffer = Buffer.from(pendingOAuthState);
-	// timingSafeEqual throws RangeError if lengths differ
-	if (stateBuffer.length !== expectedBuffer.length) {
-		pendingOAuthState = null;
+	if (!state) return { valid: false };
+	const entry = pendingOAuthStates.get(state);
+	if (!entry) return { valid: false };
+
+	pendingOAuthStates.delete(state); // single use
+	if (Date.now() - entry.createdAt > OAUTH_STATE_TTL_MS) {
 		return { valid: false };
 	}
-	const valid = crypto.timingSafeEqual(stateBuffer, expectedBuffer);
-	const savedState = pendingOAuthState;
-	pendingOAuthState = null; // consume — single use
-	if (!valid) return { valid: false };
-
-	const colonIdx = savedState.indexOf(":");
-	if (colonIdx !== -1) {
-		return { valid: true, account: savedState.slice(0, colonIdx) };
-	}
-	return { valid: true };
+	return { valid: true, account: entry.account };
 }
 
 // ── Token refresh mutex per account ─────────────────────────────
@@ -70,13 +93,19 @@ export function getAccountConfig(
 	accountName?: string,
 ): GmailAccountConfig {
 	const target = accountName || settings.account || settings.defaultAccount;
-	if (target && settings.accounts?.[target]) {
-		const acc = settings.accounts[target];
-		return {
-			clientId: acc.clientId ?? settings.clientId,
-			clientSecret: acc.clientSecret ?? settings.clientSecret,
-			readOnly: acc.readOnly ?? settings.readOnly,
-		};
+	if (target && target !== "default") {
+		validateAccountName(target);
+		if (settings.accounts && Object.keys(settings.accounts).length > 0) {
+			const acc = settings.accounts[target];
+			if (!acc) {
+				throw new Error(`Account "${target}" is not configured in settings.json`);
+			}
+			return {
+				clientId: acc.clientId ?? settings.clientId,
+				clientSecret: acc.clientSecret ?? settings.clientSecret,
+				readOnly: acc.readOnly ?? settings.readOnly,
+			};
+		}
 	}
 	return {
 		clientId: settings.clientId,
@@ -90,6 +119,7 @@ export function getAccountConfig(
 export function getTokensPath(agentDir: string, accountName?: string): string {
 	const name = accountName?.trim();
 	if (name && name !== "default") {
+		validateAccountName(name);
 		return path.join(agentDir, "db", `gmail-tokens-${name}.json`);
 	}
 	return path.join(agentDir, "db", TOKENS_FILENAME);
@@ -103,16 +133,6 @@ export function loadTokens(agentDir: string, accountName?: string): OAuthTokens 
 		const data = fs.readFileSync(tokensPath, "utf-8");
 		return JSON.parse(data) as OAuthTokens;
 	} catch {
-		// Fallback to default tokens file if account-specific file is missing and no explicit account specified
-		if (!accountName || accountName === "default") {
-			const fallbackPath = path.join(agentDir, "db", TOKENS_FILENAME);
-			try {
-				const data = fs.readFileSync(fallbackPath, "utf-8");
-				return JSON.parse(data) as OAuthTokens;
-			} catch {
-				return null;
-			}
-		}
 		return null;
 	}
 }
@@ -131,6 +151,7 @@ export async function clearTokens(agentDir: string, accountName?: string): Promi
 			await fetch(`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(tokens.refresh_token)}`, {
 				method: "POST",
 				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 			});
 		} catch {
 			// Best-effort — continue with local cleanup
@@ -196,6 +217,7 @@ export async function exchangeCode(
 			redirect_uri: redirectUri,
 			grant_type: "authorization_code",
 		}),
+		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 	});
 
 	if (!resp.ok) {
@@ -277,6 +299,7 @@ async function refreshAccessToken(
 			refresh_token: tokens.refresh_token,
 			grant_type: "refresh_token",
 		}),
+		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 	});
 
 	if (!resp.ok) {
@@ -328,32 +351,34 @@ export function listAccounts(
 ): AccountInfo[] {
 	const names = new Set<string>();
 
-	if (settings.accounts && Object.keys(settings.accounts).length > 0) {
+	if (settings.accounts) {
 		for (const name of Object.keys(settings.accounts)) {
 			names.add(name);
 		}
-	} else {
-		const dbDir = path.join(agentDir, "db");
-		if (fs.existsSync(dbDir)) {
-			try {
-				const files = fs.readdirSync(dbDir);
-				for (const file of files) {
-					if (file === "gmail-tokens.json") {
+	}
+
+	const dbDir = path.join(agentDir, "db");
+	if (fs.existsSync(dbDir)) {
+		try {
+			const files = fs.readdirSync(dbDir);
+			for (const file of files) {
+				if (file === "gmail-tokens.json") {
+					if (!settings.accounts || Object.keys(settings.accounts).length === 0) {
 						names.add("default");
-					} else if (file.startsWith("gmail-tokens-") && file.endsWith(".json")) {
-						const name = file.slice("gmail-tokens-".length, -".json".length);
-						if (name) names.add(name);
 					}
+				} else if (file.startsWith("gmail-tokens-") && file.endsWith(".json")) {
+					const name = file.slice("gmail-tokens-".length, -".json".length);
+					if (name) names.add(name);
 				}
-			} catch {}
-		}
+			}
+		} catch {}
 	}
 
 	if (names.size === 0 && (settings.clientId || isAuthenticated(agentDir))) {
 		names.add("default");
 	}
 
-	const defaultName = settings.defaultAccount || "default";
+	const defaultName = settings.defaultAccount || (names.has("default") ? "default" : names.values().next().value || "default");
 	const currentActive = activeAccount || settings.account || defaultName;
 
 	const list: AccountInfo[] = [];
@@ -380,6 +405,7 @@ export async function fetchUserEmail(accessToken: string): Promise<string> {
 	try {
 		const resp = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
 			headers: { Authorization: `Bearer ${accessToken}` },
+			signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 		});
 		if (resp.ok) {
 			const data = (await resp.json()) as any;
@@ -391,6 +417,7 @@ export async function fetchUserEmail(accessToken: string): Promise<string> {
 	try {
 		const resp = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
 			headers: { Authorization: `Bearer ${accessToken}` },
+			signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
 		});
 		if (resp.ok) {
 			const data = (await resp.json()) as any;

--- a/extensions/pi-gmail/index.ts
+++ b/extensions/pi-gmail/index.ts
@@ -3,16 +3,24 @@
  *
  * Provides:
  *   - `gmail` tool — search, read, compose, reply, send, archive, trash, label, etc.
- *   - /gmail web page — OAuth status and auth flow
+ *   - /gmail web page — OAuth status and auth flow (with multi-account support)
  *   - /api/gmail — Status endpoint
  *   - /gmail-auth command — Start OAuth flow from CLI
- *   - /gmail-logout command — Disconnect Gmail
+ *   - /gmail-switch command — Switch active Gmail account or list accounts
+ *   - /gmail-accounts command — List all configured Gmail accounts
+ *   - /gmail-logout command — Disconnect Gmail account
+ *   - /gmail-status command — Show current Gmail status
  *   - Email notification forwarding via pi-channels
  *
  * Settings (in settings.json):
  *   "pi-gmail": {
  *     "clientId": "your-client-id",
  *     "clientSecret": "your-client-secret",
+ *     "defaultAccount": "personal",
+ *     "accounts": {
+ *       "personal": { "clientId": "...", "clientSecret": "..." },
+ *       "work": { "clientId": "...", "clientSecret": "..." }
+ *     },
  *     "maxResults": 20,
  *     "readOnly": true,
  *     "notifications": {
@@ -33,8 +41,10 @@ import {
 	isAuthenticated,
 	getAuthenticatedEmail,
 	clearTokens,
+	listAccounts,
+	getAccountConfig,
 } from "./auth.ts";
-import type { GmailSettings } from "./types.ts";
+import type { GmailSettings, AccountInfo } from "./types.ts";
 import * as client from "./client.ts";
 import { formatSearchResult } from "./formatter.ts";
 import { openUrl } from "./utils.ts";
@@ -62,12 +72,61 @@ function getSettings(cwd: string): FullGmailSettings {
 	return {
 		...globalSettings,
 		...projectSettings,
+		accounts: {
+			...globalSettings?.accounts,
+			...projectSettings?.accounts,
+		},
 		// Deep merge nested notifications so project keys don't clobber global defaults
 		notifications: {
 			...globalSettings?.notifications,
 			...projectSettings?.notifications,
 		},
 	};
+}
+
+// ── UI Status helpers ───────────────────────────────────────────
+
+function updateStatus(
+	ctx: any,
+	agentDir: string,
+	settings: GmailSettings,
+	log?: ReturnType<typeof createLogger>,
+): void {
+	const activeName = settings.account || settings.defaultAccount;
+	const target = activeName === "default" ? undefined : activeName;
+	const config = getAccountConfig(settings, target);
+
+	if (!config.clientId) {
+		log?.("init", { status: "no clientId configured", account: activeName }, "WARN");
+		ctx?.ui?.setStatus("gmail", "Gmail: not configured");
+		return;
+	}
+
+	if (isAuthenticated(agentDir, target)) {
+		const email = getAuthenticatedEmail(agentDir, target);
+		const label = target ? `Gmail: ${email} (${target})` : `Gmail: ${email}`;
+		ctx?.ui?.setStatus("gmail", label);
+		log?.("auth", { status: "authenticated", email, account: target });
+	} else {
+		const label = target ? `Gmail: not connected (${target})` : "Gmail: not connected";
+		ctx?.ui?.setStatus("gmail", label);
+		log?.("auth", { status: "not authenticated", account: target });
+	}
+}
+
+function formatAccountsList(accounts: AccountInfo[]): string {
+	if (accounts.length === 0) {
+		return "No Gmail accounts configured or connected.";
+	}
+	const lines = ["**Gmail Accounts:**\n"];
+	for (const acc of accounts) {
+		const activeMark = acc.isActive ? "👉 **[active]**" : "  ";
+		const defaultMark = acc.isDefault ? " *(default)*" : "";
+		const status = acc.authenticated ? `✅ ${acc.email || "connected"}` : "❌ not connected";
+		lines.push(`${activeMark} \`${acc.name}\`${defaultMark} — ${status}`);
+	}
+	lines.push("\nSwitch account with `/gmail-switch <name>` or connect with `/gmail-auth [name]`.");
+	return lines.join("\n");
 }
 
 // ── Notification polling ────────────────────────────────────────
@@ -107,7 +166,7 @@ function startNotifications(
 	const channel = notif.channel ?? "default";
 	const generation = ++pollGeneration;
 
-	log("notifications", { status: "starting", intervalMs, query, channel });
+	log("notifications", { status: "starting", intervalMs, query, channel, account: settings.account });
 
 	// Self-scheduling setTimeout pattern to avoid overlapping polls
 	async function poll() {
@@ -115,37 +174,44 @@ function startNotifications(
 		if (notificationTimer === null || generation !== pollGeneration) return;
 
 		try {
-			if (!isAuthenticated(agentDir)) return;
+			const target = settings.account === "default" ? undefined : settings.account;
+			if (!isAuthenticated(agentDir, target)) return;
 
 			// Search for new messages since last check (epoch seconds for precise filtering)
-			const afterEpoch = Math.floor(lastCheckTimestamp / 1000);
-			const fullQuery = `${query} after:${afterEpoch}`;
-
-			const list = await client.listMessages(settings, agentDir, fullQuery, 10);
-			if (list.messages && list.messages.length > 0) {
-				// Filter out already-notified messages
-				const newMessages = list.messages.filter((m) => !notifiedMessageIds.has(m.id));
-				if (newMessages.length > 0) {
-					const messages = await Promise.all(
-						newMessages.slice(0, 5).map((m) =>
-							client.getMessage(settings, agentDir, m.id, "metadata"),
-						),
-					);
-
-					const summary = messages.map((m, i) => formatSearchResult(m, i)).join("\n\n");
-					const text = `📧 **New Gmail messages (${newMessages.length}):**\n\n${summary}`;
-
-					pi.events.emit("channel:send", {
-						channel,
-						text, source: "pi-gmail",
-					});
-
-					// Mark all fetched messages as seen (not just the displayed ones)
-					for (const m of newMessages) trackNotified(m.id);
-				}
-			}
-
+			const sinceSec = Math.floor(lastCheckTimestamp / 1000);
+			const fullQuery = `${query} after:${sinceSec}`;
 			lastCheckTimestamp = Date.now();
+
+			const list = await client.listMessages(settings, agentDir, fullQuery, 5);
+			const messageIds = list.messages?.map((m) => m.id) ?? [];
+
+			// Filter out already-notified messages
+			const newIds = messageIds.filter((id) => !notifiedMessageIds.has(id));
+
+			if (newIds.length > 0) {
+				for (const id of newIds) trackNotified(id);
+
+				log("notifications", { newMessages: newIds.length });
+
+				// Fetch snippets for notification text
+				const messages = await Promise.all(
+					newIds.slice(0, 3).map((id) => client.getMessage(settings, agentDir, id, "metadata")),
+				);
+
+				const summary = messages.map((m, i) => formatSearchResult(m, i + 1)).join("\n");
+				const countText =
+					newIds.length === 1
+						? "1 new email"
+						: `${newIds.length} new emails`;
+
+				// Forward notification via pi-channels
+				pi.events.emit("channel:notify", {
+					channel,
+					title: `Gmail: ${countText}`,
+					body: summary,
+					data: { source: "pi-gmail", count: newIds.length, messageIds: newIds },
+				});
+			}
 		} catch (err: any) {
 			log("notification-error", { error: err.message }, "ERROR");
 		}
@@ -186,25 +252,16 @@ export default function (pi: ExtensionAPI) {
 		const agentDir = getAgentDir();
 		cachedSettings = getSettings(ctx.cwd);
 
-		const clientId = cachedSettings.clientId ?? "";
-		if (!clientId) {
-			log("init", { status: "no clientId configured" }, "WARN");
-			ctx.ui.setStatus("gmail", "Gmail: not configured");
-			return;
+		if (!cachedSettings.account) {
+			cachedSettings.account = cachedSettings.defaultAccount;
 		}
 
-		log("init", { status: "ready" });
+		updateStatus(ctx, agentDir, cachedSettings, log);
 
-		if (isAuthenticated(agentDir)) {
-			const email = getAuthenticatedEmail(agentDir);
-			ctx.ui.setStatus("gmail", `Gmail: ${email}`);
-			log("auth", { status: "authenticated", email });
-
+		const target = cachedSettings.account === "default" ? undefined : cachedSettings.account;
+		if (isAuthenticated(agentDir, target)) {
 			// Start notification polling if configured
 			startNotifications(pi, cachedSettings, agentDir, log);
-		} else {
-			ctx.ui.setStatus("gmail", "Gmail: not connected");
-			log("auth", { status: "not authenticated" });
 		}
 
 		// Mount web routes
@@ -230,14 +287,17 @@ export default function (pi: ExtensionAPI) {
 	// ── Commands ────────────────────────────────────────────────
 
 	pi.registerCommand("gmail-auth", {
-		description: "Connect your Gmail account via OAuth",
-		handler: async (_args: string | undefined, ctx: any) => {
+		description: "Connect a Gmail account via OAuth (usage: /gmail-auth [account_name])",
+		handler: async (args: string | undefined, ctx: any) => {
 			const settings = getSettings(ctx.cwd);
-			const clientId = settings.clientId ?? "";
+			const requestedAccount = args?.trim() || settings.account || settings.defaultAccount;
+			const target = requestedAccount === "default" ? undefined : requestedAccount;
+			const config = getAccountConfig(settings, target);
 
-			if (!clientId) {
+			if (!config.clientId) {
+				const accInfo = target ? ` for account "${target}"` : "";
 				ctx.ui.notify(
-					'Gmail not configured. Add clientId and clientSecret to the "pi-gmail" section of settings.json.',
+					`Gmail not configured${accInfo}. Add clientId and clientSecret to the "pi-gmail" section of settings.json.`,
 					"error",
 				);
 				return;
@@ -255,12 +315,11 @@ export default function (pi: ExtensionAPI) {
 			});
 
 			if (discovery.info !== null && updateGmailWebInfo(discovery.info)) {
-				// Routes may have mounted before a manually started webserver. The updater
-				// refreshes the OAuth redirect origin before the browser requests this URL.
-				const url = new URL("/gmail/auth", discovery.info.url).toString();
+				const authPath = target ? `/gmail/auth?account=${encodeURIComponent(target)}` : "/gmail/auth";
+				const url = new URL(authPath, discovery.info.url).toString();
 				pi.sendMessage({
 					customType: "gmail_auth",
-					content: `Opening Gmail authentication in your browser. If it does not appear, open this link:\n${url}`,
+					content: `Opening Gmail authentication in your browser${target ? ` for account "${target}"` : ""}. If it does not appear, open this link:\n${url}`,
 					display: true,
 					details: { type: "info" },
 				});
@@ -275,28 +334,85 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("gmail-logout", {
-		description: "Disconnect Gmail account",
+	pi.registerCommand("gmail-switch", {
+		description: "Switch active Gmail account or list accounts (usage: /gmail-switch [account_name])",
+		handler: async (args: string | undefined, ctx: any) => {
+			const agentDir = getAgentDir();
+			const settings = cachedSettings ?? getSettings(ctx.cwd);
+			const target = args?.trim();
+
+			if (!target) {
+				const accounts = listAccounts(settings, agentDir, settings.account);
+				const formatted = formatAccountsList(accounts);
+				pi.sendMessage({
+					customType: "gmail_accounts",
+					content: formatted,
+					display: true,
+					details: { type: "info" },
+				});
+				ctx.ui.notify(formatted, "info");
+				return;
+			}
+
+			// Update active account in cachedSettings
+			settings.account = target === "default" ? undefined : target;
+			cachedSettings = settings;
+
+			updateStatus(ctx, agentDir, settings, log);
+
+			stopNotifications();
+			if (isAuthenticated(agentDir, settings.account)) {
+				startNotifications(pi, settings, agentDir, log);
+				const email = getAuthenticatedEmail(agentDir, settings.account);
+				ctx.ui.notify(`✅ Switched to Gmail account "${target}" (${email}).`, "info");
+			} else {
+				ctx.ui.notify(`Switched to Gmail account "${target}" (not connected). Run \`/gmail-auth ${target}\` to connect.`, "info");
+			}
+		},
+	});
+
+	pi.registerCommand("gmail-accounts", {
+		description: "List all configured and connected Gmail accounts",
 		handler: async (_args: string | undefined, ctx: any) => {
 			const agentDir = getAgentDir();
-			const email = getAuthenticatedEmail(agentDir);
+			const settings = cachedSettings ?? getSettings(ctx.cwd);
+			const accounts = listAccounts(settings, agentDir, settings.account);
+			const formatted = formatAccountsList(accounts);
+			pi.sendMessage({
+				customType: "gmail_accounts",
+				content: formatted,
+				display: true,
+				details: { type: "info" },
+			});
+			ctx.ui.notify(formatted, "info");
+		},
+	});
 
-			if (!email) {
-				ctx.ui.notify("Gmail is not connected.", "info");
+	pi.registerCommand("gmail-logout", {
+		description: "Disconnect Gmail account (usage: /gmail-logout [account_name])",
+		handler: async (args: string | undefined, ctx: any) => {
+			const agentDir = getAgentDir();
+			const settings = cachedSettings ?? getSettings(ctx.cwd);
+			const requestedAccount = args?.trim() || settings.account;
+			const target = requestedAccount === "default" ? undefined : requestedAccount;
+			const email = getAuthenticatedEmail(agentDir, target);
+
+			if (!email && !isAuthenticated(agentDir, target)) {
+				ctx.ui.notify(`Gmail account "${requestedAccount || "default"}" is not connected.`, "info");
 				return;
 			}
 
 			const confirmed = await ctx.ui.confirm(
 				"Disconnect Gmail?",
-				`This will remove the stored tokens for ${email}.`,
+				`This will remove the stored tokens for ${email || requestedAccount || "default"}.`,
 			);
 
 			if (!confirmed) return;
 
-			await clearTokens(agentDir);
+			await clearTokens(agentDir, target);
 			stopNotifications();
-			ctx.ui.setStatus("gmail", "Gmail: not connected");
-			ctx.ui.notify(`Gmail disconnected (${email}).`, "info");
+			updateStatus(ctx, agentDir, settings, log);
+			ctx.ui.notify(`Gmail disconnected (${email || requestedAccount || "default"}).`, "info");
 		},
 	});
 
@@ -304,27 +420,45 @@ export default function (pi: ExtensionAPI) {
 		description: "Show Gmail connection status",
 		handler: async (_args: string | undefined, ctx: any) => {
 			const agentDir = getAgentDir();
-			if (isAuthenticated(agentDir)) {
-				const email = getAuthenticatedEmail(agentDir);
-				ctx.ui.notify(`✅ Gmail connected as ${email}`, "info");
+			const settings = cachedSettings ?? getSettings(ctx.cwd);
+			const target = settings.account === "default" ? undefined : settings.account;
+
+			if (isAuthenticated(agentDir, target)) {
+				const email = getAuthenticatedEmail(agentDir, target);
+				const accLabel = target ? ` [account: ${target}]` : "";
+				ctx.ui.notify(`✅ Gmail connected as ${email}${accLabel}`, "info");
 			} else {
-				ctx.ui.notify("⚠️ Gmail not connected. Run /gmail-auth to connect.", "info");
+				const accLabel = target ? ` for account "${target}"` : "";
+				ctx.ui.notify(`⚠️ Gmail not connected${accLabel}. Run /gmail-auth to connect.`, "info");
 			}
 		},
 	});
 
-	// Event bus listener for web/mobile slash command support
-	// Note: /gmail-auth and /gmail-logout need ctx.ui.confirm() — skipped
+	// Event bus listeners for web/mobile slash command support
 	pi.events.on("command:gmail-status", async (data: unknown) => {
 		const { source } = data as { args: string; source?: string };
 		const agentDir = getAgentDir();
-		if (isAuthenticated(agentDir)) {
-			const email = getAuthenticatedEmail(agentDir);
-			pi.sendMessage({ customType: "command_result", content: `✅ Gmail connected as ${email}`, display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "gmail-status", message: `✅ Gmail connected as ${email}`, type: "info", source: source ?? "" });
+		const settings = cachedSettings ?? getSettings(process.cwd());
+		const target = settings.account === "default" ? undefined : settings.account;
+		if (isAuthenticated(agentDir, target)) {
+			const email = getAuthenticatedEmail(agentDir, target);
+			const msg = `✅ Gmail connected as ${email}${target ? ` [account: ${target}]` : ""}`;
+			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type: "info" } });
+			pi.events.emit("command_result", { command: "gmail-status", message: msg, type: "info", source: source ?? "" });
 		} else {
-			pi.sendMessage({ customType: "command_result", content: "⚠️ Gmail not connected. Run /gmail-auth to connect.", display: true, details: { type: "info" } });
-			pi.events.emit("command_result", { command: "gmail-status", message: "⚠️ Gmail not connected. Run /gmail-auth to connect.", type: "info", source: source ?? "" });
+			const msg = `⚠️ Gmail not connected${target ? ` for account "${target}"` : ""}. Run /gmail-auth to connect.`;
+			pi.sendMessage({ customType: "command_result", content: msg, display: true, details: { type: "info" } });
+			pi.events.emit("command_result", { command: "gmail-status", message: msg, type: "info", source: source ?? "" });
 		}
+	});
+
+	pi.events.on("command:gmail-accounts", async (data: unknown) => {
+		const { source } = data as { args: string; source?: string };
+		const agentDir = getAgentDir();
+		const settings = cachedSettings ?? getSettings(process.cwd());
+		const accounts = listAccounts(settings, agentDir, settings.account);
+		const formatted = formatAccountsList(accounts);
+		pi.sendMessage({ customType: "command_result", content: formatted, display: true, details: { type: "info" } });
+		pi.events.emit("command_result", { command: "gmail-accounts", message: formatted, type: "info", source: source ?? "" });
 	});
 }

--- a/extensions/pi-gmail/index.ts
+++ b/extensions/pi-gmail/index.ts
@@ -205,14 +205,14 @@ function startNotifications(
 			const newIds = messageIds.filter((id) => !notifiedMessageIds.has(id));
 
 			if (newIds.length > 0) {
-				for (const id of newIds) trackNotified(id);
-
 				log("notifications", { newMessages: newIds.length });
 
 				// Fetch snippets for notification text
 				const messages = await Promise.all(
 					newIds.slice(0, 3).map((id) => client.getMessage(settings, agentDir, id, "metadata")),
 				);
+
+				for (const id of newIds) trackNotified(id);
 
 				const summary = messages.map((m, i) => formatSearchResult(m, i + 1)).join("\n");
 				const countText =
@@ -386,6 +386,16 @@ export default function (pi: ExtensionAPI) {
 					validateAccountName(target);
 				} catch (err: any) {
 					ctx.ui.notify(err.message, "error");
+					return;
+				}
+
+				if (
+					settings.accounts &&
+					Object.keys(settings.accounts).length > 0 &&
+					!settings.accounts[target] &&
+					!isAuthenticated(agentDir, target)
+				) {
+					ctx.ui.notify(`Account "${target}" is not configured in settings.json.`, "error");
 					return;
 				}
 			}

--- a/extensions/pi-gmail/index.ts
+++ b/extensions/pi-gmail/index.ts
@@ -19,7 +19,7 @@
  *     "defaultAccount": "personal",
  *     "accounts": {
  *       "personal": { "clientId": "...", "clientSecret": "..." },
- *       "work": { "clientId": "...", "clientSecret": "..." }
+ *       "work": { "clientId": "...", "clientSecret": "...", "readOnly": true }
  *     },
  *     "maxResults": 20,
  *     "readOnly": true,
@@ -43,11 +43,19 @@ import {
 	clearTokens,
 	listAccounts,
 	getAccountConfig,
+	validateAccountName,
 } from "./auth.ts";
-import type { GmailSettings, AccountInfo } from "./types.ts";
+import type { GmailSettings, GmailAccountConfig, AccountInfo } from "./types.ts";
 import * as client from "./client.ts";
 import { formatSearchResult } from "./formatter.ts";
 import { openUrl } from "./utils.ts";
+
+// ── Shared helpers ──────────────────────────────────────────────
+
+export function resolveAccountTarget(name?: string): string | undefined {
+	if (!name || name === "default") return undefined;
+	return name.trim();
+}
 
 // ── Settings ────────────────────────────────────────────────────
 
@@ -69,13 +77,22 @@ function getSettings(cwd: string): FullGmailSettings {
 	const project = sm.getProjectSettings() as Record<string, any>;
 	const globalSettings = global?.["pi-gmail"] ?? {};
 	const projectSettings = project?.["pi-gmail"] ?? {};
+
+	// Deep merge per-account configurations
+	const globalAccounts: Record<string, GmailAccountConfig> = globalSettings?.accounts ?? {};
+	const projectAccounts: Record<string, GmailAccountConfig> = projectSettings?.accounts ?? {};
+	const mergedAccounts: Record<string, GmailAccountConfig> = {};
+	for (const name of new Set([...Object.keys(globalAccounts), ...Object.keys(projectAccounts)])) {
+		mergedAccounts[name] = {
+			...globalAccounts[name],
+			...projectAccounts[name],
+		};
+	}
+
 	return {
 		...globalSettings,
 		...projectSettings,
-		accounts: {
-			...globalSettings?.accounts,
-			...projectSettings?.accounts,
-		},
+		accounts: mergedAccounts,
 		// Deep merge nested notifications so project keys don't clobber global defaults
 		notifications: {
 			...globalSettings?.notifications,
@@ -93,7 +110,7 @@ function updateStatus(
 	log?: ReturnType<typeof createLogger>,
 ): void {
 	const activeName = settings.account || settings.defaultAccount;
-	const target = activeName === "default" ? undefined : activeName;
+	const target = resolveAccountTarget(activeName);
 	const config = getAccountConfig(settings, target);
 
 	if (!config.clientId) {
@@ -174,15 +191,14 @@ function startNotifications(
 		if (notificationTimer === null || generation !== pollGeneration) return;
 
 		try {
-			const target = settings.account === "default" ? undefined : settings.account;
+			const target = resolveAccountTarget(settings.account);
 			if (!isAuthenticated(agentDir, target)) return;
 
-			// Search for new messages since last check (epoch seconds for precise filtering)
+			const pollTimestamp = Date.now();
 			const sinceSec = Math.floor(lastCheckTimestamp / 1000);
 			const fullQuery = `${query} after:${sinceSec}`;
-			lastCheckTimestamp = Date.now();
 
-			const list = await client.listMessages(settings, agentDir, fullQuery, 5);
+			const list = await client.listMessages(settings, agentDir, fullQuery, 20);
 			const messageIds = list.messages?.map((m) => m.id) ?? [];
 
 			// Filter out already-notified messages
@@ -204,14 +220,16 @@ function startNotifications(
 						? "1 new email"
 						: `${newIds.length} new emails`;
 
-				// Forward notification via pi-channels
-				pi.events.emit("channel:notify", {
-					channel,
-					title: `Gmail: ${countText}`,
-					body: summary,
-					data: { source: "pi-gmail", count: newIds.length, messageIds: newIds },
+				// Forward notification via pi-channels using channel:send event
+				pi.events.emit("channel:send", {
+					route: channel,
+					text: `Gmail (${resolveAccountTarget(settings.account) || "default"}): ${countText}\n\n${summary}`,
+					source: "pi-gmail",
 				});
 			}
+
+			// Advance timestamp only after successful fetch/processing
+			lastCheckTimestamp = pollTimestamp;
 		} catch (err: any) {
 			log("notification-error", { error: err.message }, "ERROR");
 		}
@@ -258,7 +276,7 @@ export default function (pi: ExtensionAPI) {
 
 		updateStatus(ctx, agentDir, cachedSettings, log);
 
-		const target = cachedSettings.account === "default" ? undefined : cachedSettings.account;
+		const target = resolveAccountTarget(cachedSettings.account);
 		if (isAuthenticated(agentDir, target)) {
 			// Start notification polling if configured
 			startNotifications(pi, cachedSettings, agentDir, log);
@@ -291,7 +309,17 @@ export default function (pi: ExtensionAPI) {
 		handler: async (args: string | undefined, ctx: any) => {
 			const settings = getSettings(ctx.cwd);
 			const requestedAccount = args?.trim() || settings.account || settings.defaultAccount;
-			const target = requestedAccount === "default" ? undefined : requestedAccount;
+			const target = resolveAccountTarget(requestedAccount);
+
+			if (target) {
+				try {
+					validateAccountName(target);
+				} catch (err: any) {
+					ctx.ui.notify(err.message, "error");
+					return;
+				}
+			}
+
 			const config = getAccountConfig(settings, target);
 
 			if (!config.clientId) {
@@ -350,20 +378,29 @@ export default function (pi: ExtensionAPI) {
 					display: true,
 					details: { type: "info" },
 				});
-				ctx.ui.notify(formatted, "info");
 				return;
 			}
 
-			// Update active account in cachedSettings
-			settings.account = target === "default" ? undefined : target;
+			if (target !== "default") {
+				try {
+					validateAccountName(target);
+				} catch (err: any) {
+					ctx.ui.notify(err.message, "error");
+					return;
+				}
+			}
+
+			// Update active account in cachedSettings (preserving the target name)
+			settings.account = target;
 			cachedSettings = settings;
 
 			updateStatus(ctx, agentDir, settings, log);
 
+			const resolvedTarget = resolveAccountTarget(target);
 			stopNotifications();
-			if (isAuthenticated(agentDir, settings.account)) {
+			if (isAuthenticated(agentDir, resolvedTarget)) {
 				startNotifications(pi, settings, agentDir, log);
-				const email = getAuthenticatedEmail(agentDir, settings.account);
+				const email = getAuthenticatedEmail(agentDir, resolvedTarget);
 				ctx.ui.notify(`✅ Switched to Gmail account "${target}" (${email}).`, "info");
 			} else {
 				ctx.ui.notify(`Switched to Gmail account "${target}" (not connected). Run \`/gmail-auth ${target}\` to connect.`, "info");
@@ -373,9 +410,9 @@ export default function (pi: ExtensionAPI) {
 
 	pi.registerCommand("gmail-accounts", {
 		description: "List all configured and connected Gmail accounts",
-		handler: async (_args: string | undefined, ctx: any) => {
+		handler: async (_args: string | undefined, _ctx: any) => {
 			const agentDir = getAgentDir();
-			const settings = cachedSettings ?? getSettings(ctx.cwd);
+			const settings = cachedSettings ?? getSettings(process.cwd());
 			const accounts = listAccounts(settings, agentDir, settings.account);
 			const formatted = formatAccountsList(accounts);
 			pi.sendMessage({
@@ -384,7 +421,6 @@ export default function (pi: ExtensionAPI) {
 				display: true,
 				details: { type: "info" },
 			});
-			ctx.ui.notify(formatted, "info");
 		},
 	});
 
@@ -393,8 +429,8 @@ export default function (pi: ExtensionAPI) {
 		handler: async (args: string | undefined, ctx: any) => {
 			const agentDir = getAgentDir();
 			const settings = cachedSettings ?? getSettings(ctx.cwd);
-			const requestedAccount = args?.trim() || settings.account;
-			const target = requestedAccount === "default" ? undefined : requestedAccount;
+			const requestedAccount = args?.trim() || settings.account || settings.defaultAccount;
+			const target = resolveAccountTarget(requestedAccount);
 			const email = getAuthenticatedEmail(agentDir, target);
 
 			if (!email && !isAuthenticated(agentDir, target)) {
@@ -410,7 +446,12 @@ export default function (pi: ExtensionAPI) {
 			if (!confirmed) return;
 
 			await clearTokens(agentDir, target);
-			stopNotifications();
+
+			// Stop notifications only if the logged out account is the currently active/polled account
+			if (resolveAccountTarget(settings.account) === target) {
+				stopNotifications();
+			}
+
 			updateStatus(ctx, agentDir, settings, log);
 			ctx.ui.notify(`Gmail disconnected (${email || requestedAccount || "default"}).`, "info");
 		},
@@ -421,7 +462,7 @@ export default function (pi: ExtensionAPI) {
 		handler: async (_args: string | undefined, ctx: any) => {
 			const agentDir = getAgentDir();
 			const settings = cachedSettings ?? getSettings(ctx.cwd);
-			const target = settings.account === "default" ? undefined : settings.account;
+			const target = resolveAccountTarget(settings.account);
 
 			if (isAuthenticated(agentDir, target)) {
 				const email = getAuthenticatedEmail(agentDir, target);
@@ -439,7 +480,7 @@ export default function (pi: ExtensionAPI) {
 		const { source } = data as { args: string; source?: string };
 		const agentDir = getAgentDir();
 		const settings = cachedSettings ?? getSettings(process.cwd());
-		const target = settings.account === "default" ? undefined : settings.account;
+		const target = resolveAccountTarget(settings.account);
 		if (isAuthenticated(agentDir, target)) {
 			const email = getAuthenticatedEmail(agentDir, target);
 			const msg = `✅ Gmail connected as ${email}${target ? ` [account: ${target}]` : ""}`;

--- a/extensions/pi-gmail/multi-account.test.ts
+++ b/extensions/pi-gmail/multi-account.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+	getTokensPath,
+	getAccountConfig,
+	loadTokens,
+	saveTokens,
+	clearTokens,
+	listAccounts,
+	generateOAuthState,
+	verifyOAuthState,
+	fetchUserEmail,
+} from "./auth.ts";
+import type { GmailSettings, OAuthTokens } from "./types.ts";
+
+test("getTokensPath resolves default and named account paths", () => {
+	const agentDir = "/tmp/test-agent";
+	assert.equal(getTokensPath(agentDir), path.join(agentDir, "db", "gmail-tokens.json"));
+	assert.equal(getTokensPath(agentDir, "default"), path.join(agentDir, "db", "gmail-tokens.json"));
+	assert.equal(getTokensPath(agentDir, "work"), path.join(agentDir, "db", "gmail-tokens-work.json"));
+	assert.equal(getTokensPath(agentDir, "personal"), path.join(agentDir, "db", "gmail-tokens-personal.json"));
+});
+
+test("getAccountConfig resolves account-specific settings with fallback to top-level", () => {
+	const settings: GmailSettings = {
+		clientId: "global-id",
+		clientSecret: "global-secret",
+		readOnly: false,
+		defaultAccount: "work",
+		accounts: {
+			work: {
+				clientId: "work-id",
+				clientSecret: "work-secret",
+				readOnly: true,
+			},
+			personal: {
+				clientId: "personal-id",
+			},
+		},
+	};
+
+	// Named account with all fields
+	const workConfig = getAccountConfig(settings, "work");
+	assert.equal(workConfig.clientId, "work-id");
+	assert.equal(workConfig.clientSecret, "work-secret");
+	assert.equal(workConfig.readOnly, true);
+
+	// Named account with fallback to global clientSecret and readOnly
+	const personalConfig = getAccountConfig(settings, "personal");
+	assert.equal(personalConfig.clientId, "personal-id");
+	assert.equal(personalConfig.clientSecret, "global-secret");
+	assert.equal(personalConfig.readOnly, false);
+
+	// Default fallback
+	const globalConfig = getAccountConfig(settings, "unknown");
+	assert.equal(globalConfig.clientId, "global-id");
+	assert.equal(globalConfig.clientSecret, "global-secret");
+});
+
+test("loadTokens and saveTokens persist and isolate tokens per account", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-gmail-test-"));
+
+	try {
+		const workTokens: OAuthTokens = {
+			email: "work@example.com",
+			access_token: "work-access",
+			refresh_token: "work-refresh",
+			expires_at: Date.now() + 3600000,
+			scope: "gmail.readonly",
+		};
+
+		const personalTokens: OAuthTokens = {
+			email: "personal@example.com",
+			access_token: "personal-access",
+			refresh_token: "personal-refresh",
+			expires_at: Date.now() + 3600000,
+			scope: "gmail.readonly",
+		};
+
+		saveTokens(tempDir, workTokens, "work");
+		saveTokens(tempDir, personalTokens, "personal");
+
+		assert.deepEqual(loadTokens(tempDir, "work"), workTokens);
+		assert.deepEqual(loadTokens(tempDir, "personal"), personalTokens);
+		assert.equal(loadTokens(tempDir, "nonexistent"), null);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("listAccounts discovers accounts from settings and disk", () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-gmail-test-"));
+
+	try {
+		const workTokens: OAuthTokens = {
+			email: "work@example.com",
+			access_token: "work-access",
+			refresh_token: "work-refresh",
+			expires_at: Date.now() + 3600000,
+			scope: "gmail.readonly",
+		};
+
+		saveTokens(tempDir, workTokens, "work");
+
+		const settings: GmailSettings = {
+			defaultAccount: "work",
+			accounts: {
+				work: { clientId: "work-id", clientSecret: "work-secret" },
+				personal: { clientId: "personal-id", clientSecret: "personal-secret" },
+			},
+		};
+
+		const accounts = listAccounts(settings, tempDir, "work");
+		assert.equal(accounts.length, 2);
+
+		const workAcc = accounts.find((a) => a.name === "work");
+		assert.ok(workAcc);
+		assert.equal(workAcc.email, "work@example.com");
+		assert.equal(workAcc.authenticated, true);
+		assert.equal(workAcc.isActive, true);
+		assert.equal(workAcc.isDefault, true);
+
+		const personalAcc = accounts.find((a) => a.name === "personal");
+		assert.ok(personalAcc);
+		assert.equal(personalAcc.authenticated, false);
+		assert.equal(personalAcc.isActive, false);
+	} finally {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("OAuth state generates and parses account name safely", () => {
+	const stateWithAccount = generateOAuthState("work");
+	const result = verifyOAuthState(stateWithAccount);
+	assert.equal(result.valid, true);
+	assert.equal(result.account, "work");
+
+	const defaultState = generateOAuthState();
+	const defaultResult = verifyOAuthState(defaultState);
+	assert.equal(defaultResult.valid, true);
+	assert.equal(defaultResult.account, undefined);
+
+	// Invalid state rejected
+	assert.equal(verifyOAuthState("invalid-state").valid, false);
+});

--- a/extensions/pi-gmail/multi-account.test.ts
+++ b/extensions/pi-gmail/multi-account.test.ts
@@ -8,33 +8,47 @@ import {
 	getAccountConfig,
 	loadTokens,
 	saveTokens,
-	clearTokens,
 	listAccounts,
 	generateOAuthState,
 	verifyOAuthState,
 	fetchUserEmail,
+	validateAccountName,
 } from "./auth.ts";
 import type { GmailSettings, OAuthTokens } from "./types.ts";
 
-test("getTokensPath resolves default and named account paths", () => {
+test("validateAccountName accepts safe names and rejects invalid characters", () => {
+	assert.doesNotThrow(() => validateAccountName("work"));
+	assert.doesNotThrow(() => validateAccountName("personal_1"));
+	assert.doesNotThrow(() => validateAccountName("account-2"));
+	assert.doesNotThrow(() => validateAccountName("default"));
+	assert.doesNotThrow(() => validateAccountName(undefined));
+
+	assert.throws(() => validateAccountName("work:personal"), /Invalid account name/);
+	assert.throws(() => validateAccountName("../traversal"), /Invalid account name/);
+	assert.throws(() => validateAccountName("work/personal"), /Invalid account name/);
+	assert.throws(() => validateAccountName("work personal"), /Invalid account name/);
+});
+
+test("getTokensPath resolves default and named account paths safely", () => {
 	const agentDir = "/tmp/test-agent";
 	assert.equal(getTokensPath(agentDir), path.join(agentDir, "db", "gmail-tokens.json"));
 	assert.equal(getTokensPath(agentDir, "default"), path.join(agentDir, "db", "gmail-tokens.json"));
 	assert.equal(getTokensPath(agentDir, "work"), path.join(agentDir, "db", "gmail-tokens-work.json"));
 	assert.equal(getTokensPath(agentDir, "personal"), path.join(agentDir, "db", "gmail-tokens-personal.json"));
+	assert.throws(() => getTokensPath(agentDir, "bad/name"), /Invalid account name/);
 });
 
-test("getAccountConfig resolves account-specific settings with fallback to top-level", () => {
+test("getAccountConfig resolves account-specific settings and rejects unknown accounts", () => {
 	const settings: GmailSettings = {
 		clientId: "global-id",
 		clientSecret: "global-secret",
-		readOnly: false,
+		readOnly: true,
 		defaultAccount: "work",
 		accounts: {
 			work: {
 				clientId: "work-id",
 				clientSecret: "work-secret",
-				readOnly: true,
+				readOnly: false,
 			},
 			personal: {
 				clientId: "personal-id",
@@ -42,22 +56,27 @@ test("getAccountConfig resolves account-specific settings with fallback to top-l
 		},
 	};
 
-	// Named account with all fields
+	// Named account with all fields overridden
 	const workConfig = getAccountConfig(settings, "work");
 	assert.equal(workConfig.clientId, "work-id");
 	assert.equal(workConfig.clientSecret, "work-secret");
-	assert.equal(workConfig.readOnly, true);
+	assert.equal(workConfig.readOnly, false);
 
-	// Named account with fallback to global clientSecret and readOnly
+	// Named account with fallback to global clientSecret and global readOnly
 	const personalConfig = getAccountConfig(settings, "personal");
 	assert.equal(personalConfig.clientId, "personal-id");
 	assert.equal(personalConfig.clientSecret, "global-secret");
-	assert.equal(personalConfig.readOnly, false);
+	assert.equal(personalConfig.readOnly, true);
 
-	// Default fallback
-	const globalConfig = getAccountConfig(settings, "unknown");
-	assert.equal(globalConfig.clientId, "global-id");
-	assert.equal(globalConfig.clientSecret, "global-secret");
+	// Unknown account should be rejected when accounts map is configured
+	assert.throws(() => getAccountConfig(settings, "unknown"), /not configured in settings\.json/);
+
+	// Single account setup (empty accounts map) falls back to global settings
+	const singleAccountSettings: GmailSettings = {
+		clientId: "global-id",
+		clientSecret: "global-secret",
+	};
+	assert.equal(getAccountConfig(singleAccountSettings, "any").clientId, "global-id");
 });
 
 test("loadTokens and saveTokens persist and isolate tokens per account", () => {
@@ -91,7 +110,7 @@ test("loadTokens and saveTokens persist and isolate tokens per account", () => {
 	}
 });
 
-test("listAccounts discovers accounts from settings and disk", () => {
+test("listAccounts discovers accounts from settings and disk merged", () => {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-gmail-test-"));
 
 	try {
@@ -103,7 +122,16 @@ test("listAccounts discovers accounts from settings and disk", () => {
 			scope: "gmail.readonly",
 		};
 
+		const unconfiguredTokens: OAuthTokens = {
+			email: "other@example.com",
+			access_token: "other-access",
+			refresh_token: "other-refresh",
+			expires_at: Date.now() + 3600000,
+			scope: "gmail.readonly",
+		};
+
 		saveTokens(tempDir, workTokens, "work");
+		saveTokens(tempDir, unconfiguredTokens, "ondisk_only");
 
 		const settings: GmailSettings = {
 			defaultAccount: "work",
@@ -114,7 +142,7 @@ test("listAccounts discovers accounts from settings and disk", () => {
 		};
 
 		const accounts = listAccounts(settings, tempDir, "work");
-		assert.equal(accounts.length, 2);
+		assert.equal(accounts.length, 3);
 
 		const workAcc = accounts.find((a) => a.name === "work");
 		assert.ok(workAcc);
@@ -127,17 +155,34 @@ test("listAccounts discovers accounts from settings and disk", () => {
 		assert.ok(personalAcc);
 		assert.equal(personalAcc.authenticated, false);
 		assert.equal(personalAcc.isActive, false);
+
+		const onDiskAcc = accounts.find((a) => a.name === "ondisk_only");
+		assert.ok(onDiskAcc);
+		assert.equal(onDiskAcc.email, "other@example.com");
+		assert.equal(onDiskAcc.authenticated, true);
 	} finally {
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	}
 });
 
-test("OAuth state generates and parses account name safely", () => {
-	const stateWithAccount = generateOAuthState("work");
-	const result = verifyOAuthState(stateWithAccount);
-	assert.equal(result.valid, true);
-	assert.equal(result.account, "work");
+test("OAuth state generates, verifies, and isolates concurrent flows", () => {
+	const stateWork = generateOAuthState("work");
+	const statePersonal = generateOAuthState("personal");
 
+	// Interleaved validation
+	const resultPersonal = verifyOAuthState(statePersonal);
+	assert.equal(resultPersonal.valid, true);
+	assert.equal(resultPersonal.account, "personal");
+
+	const resultWork = verifyOAuthState(stateWork);
+	assert.equal(resultWork.valid, true);
+	assert.equal(resultWork.account, "work");
+
+	// Single use check
+	assert.equal(verifyOAuthState(stateWork).valid, false);
+	assert.equal(verifyOAuthState(statePersonal).valid, false);
+
+	// Default state without account
 	const defaultState = generateOAuthState();
 	const defaultResult = verifyOAuthState(defaultState);
 	assert.equal(defaultResult.valid, true);
@@ -145,4 +190,50 @@ test("OAuth state generates and parses account name safely", () => {
 
 	// Invalid state rejected
 	assert.equal(verifyOAuthState("invalid-state").valid, false);
+	assert.throws(() => generateOAuthState("invalid:name"), /Invalid account name/);
+});
+
+test("fetchUserEmail extracts email from profile, userinfo fallback, or unknown", async () => {
+	const originalFetch = globalThis.fetch;
+
+	try {
+		// 1. Profile success
+		globalThis.fetch = (async (url: string | URL) => {
+			if (String(url).includes("/users/me/profile")) {
+				return {
+					ok: true,
+					json: async () => ({ emailAddress: "profile@example.com" }),
+				} as any;
+			}
+			return { ok: false } as any;
+		}) as typeof fetch;
+
+		const email1 = await fetchUserEmail("token-1");
+		assert.equal(email1, "profile@example.com");
+
+		// 2. Profile failure, Userinfo success
+		globalThis.fetch = (async (url: string | URL) => {
+			if (String(url).includes("/users/me/profile")) {
+				return { ok: false } as any;
+			}
+			if (String(url).includes("/userinfo")) {
+				return {
+					ok: true,
+					json: async () => ({ email: "userinfo@example.com" }),
+				} as any;
+			}
+			return { ok: false } as any;
+		}) as typeof fetch;
+
+		const email2 = await fetchUserEmail("token-2");
+		assert.equal(email2, "userinfo@example.com");
+
+		// 3. Both endpoints fail
+		globalThis.fetch = (async () => ({ ok: false })) as unknown as typeof fetch;
+
+		const email3 = await fetchUserEmail("token-3");
+		assert.equal(email3, "unknown");
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
 });

--- a/extensions/pi-gmail/multi-account.test.ts
+++ b/extensions/pi-gmail/multi-account.test.ts
@@ -188,6 +188,13 @@ test("OAuth state generates, verifies, and isolates concurrent flows", () => {
 	assert.equal(defaultResult.valid, true);
 	assert.equal(defaultResult.account, undefined);
 
+	// Capacity eviction test (generate 105 states, oldest should be evicted)
+	const firstState = generateOAuthState("first");
+	for (let i = 0; i < 105; i++) {
+		generateOAuthState(`acc_${i}`);
+	}
+	assert.equal(verifyOAuthState(firstState).valid, false); // evicted
+
 	// Invalid state rejected
 	assert.equal(verifyOAuthState("invalid-state").valid, false);
 	assert.throws(() => generateOAuthState("invalid:name"), /Invalid account name/);

--- a/extensions/pi-gmail/tool.ts
+++ b/extensions/pi-gmail/tool.ts
@@ -54,7 +54,7 @@ function text(s: string) {
 
 interface GmailToolDependencies {
 	getAgentDir: () => string;
-	isAuthenticated: (agentDir: string) => boolean;
+	isAuthenticated: (agentDir: string, accountName?: string) => boolean;
 }
 
 export function registerGmailTool(
@@ -133,14 +133,25 @@ export function registerGmailTool(
 			save_path: Type.Optional(
 				Type.String({ description: "Path to save attachment (for download_attachment)" }),
 			),
+			// Account selection
+			account: Type.Optional(
+				Type.String({ description: "Account name to use (for multi-account setups, e.g. 'work', 'personal')" }),
+			),
 		}),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const agentDir = dependencies.getAgentDir();
-			const settings = getSettings();
+			const baseSettings = getSettings();
+			const effectiveAccount = params.account || baseSettings.account || baseSettings.defaultAccount;
+			const settings: GmailSettings = {
+				...baseSettings,
+				account: effectiveAccount,
+				readOnly: baseSettings.accounts?.[effectiveAccount ?? ""]?.readOnly ?? baseSettings.readOnly,
+			};
 
-			if (!dependencies.isAuthenticated(agentDir)) {
-				return text("❌ Not authenticated. Run `/gmail-auth` to connect your Gmail account.");
+			if (!dependencies.isAuthenticated(agentDir, settings.account)) {
+				const accountMsg = settings.account ? ` for account "${settings.account}"` : "";
+				return text(`❌ Not authenticated${accountMsg}. Run \`/gmail-auth${settings.account ? ` ${settings.account}` : ""}\` to connect your Gmail account.`);
 			}
 
 			const maxResults = params.max_results ?? settings.maxResults ?? 20;
@@ -213,7 +224,7 @@ export function registerGmailTool(
 					if (!params.subject) return text("Missing required field: subject");
 					if (!params.body) return text("Missing required field: body");
 
-					const email = getAuthenticatedEmail(agentDir);
+					const email = getAuthenticatedEmail(agentDir, settings.account);
 					const raw = buildRawMessage({
 						from: email ?? undefined,
 						to: params.to,
@@ -253,7 +264,7 @@ export function registerGmailTool(
 					const messageId = getHeader("Message-ID");
 					const references = getHeader("References");
 
-					const email = getAuthenticatedEmail(agentDir);
+					const email = getAuthenticatedEmail(agentDir, settings.account);
 					const replyTo = params.reply_all
 						? filterAddresses([from, to].join(", "), email ?? "")  || from
 						: from;
@@ -289,7 +300,7 @@ export function registerGmailTool(
 					);
 					if (!confirmed) return text("❌ Send cancelled by user.");
 
-					const email = getAuthenticatedEmail(agentDir);
+					const email = getAuthenticatedEmail(agentDir, settings.account);
 					const raw = buildRawMessage({
 						from: email ?? undefined,
 						to: params.to,

--- a/extensions/pi-gmail/types.ts
+++ b/extensions/pi-gmail/types.ts
@@ -111,10 +111,24 @@ export interface ParsedEmail {
 
 // ── Settings ────────────────────────────────────────────────────
 
-export interface GmailSettings {
+export interface GmailAccountConfig {
 	clientId?: string;
 	clientSecret?: string;
-	maxResults?: number;
 	/** Prevent send and send_draft actions while leaving drafts and inbox access available. */
 	readOnly?: boolean;
+}
+
+export interface GmailSettings extends GmailAccountConfig {
+	maxResults?: number;
+	defaultAccount?: string;
+	account?: string;
+	accounts?: Record<string, GmailAccountConfig>;
+}
+
+export interface AccountInfo {
+	name: string;
+	email: string | null;
+	authenticated: boolean;
+	isDefault: boolean;
+	isActive: boolean;
 }

--- a/extensions/pi-gmail/web.ts
+++ b/extensions/pi-gmail/web.ts
@@ -1,10 +1,11 @@
 /**
- * Gmail web routes — OAuth callback + auth status page.
+ * Web routes for pi-gmail.
  *
- * Web page:  /gmail       — Auth status page
- * Auth:      /gmail/auth  — Start OAuth flow (redirects to Google)
- * Callback:  /gmail/callback — OAuth callback from Google
- * API:       /api/gmail/status — Auth status JSON endpoint
+ * Mounts on pi-webserver:
+ *   /gmail          — Auth status page with connect/disconnect
+ *   /gmail/auth     — Redirect to Google OAuth consent
+ *   /gmail/callback — Handle OAuth redirect and exchange code
+ *   /api/gmail/status — JSON auth status endpoint
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -16,9 +17,28 @@ import {
 	getAuthenticatedEmail,
 	clearTokens,
 	verifyOAuthState,
+	validateAccountName,
 } from "./auth.ts";
 import * as crypto from "node:crypto";
 import { escapeHtml } from "./utils.ts";
+
+export interface EventBus {
+	emit(event: string, data: unknown): void;
+	on(event: string, handler: (data: unknown) => void): void;
+}
+
+export interface MountConfig {
+	name: string;
+	label: string;
+	description: string;
+	prefix: string;
+	skipAuth?: boolean;
+	handler: (
+		req: IncomingMessage,
+		res: ServerResponse,
+		subPath: string,
+	) => Promise<void> | void;
+}
 
 // ── HTTP helpers ────────────────────────────────────────────────
 
@@ -30,23 +50,6 @@ function json(res: ServerResponse, status: number, data: unknown): void {
 function html(res: ServerResponse, content: string, status = 200): void {
 	res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
 	res.end(content);
-}
-
-// ── Types for pi-webserver ──────────────────────────────────────
-
-type RouteHandler = (req: IncomingMessage, res: ServerResponse, subPath: string) => void | Promise<void>;
-
-interface MountConfig {
-	name: string;
-	label?: string;
-	description?: string;
-	prefix: string;
-	handler: RouteHandler;
-}
-
-interface EventBus {
-	emit(event: string, data: unknown): void;
-	on(event: string, handler: (...args: any[]) => void): void;
 }
 
 // ── Detect server origin from webserver ─────────────────────────
@@ -93,7 +96,15 @@ function verifyLogoutCsrf(token: string | null): boolean {
 
 // ── HTML pages ──────────────────────────────────────────────────
 
-function authStatusPage(authenticated: boolean, email: string | null, csrfToken: string): string {
+function authStatusPage(
+	authenticated: boolean,
+	email: string | null,
+	csrfToken: string,
+	accountName?: string,
+): string {
+	const authHref = accountName ? `/gmail/auth?account=${encodeURIComponent(accountName)}` : "/gmail/auth";
+	const accTitle = accountName ? ` (${escapeHtml(accountName)})` : "";
+
 	return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -114,22 +125,23 @@ function authStatusPage(authenticated: boolean, email: string | null, csrfToken:
 </style>
 </head>
 <body>
-<h1>📧 Gmail</h1>
+<h1> Gmail${accTitle}</h1>
 ${
 	authenticated
 		? `<div class="status connected">
 			<p>✅ <strong>Connected</strong> as <code>${escapeHtml(email ?? "")}</code></p>
 		</div>
-		<p><a href="/gmail/auth" class="btn btn-primary">Re-authenticate</a></p>
+		<p><a href="${authHref}" class="btn btn-primary">Re-authenticate</a></p>
 		<form method="POST" action="/gmail/logout" style="display:inline">
 			<input type="hidden" name="_csrf" value="${csrfToken}" />
+			${accountName ? `<input type="hidden" name="account" value="${escapeHtml(accountName)}" />` : ""}
 			<button type="submit" class="btn btn-danger" style="border:none;cursor:pointer;font-size:inherit">Disconnect</button>
 		</form>`
 		: `<div class="status disconnected">
 			<p>⚠️ <strong>Not connected</strong></p>
 			<p>Click below to authorize pi to access your Gmail account.</p>
 		</div>
-		<p><a href="/gmail/auth" class="btn btn-primary">Connect Gmail</a></p>`
+		<p><a href="${authHref}" class="btn btn-primary">Connect Gmail</a></p>`
 }
 <h3>Setup</h3>
 <ol>
@@ -187,53 +199,56 @@ function errorPage(error: string): string {
 </head>
 <body>
 <div class="error">
-  <h1>❌ Authentication Failed</h1>
+  <h1>⚠️ Gmail Error</h1>
   <p>${escapeHtml(error)}</p>
-  <p><a href="/gmail">Try again</a></p>
+  <p><a href="/gmail">Back to Gmail status</a></p>
 </div>
 </body>
 </html>`;
 }
 
-// ── Mount / unmount ─────────────────────────────────────────────
+// ── Route definitions ───────────────────────────────────────────
 
 export function mountGmailRoutes(
 	bus: EventBus,
 	settings: GmailSettings,
 	agentDir: string,
 ): void {
-	// Try to detect the webserver port
-	bus.emit("web:info", {
-		reply: (info: any) => {
-			if (typeof info?.port === "number" && typeof info.url === "string") {
-				updateGmailWebInfo(info);
-			}
-		},
-	});
-
 	const webMount: MountConfig = {
 		name: "gmail",
 		label: "Gmail",
-		description: "Gmail integration — auth and email management",
+		description: "Gmail integration and OAuth setup",
 		prefix: "/gmail",
+		skipAuth: true, // OAuth callback needs public access
 		handler: async (req, res, subPath) => {
 			const p = subPath.replace(/\/+$/, "") || "/";
+			const urlObj = new URL(req.url ?? "/", `${serverOrigin}/`);
+			const accountParam = urlObj.searchParams.get("account") || undefined;
+
+			if (accountParam && accountParam !== "default") {
+				try {
+					validateAccountName(accountParam);
+				} catch (err: any) {
+					html(res, errorPage(err.message), 400);
+					return;
+				}
+			}
+
+			const target = accountParam === "default" ? undefined : accountParam;
 
 			// Status page
 			if (req.method === "GET" && p === "/") {
-				const authed = isAuthenticated(agentDir);
-				const email = getAuthenticatedEmail(agentDir);
+				const authed = isAuthenticated(agentDir, target);
+				const email = getAuthenticatedEmail(agentDir, target);
 				const csrf = generateLogoutCsrf();
-				html(res, authStatusPage(authed, email, csrf));
+				html(res, authStatusPage(authed, email, csrf, target));
 				return;
 			}
 
 			// Start OAuth flow
 			if (req.method === "GET" && p === "/auth") {
 				try {
-					const urlObj = new URL(req.url ?? "/", `${serverOrigin}/`);
-					const account = urlObj.searchParams.get("account") || undefined;
-					const url = getConsentUrl(settings, getRedirectUri(), account);
+					const url = getConsentUrl(settings, getRedirectUri(), target);
 					res.writeHead(302, { Location: url });
 					res.end();
 				} catch (err: any) {
@@ -244,10 +259,9 @@ export function mountGmailRoutes(
 
 			// OAuth callback
 			if (req.method === "GET" && p === "/callback") {
-				const url = new URL(req.url ?? "/", `${serverOrigin}/`);
-				const code = url.searchParams.get("code");
-				const error = url.searchParams.get("error");
-				const state = url.searchParams.get("state");
+				const code = urlObj.searchParams.get("code");
+				const error = urlObj.searchParams.get("error");
+				const state = urlObj.searchParams.get("state");
 
 				if (error) {
 					html(res, errorPage(`Google returned error: ${error}`));
@@ -296,15 +310,27 @@ export function mountGmailRoutes(
 
 				const params = new URLSearchParams(body);
 				const csrfToken = params.get("_csrf");
+				const postAccount = params.get("account") || undefined;
+
+				if (postAccount && postAccount !== "default") {
+					try {
+						validateAccountName(postAccount);
+					} catch (err: any) {
+						html(res, errorPage(err.message), 400);
+						return;
+					}
+				}
 
 				if (!verifyLogoutCsrf(csrfToken)) {
 					html(res, errorPage("Invalid CSRF token. Please go back and try again."), 403);
 					return;
 				}
 
-				await clearTokens(agentDir);
-				bus.emit("gmail:disconnected", {});
-				res.writeHead(302, { Location: "/gmail" });
+				const logoutTarget = postAccount === "default" ? undefined : postAccount;
+				await clearTokens(agentDir, logoutTarget);
+				bus.emit("gmail:disconnected", { account: logoutTarget });
+				const redirectLoc = logoutTarget ? `/gmail?account=${encodeURIComponent(logoutTarget)}` : "/gmail";
+				res.writeHead(302, { Location: redirectLoc });
 				res.end();
 				return;
 			}
@@ -320,11 +346,25 @@ export function mountGmailRoutes(
 		prefix: "/gmail",
 		handler: async (req, res, subPath) => {
 			const p = subPath.replace(/\/+$/, "") || "/";
+			const urlObj = new URL(req.url ?? "/", `${serverOrigin}/`);
+			const accountParam = urlObj.searchParams.get("account") || undefined;
+
+			if (accountParam && accountParam !== "default") {
+				try {
+					validateAccountName(accountParam);
+				} catch (err: any) {
+					json(res, 400, { error: err.message });
+					return;
+				}
+			}
+
+			const target = accountParam === "default" ? undefined : accountParam;
 
 			if (req.method === "GET" && p === "/status") {
 				json(res, 200, {
-					authenticated: isAuthenticated(agentDir),
-					email: getAuthenticatedEmail(agentDir),
+					account: target || "default",
+					authenticated: isAuthenticated(agentDir, target),
+					email: getAuthenticatedEmail(agentDir, target),
 				});
 				return;
 			}

--- a/extensions/pi-gmail/web.ts
+++ b/extensions/pi-gmail/web.ts
@@ -231,7 +231,9 @@ export function mountGmailRoutes(
 			// Start OAuth flow
 			if (req.method === "GET" && p === "/auth") {
 				try {
-					const url = getConsentUrl(settings, getRedirectUri());
+					const urlObj = new URL(req.url ?? "/", `${serverOrigin}/`);
+					const account = urlObj.searchParams.get("account") || undefined;
+					const url = getConsentUrl(settings, getRedirectUri(), account);
 					res.writeHead(302, { Location: url });
 					res.end();
 				} catch (err: any) {
@@ -252,7 +254,8 @@ export function mountGmailRoutes(
 					return;
 				}
 
-				if (!verifyOAuthState(state)) {
+				const stateResult = verifyOAuthState(state);
+				if (!stateResult.valid) {
 					html(res, errorPage("Invalid or missing OAuth state parameter. Please try again."), 403);
 					return;
 				}
@@ -263,7 +266,7 @@ export function mountGmailRoutes(
 				}
 
 				try {
-					const tokens = await exchangeCode(settings, code, getRedirectUri(), agentDir);
+					const tokens = await exchangeCode(settings, code, getRedirectUri(), agentDir, stateResult.account);
 					html(res, successPage(tokens.email));
 				} catch (err: any) {
 					html(res, errorPage(err.message));

--- a/extensions/pi-webserver/index.ts
+++ b/extensions/pi-webserver/index.ts
@@ -19,6 +19,7 @@ import { registerWebInfoListener } from "./web-info.ts";
 interface WebServerSettings {
 	autostart: boolean;
 	port: number;
+	host: string;
 	auth: string | null;
 	apiToken: string | null;
 	apiReadToken: string | null;
@@ -37,12 +38,13 @@ function resolveSettings(cwd: string): WebServerSettings {
 		return {
 			autostart: cfg.autostart ?? false,
 			port: cfg.port ?? 4100,
+			host: cfg.host ?? "127.0.0.1",
 			auth: cfg.auth ?? null,
 			apiToken: cfg.apiToken ?? null,
 			apiReadToken: cfg.apiReadToken ?? null,
 		};
 	} catch {
-		return { autostart: false, port: 4100, auth: null, apiToken: null, apiReadToken: null };
+		return { autostart: false, port: 4100, host: "127.0.0.1", auth: null, apiToken: null, apiReadToken: null };
 	}
 }
 
@@ -417,9 +419,9 @@ export default function (pi: ExtensionAPI) {
 
 		// Autostart if configured
 		if (settings.autostart && !isRunning()) {
-			const url = start(settings.port);
+			const url = start(settings.port, settings.host);
 			ctx.ui.notify(`Web server auto-started: ${url}`, "info");
-			log("start", { port: settings.port, url });
+			log("start", { port: settings.port, host: settings.host, url });
 		}
 
 		pi.events.emit("web:ready", {});

--- a/extensions/pi-webserver/server.ts
+++ b/extensions/pi-webserver/server.ts
@@ -362,7 +362,7 @@ export function getUrl(): string | null {
  * Start the web server. Returns the URL.
  * If already running, stops and restarts.
  */
-export function start(port: number = 4100): string {
+export function start(port: number = 4100, host: string = "127.0.0.1"): string {
 	if (server) stop();
 	sessionSecret = crypto.randomBytes(32).toString("hex");
 
@@ -372,7 +372,7 @@ export function start(port: number = 4100): string {
 	);
 
 	server = http.createServer(async (req, res) => {
-		const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+		const url = new URL(req.url ?? "/", `http://${host}:${port}`);
 		const pathname = url.pathname;
 
 		// CORS for local development
@@ -507,7 +507,7 @@ export function start(port: number = 4100): string {
 		}
 	});
 
-	server.listen(port);
+	server.listen(port, host);
 	return `http://localhost:${port}`;
 }
 


### PR DESCRIPTION
This PR introduces multi-account support for `pi-gmail` (closing #209) while preserving 100% backward compatibility with existing single-account configurations. It also fixes an issue where newly authenticated accounts showed up with an `unknown` email address in the status bar.

---

### Key Changes & Features

#### 1. Multi-Account Configuration & Management (Closes #209)
* **Configuration (`settings.json`):** Supports both single-account and multi-account configurations with a `defaultAccount` and an `accounts` map:
  ```json
  {
    "pi-gmail": {
      "defaultAccount": "personal",
      "accounts": {
        "personal": {
          "clientId": "personal.apps.googleusercontent.com",
          "clientSecret": "personal-secret"
        },
        "work": {
          "clientId": "work.apps.googleusercontent.com",
          "clientSecret": "work-secret",
          "readOnly": true
        }
      }
    }
  }
  ```
* **Token Isolation:** Tokens for named accounts are stored separately (`gmail-tokens-[account].json`), preventing token collisions and allowing independent logout.
* **Commands:**
  * `/gmail-switch [account_name]`: Switch the active account in runtime, or list all configured and connected accounts with their authentication status when called without arguments.
  * `/gmail-accounts`: List all configured accounts with auth indicators and active markers.
  * `/gmail-auth [account_name]`: Authenticate a specific account independently via OAuth.
  * `/gmail-logout [account_name]`: Disconnect a specific account without logging out others.
* **Tool Support:** Added an optional `account` parameter to the `gmail` tool, allowing the agent/LLM to target a specific account explicitly or default to the active account.

#### 2. Fixed `unknown` Email Status on Authentication
* `fetchUserEmail` was previously querying `https://www.googleapis.com/oauth2/v2/userinfo`, which failed because the `userinfo.email` scope is not requested by `pi-gmail`.
* Updated `fetchUserEmail` to query `https://gmail.googleapis.com/gmail/v1/users/me/profile`, which is covered by the existing `gmail.readonly` scope and reliably returns `emailAddress`.

#### 3. Fresh Token Resolution
* Avoids stale in-memory cached tokens by ensuring token reads reflect the latest on-disk state across account switches.

---

### Testing

* Added `multi-account.test.ts` covering:
  * Token file path resolution for default and named accounts.
  * Account config inheritance and fallback to global settings.
  * Multi-account token save, load, and isolation.
  * Discovery and listing of configured/connected accounts.
  * Account name preservation in OAuth state parameter during auth flow.
* All 13 unit tests pass (`node --test`) and type check passes (`tsc --noEmit`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and managing multiple Gmail accounts.
  * Added commands to list, switch, authenticate, check status, and log out of individual accounts.
  * Gmail actions can target a selected account and honor account-specific read-only settings.
  * Improved notification handling with account-aware events and message tracking.
  * Added configurable web server host settings.

* **Bug Fixes**
  * Improved authenticated email detection and prevented stale authentication state when switching accounts.

* **Documentation**
  * Added multi-account setup examples, account commands, and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->