### PR TITLE
chore: ignore pi-subagents runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pnpm-debug.log*
 
 *.lock
 .pi/
+.pi-subagents/
 telemetry/
 memory/
 db/


### PR DESCRIPTION
## Summary
- ignore the root `.pi-subagents/` runtime-state directory

## Verification
- `git check-ignore -v .pi-subagents/example`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version control ignore settings to exclude internal agent-generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->